### PR TITLE
On NixOS, one has to pass cache.nixos.org explicitly

### DIFF
--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -75,6 +75,7 @@ addBinaryCache Api.BinaryCache{..} (EchoNixOSWithTrustedUser _) = do
   putText [iTrim|
 nix = {
   binaryCaches = [
+    "https://cache.nixos.org/"
     "${uri}"
   ];
   binaryCachePublicKeys = [


### PR DESCRIPTION
cc @angerman