### PR TITLE
Add Nix 1.11.X support

### DIFF
--- a/cachix/ChangeLog.md
+++ b/cachix/ChangeLog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- #102 Nix 1.0 support @domenkozar
+
 ## [0.1.0.2] - 2018-07-06
 
 ### Changed

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -50,8 +50,8 @@ import           Cachix.Client.Config           ( Config(..)
                                                 )
 import qualified Cachix.Client.Config          as Config
 import           Cachix.Client.InstallationMode
-import           Cachix.Client.NixVersion       ( getNixMode
-                                                , NixMode
+import           Cachix.Client.NixVersion       ( getNixVersion
+                                                , NixVersion
                                                 )
 import qualified Cachix.Client.NixConf         as NixConf
 import           Cachix.Client.Servant
@@ -118,23 +118,23 @@ use env _ name shouldEchoNixOS = do
     -- TODO: handle 404
     Left err -> panic $ show err
     Right binaryCache -> do
-      eitherNixMode <- getNixMode
-      case eitherNixMode of
+      eitherNixVersion <- getNixVersion
+      case eitherNixVersion of
         Left err -> panic err
-        Right nixMode -> do
+        Right nixVersion -> do
           user <- getUser
           nc <- NixConf.read NixConf.Global
           isTrusted <- isTrustedUser $ NixConf.readLines (catMaybes [nc]) NixConf.isTrustedUsers
           isNixOS <- doesFileExist "/etc/NIXOS"
           let nixEnv = NixEnv
-                { nixMode = nixMode
+                { nixVersion = nixVersion
                 , isRoot = user == "root"
                 , isTrusted = isTrusted
                 , isNixOS = isNixOS
                 }
           addBinaryCache binaryCache $
             if shouldEchoNixOS
-            then EchoNixOS
+            then EchoNixOS nixVersion
             else getInstallationMode nixEnv
 
 

--- a/cachix/src/Cachix/Client/NixVersion.hs
+++ b/cachix/src/Cachix/Client/NixVersion.hs
@@ -1,7 +1,7 @@
 module Cachix.Client.NixVersion
-  ( getNixMode
-  , parseNixMode
-  , NixMode(..)
+  ( getNixVersion
+  , parseNixVersion
+  , NixVersion(..)
   ) where
 
 import Protolude
@@ -10,22 +10,22 @@ import Data.Versions
 import Data.Text as T
 
 
-data NixMode
+data NixVersion
   = Nix20
   | Nix201
   | Nix1XX
   deriving (Show, Eq)
 
-getNixMode :: IO (Either Text NixMode)
-getNixMode = do
+getNixVersion :: IO (Either Text NixVersion)
+getNixVersion = do
   (exitcode, out, err) <- readProcessWithExitCode "nix-env" ["--version"] mempty
   unless (err == "") $ putStrLn $ "nix-env stderr: " <> err
   return $ case exitcode of
     ExitFailure i -> Left $ "'nix-env --version' exited with " <> show i
-    ExitSuccess -> parseNixMode $ toS out
+    ExitSuccess -> parseNixVersion $ toS out
 
-parseNixMode :: Text -> Either Text NixMode
-parseNixMode output =
+parseNixVersion :: Text -> Either Text NixVersion
+parseNixVersion output =
   let
     verStr = T.drop 14 $ T.strip output
     err = "Couldn't parse 'nix-env --version' output: " <> output

--- a/cachix/test/NixVersionSpec.hs
+++ b/cachix/test/NixVersionSpec.hs
@@ -6,16 +6,16 @@ import Test.Hspec
 import Cachix.Client.NixVersion
 
 spec :: Spec
-spec = describe "parseNixMode" $ do
+spec = describe "parseNixVersion" $ do
   it "parses 'nix-env (Nix) 2.0' as Nix20" $
-    parseNixMode "nix-env (Nix) 2.0" `shouldBe` Right Nix20
+    parseNixVersion "nix-env (Nix) 2.0" `shouldBe` Right Nix20
   it "parses 'nix-env (Nix) 2.0.1' as Nix201" $
-    parseNixMode "nix-env (Nix) 2.0.1" `shouldBe` Right Nix201
+    parseNixVersion "nix-env (Nix) 2.0.1" `shouldBe` Right Nix201
   it "parses 'nix-env (Nix) 1.11.13' as Nix1XX" $
-    parseNixMode "nix-env (Nix) 1.11.13" `shouldBe` Right Nix1XX
+    parseNixVersion "nix-env (Nix) 1.11.13" `shouldBe` Right Nix1XX
   it "parses 'nix-env (Nix) 2.0.5' as Nix201" $
-    parseNixMode "nix-env (Nix) 2.0.5" `shouldBe` Right Nix201
+    parseNixVersion "nix-env (Nix) 2.0.5" `shouldBe` Right Nix201
   it "parses 'nix-env (Nix) 2.0.1pre6053_444b921' as Nix201" $
-    parseNixMode "nix-env (Nix) 2.0.1pre6053_444b921" `shouldBe` Right Nix201
+    parseNixVersion "nix-env (Nix) 2.0.1pre6053_444b921" `shouldBe` Right Nix201
   it "fails with unknown string 'foobar'" $
-    parseNixMode "foobar" `shouldBe` Left "Couldn't parse 'nix-env --version' output: foobar"
+    parseNixVersion "foobar" `shouldBe` Left "Couldn't parse 'nix-env --version' output: foobar"

--- a/default.nix
+++ b/default.nix
@@ -18,14 +18,7 @@ let
       inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa CoreServices;
     };
   };
-in if builtins.compareVersions "2.0" builtins.nixVersion == 1
-   then abort ''
-      Cachix requires Nix >= 2.0, please upgrade:
-      - If you are running NixOS, use `nixos-rebuild' to upgrade your system.
-      - If you installed Nix using the install script (https://nixos.org/nix/install),
-        it is safe to upgrade by running it again:
-            curl https://nixos.org/nix/install | sh
-   ''
-  else hsPkgs.cachix // { 
-    hlint = pkgs.hlint; 
-  }
+in hsPkgs.cachix // { 
+  hlint = pkgs.hlint; 
+  hsPkgs = hsPkgs;
+}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,5 +1,10 @@
 # to update: $ nix-prefetch-url --unpack url
-import (builtins.fetchTarball {
+let
+  fetchTarball = { url, sha256 }@attrs:
+    if builtins.lessThan builtins.nixVersion "1.12"
+    then builtins.fetchTarball { inherit url; }
+    else builtins.fetchTarball attrs;
+in import (fetchTarball {
   url = "https://github.com/domenkozar/nixpkgs/archive/ed4f1af5efc2d78977fe90a7a8ecf84ffd7d1217.tar.gz";
   sha256 = "0jsc3mqwvy2vlbc3zkycv4c5w8z122fzf3ia31mpbq75nknaa7nd";
 }) { config = {}; overlays = []; }


### PR DESCRIPTION
- allows Nix 1.0 to builds the project
- uses correct nix.conf naming scheme depending on Nix 1.11.X or 2.0

Fixes #67 