### PR TITLE
Rename sync command to push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ env:
   global:
     - secure: "LWfVXkoJlIHBY3yF1ylD+sX3YiHPTdNZJaopxdBpct+QCaBYEQJaJjT3qIYSjubZ9gHMLktWjLWdYSjAAQPCrlKOD8LBYPtMhg7GMzuOnBS/rSv+VhdVIH4PJ0KISZyba7QAPsDnNGm4xHlw/NeUONuNacnEBllC6+fiiEEtqtzYlRkNI71GCiSRO899uvp3/Ff+LYoY9XIgrGoRHioftoQ0GZs2K8GxhWo/UzshjqS6bV3nuiZQZH8iWC8gAAZPTK6z3dyk2xi6LFvpcOPu5wCIdjSQy0bPjCWIuQkYcJF+ql8oCfyVlkD4vAyMOb7mj+6SyhKZZ0WFhRT0tWc8Gv5PXDQ8hWrDQTtI9dPXfoB19t8BRrxRMd3vUFf/AfItcAHBX9LI8OkkSvX9MGn2hLk8f4Rz4EFJJbQDn7GIwj3pesk5hQsUizSq5jtF+MDAda0ojMGSGV8nlfBxDuYat4IdiKsi1bJTnhfZ5m1cD1yWgkOGxi77z8b8ItiWslCD7f233m5jk9464jE+BKrHOwRaEdx3Au5e7JZmJx2AtxdKcagMX6kLmmorML3odaDvkWiMYcd+ztmFDvjiebW0D96Z2IQzsTlfGb3M6PP5+vMPCw5cpYBm3O69DEGU2PI6jpvTSxrdN6lVTJL00Od9Hn9KffDNVgFZ5ijoJnTO/8A="
 script:
- - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+ - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters 'https://cache.nixos.org https://cachix.cachix.org' --trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM='
  - cachix use cachix
  - nix-build -j2 | cachix sync cachix

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -24,7 +24,7 @@ main = do
   case command of -- TODO: might want readerT here with client, config and env and opts
     AuthToken token -> Commands.authtoken env config token
     Create name -> Commands.create env config name
-    Sync name paths -> Commands.sync env config name paths
+    Push name paths -> Commands.push env config name paths
     Use name -> Commands.use env config name
 
 customManagerSettings :: ManagerSettings

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -4,7 +4,7 @@
 module Cachix.Client.Commands
   ( authtoken
   , create
-  , sync
+  , push
   , use
   ) where
 
@@ -108,12 +108,12 @@ create env (Just config@Config{..}) name = do
 Signing key has been saved on your local machine. To populate
 your binary cache:
 
-    $ nix-build | cachix sync ${name}
+    $ nix-build | cachix push ${name}
 
 Or if you'd like to use the signing key on another machine or CI:
 
     $ export CACHIX_SIGNING_KEY=${signingKey}
-    $ nix-build | cachix sync ${name}
+    $ nix-build | cachix push ${name}
 
 To instruct Nix to use the binary cache:
 
@@ -151,8 +151,8 @@ use env _ name = do
              addBinaryCache binaryCache NixConf.Global
 
 -- TODO: lots of room for perfomance improvements
-sync :: ClientEnv -> Maybe Config -> Text -> [Text] -> IO ()
-sync env config name rawPaths = do
+push :: ClientEnv -> Maybe Config -> Text -> [Text] -> IO ()
+push env config name rawPaths = do
   hasNoStdin <- hIsTerminalDevice stdin
   when (not hasNoStdin && not (null rawPaths)) $ throwIO $ AmbiguousInput "You provided both stdin and store path arguments, pick only one to proceed."
   inputStorePaths <-
@@ -186,7 +186,7 @@ sync env config name rawPaths = do
 
   -- TODO: make pool size configurable, on beefier machines this could be doubled
   successes <- mapPool 4 storePaths $ \storePath -> do
-    putStrLn $ "syncing " <> storePath
+    putStrLn $ "pushing " <> storePath
 
     narSizeRef <- liftIO $ newIORef 0
     fileSizeRef <- liftIO $ newIORef 0

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -42,7 +42,7 @@ type BinaryCacheName = Text
 data CachixCommand
   = AuthToken Text
   | Create BinaryCacheName
-  | Sync BinaryCacheName [Text]
+  | Push BinaryCacheName [Text]
   | Use BinaryCacheName
   deriving Show
 
@@ -50,12 +50,12 @@ parserCachixCommand :: Parser CachixCommand
 parserCachixCommand = subparser $
   command "authtoken" (infoH authtoken (progDesc "Configure token for authentication to cachix.org")) <>
   command "create" (infoH create (progDesc "Create a new binary cache")) <>
-  command "sync" (infoH sync (progDesc "Upload Nix store paths to the binary cache")) <>
+  command "push" (infoH push (progDesc "Upload Nix store paths to the binary cache")) <>
   command "use" (infoH use (progDesc "Configure nix.conf to enable binary cache during builds"))
   where
     authtoken = AuthToken <$> strArgument (metavar "TOKEN")
     create = Create <$> strArgument (metavar "NAME")
-    sync = Sync <$> strArgument (metavar "NAME")
+    push = Push <$> strArgument (metavar "NAME")
                 <*> many (strArgument (metavar "PATHS..."))
     use = Use <$> strArgument (metavar "NAME")
 


### PR DESCRIPTION
As pointed out by @zimbatm, sync conveys it is
bidirectional, while it's really a push.