### PR TITLE
README: Point Travis badge to .com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # https://cachix.org api and cli interface
 
-[![Build Status](https://travis-ci.org/cachix/cachix.svg?branch=master)](https://travis-ci.org/cachix/cachix)
+[![Build Status](https://travis-ci.com/cachix/cachix.svg?branch=master)](https://travis-ci.com/cachix/cachix)
 [![Hackage](https://img.shields.io/hackage/v/cachix.svg)](https://hackage.haskell.org/package/cachix)
 
 Binary Cache as a Service - Build Nix packages once and share them for good.


### PR DESCRIPTION
Travis is moving all open-source projects to the .com TLD.

[travis.org/cachix/cachix](https://travis-ci.org/cachix/cachix) only has old builds, the new ones are at [travis.com/cachix/cachix](https://travis-ci.com/cachix/cachix).