### PR TITLE
Travis: Remove extra `cachix push`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
   cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM='
 - cachix use cachix
 - cachix push cachix --watch-store&
-- nix-build -j2 | cachix push cachix
+- nix-build -j2


### PR DESCRIPTION
We already start cachix in daemon mode, which watches `/nix/store` and pushes store paths, so we don't need to push again.