### PR TITLE
Expose github username connected to the binary cache.

### DIFF
--- a/cachix-api/src/Cachix/Api/Types.hs
+++ b/cachix-api/src/Cachix/Api/Types.hs
@@ -49,6 +49,7 @@ data BinaryCache = BinaryCache
   { name :: Text
   , uri :: Text
   , publicSigningKeys :: [Text]
+  , githubUsername :: Text
   } deriving (Show, Generic, FromJSON, ToJSON, ToSchema)
 
 newtype BinaryCacheCreate = BinaryCacheCreate


### PR DESCRIPTION
This connects binary cache trust with github trust.