### PR TITLE
Fix #69: Allow whitespace (not just newline) separated paths on stdin

### DIFF
--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -141,7 +141,7 @@ push env config name rawPaths False = do
   inputStorePaths <-
     if hasNoStdin
     then return rawPaths
-    else T.lines <$> getContents
+    else T.words <$> getContents
 
   -- TODO: if empty, take whole nix store and warn: nix store-path --all
   when (null inputStorePaths) $ throwIO $ NoInput "You need to specify store paths either as stdin or as a cli argument"


### PR DESCRIPTION
Fixes #69 

```
nix-env -if https://github.com/cachix/cachix/tarball/12d4f3416dc998560f56227fa6af8e79ebe5f9fe --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
```