### PR TITLE
netrc: create possibly missing directories

### DIFF
--- a/cachix/src/Cachix/Client/NetRc.hs
+++ b/cachix/src/Cachix/Client/NetRc.hs
@@ -8,7 +8,8 @@ import           Data.List            (nubBy)
 import qualified Data.Text          as T
 import           Network.NetRc
 import           Protolude
-import           System.Directory     ( doesFileExist )
+import           System.FilePath.Posix ( takeDirectory )
+import           System.Directory     ( doesFileExist, createDirectoryIfMissing )
 import           Servant.Auth.Client  (getToken)
 
 import qualified Cachix.Api as Api
@@ -29,6 +30,7 @@ add config binarycaches filename = do
   netrc <- if doesExist
            then BS.readFile filename >>= parse
            else return $ NetRc [] []
+  createDirectoryIfMissing True (takeDirectory filename)
   BS.writeFile filename $ netRcToByteString $ uniqueAppend netrc
   where
     parse :: ByteString -> IO NetRc

--- a/cachix/src/Cachix/Client/NetRc.hs
+++ b/cachix/src/Cachix/Client/NetRc.hs
@@ -8,7 +8,7 @@ import           Data.List            (nubBy)
 import qualified Data.Text          as T
 import           Network.NetRc
 import           Protolude
-import           System.FilePath.Posix ( takeDirectory )
+import           System.FilePath       ( takeDirectory )
 import           System.Directory     ( doesFileExist, createDirectoryIfMissing )
 import           Servant.Auth.Client  (getToken)
 


### PR DESCRIPTION
Avoids 

```
$ cachix use private
/home/ielectric/.config/nix/netrc: openBinaryFile: does not exist (No such file or directory)
```