### PR TITLE
Generate https://cache.nixos.org/ when run as root on NixOS systems

### DIFF
--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -61,6 +61,7 @@ addBinaryCache Api.BinaryCache{..} (EchoNixOS _) = do
   putText [iTrim|
 nix = {
   binaryCaches = [
+    "https://cache.nixos.org/"
     "${uri}"
   ];
   binaryCachePublicKeys = [


### PR DESCRIPTION
This is a fixup after https://github.com/cachix/cachix/commit/6d68cf24b44039e7bf252322012b9406a92066c0.