### PR TITLE
Allow exitSuccess

### DIFF
--- a/cachix/cachix/Main.hs
+++ b/cachix/cachix/Main.hs
@@ -1,8 +1,9 @@
 module Main (main) where
 
-import Control.Exception (handle, SomeException)
+import Prelude
+import Control.Exception (handle, SomeException, fromException)
 import System.IO
-import System.Exit (exitFailure)
+import System.Exit (exitFailure, exitWith)
 import GHC.IO.Encoding
 
 import qualified Cachix.Client as CC
@@ -19,6 +20,7 @@ handleExceptions :: IO a -> IO a
 handleExceptions = handle handler
   where
     handler :: SomeException -> IO a
+    handler e | (Just ee) <- fromException e = exitWith ee
     handler e = do
       hPutStrLn stderr ""
       -- TODO: pretty print the record once fixed https://github.com/haskell-servant/servant/issues/807


### PR DESCRIPTION
This is required for command line completions to succeed.