### PR TITLE
when configuring cache, only warn about groups if user is not trusted

### DIFF
--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -104,11 +104,12 @@ isTrustedUser users = do
   user <- getUser
   -- to detect single user installations
   permissions <- getPermissions "/nix/store"
-  unless (null groups) $ do
+  let isTrusted = writable permissions || user `elem` users
+  unless (null groups && not isTrusted) $ do
     -- TODO: support Nix group syntax
     putText "Warn: cachix doesn't yet support checking if user is trusted via groups, so it will recommend sudo"
     putStrLn $ "Warn: groups found " <> T.intercalate "," groups
-  return $ writable permissions || user `elem` users
+  return isTrusted
   where
     groups = filter (\u -> T.head u == '@') users
 


### PR DESCRIPTION
Otherwise the following output will be seen:

```
$ cachix use foobar
Warn: cachix doesn't yet support checking if user is trusted via groups, so it will recommend sudo
Warn: groups found @wheel
Configured https://foobar.cachix.org binary cache in /home/circleci/.config/nix/nix.conf
```