### PR TITLE
Refactoring Push to a library module that doesn't depend on Env

### DIFF
--- a/cachix-api/src/Cachix/Types/SigningKeyCreate.hs
+++ b/cachix-api/src/Cachix/Types/SigningKeyCreate.hs
@@ -9,7 +9,7 @@ import           Data.Swagger
 import           Data.Text                      ( Text )
 import           GHC.Generics                   ( Generic )
 
-
+-- | Conveys that a signing secret key was created, by sharing the public key.
 newtype SigningKeyCreate = SigningKeyCreate
   { publicKey :: Text
   } deriving (Show, Generic, FromJSON, ToJSON, ToSchema)

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -39,6 +39,7 @@ library
       Cachix.Client.NixVersion
       Cachix.Client.OptionsParser
       Cachix.Client.Push
+      Cachix.Client.Secrets
       Cachix.Client.Servant
       Cachix.Client.URI
   other-modules:

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -38,6 +38,7 @@ library
       Cachix.Client.NixConf
       Cachix.Client.NixVersion
       Cachix.Client.OptionsParser
+      Cachix.Client.Push
       Cachix.Client.Servant
       Cachix.Client.URI
   other-modules:
@@ -75,6 +76,7 @@ library
     , optparse-applicative
     , process
     , protolude
+    , resourcet
     , retry
     , safe-exceptions
     , servant >=0.15

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Cachix.Client.Commands
   ( authtoken
   , create
@@ -23,6 +24,7 @@ import           Network.HTTP.Types             (status404, status401)
 import           Protolude
 import           Servant.Auth                   ()
 import           Servant.Auth.Client
+import           Servant.API                    ( NoContent )
 import           Servant.API.Generic
 import           Servant.Client.Generic
 import           Servant.Client.Streaming
@@ -85,8 +87,8 @@ generateKeypair env@Env { config = Just config } name = do
       bcc = BinaryCacheConfig name signingKey
 
   -- we first validate if key can be added to the binary cache
-  discardNoContent
-    $ escalate =<< ((`runClientM` clientenv env)
+  (_ :: NoContent) <- escalate
+    =<< ((`runClientM` clientenv env)
     $ Api.createKey (cachixBCClient name) (authToken config) signingKeyCreate)
 
   -- if key was successfully added, write it to the config

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
 module Cachix.Client.OptionsParser
   ( CachixCommand(..)
   , CachixOptions(..)
@@ -11,10 +10,10 @@ import Data.Bifunctor            (first)
 import Protolude hiding          (option)
 import URI.ByteString            (URIRef, Absolute, parseURI, strictURIParserOptions
                                  , serializeURIRef')
-import URI.ByteString.QQ
 import Options.Applicative
 
 import qualified Cachix.Client.Config as Config
+import Cachix.Client.URI         (defaultCachixURI)
 
 data CachixOptions = CachixOptions
   { host :: URIRef Absolute
@@ -26,7 +25,7 @@ parserCachixOptions :: Config.ConfigPath -> Parser CachixOptions
 parserCachixOptions defaultConfigPath = CachixOptions
   <$> option uriOption ( long "host"
                        <> short 'h'
-                       <> value [uri|https://cachix.org|]
+                       <> value defaultCachixURI
                        <> metavar "URI"
                        <> showDefaultWith (toS . serializeURIRef')
                        <> help "Host to connect to"

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Rank2Types #-}
+module Cachix.Client.Push
+  ( -- * Pushing a single path
+    pushSingleStorePath
+  , PushCache(..)
+  , PushStrategy(..)
+  , defaultWithXzipCompressor
+
+    -- * Pushing a closure of store paths
+  , pushClosure
+  , mapConcurrentlyBounded
+  ) where
+
+import           Crypto.Sign.Ed25519
+import qualified Control.Concurrent.QSem       as QSem
+import           Control.Concurrent.Async     (mapConcurrently)
+import           Control.Monad                ((>=>))
+import           Control.Monad.Trans.Resource (ResourceT)
+import           Control.Exception.Safe       (MonadMask, throwM)
+import           Control.Retry                (recoverAll, RetryStatus, RetryPolicy, constantDelay, limitRetries)
+import qualified Data.ByteString.Base64        as B64
+import           Data.Conduit
+import           Data.Conduit.Process
+import           Data.Conduit.Lzma              ( compress )
+import           Data.IORef
+import qualified Data.Text                      as T
+import           Network.HTTP.Types             (status404, status401)
+import           Protolude
+import           Servant.API
+import           Servant.Auth                   ()
+import           Servant.Auth.Client
+import           Servant.API.Generic
+import           Servant.Client.Generic
+import           Servant.Client.Streaming
+import           Servant.Conduit                ()
+import           System.Process                 ( readProcess )
+
+import qualified Cachix.Api                    as Api
+import           Cachix.Api.Error
+import           Cachix.Api.Signing             (fingerprint, passthroughSizeSink, passthroughHashSink)
+import qualified Cachix.Types.NarInfoCreate    as Api
+import           Cachix.Client.Exception        ( CachixException(..) )
+import           Cachix.Client.Servant
+
+
+data PushCache = PushCache
+  { pushCacheName :: Text
+  , pushCacheSigningKey :: SecretKey
+  , pushCacheToken :: Token
+  }
+data PushStrategy m r = PushStrategy
+  { onAlreadyPresent :: m r -- ^ Called when a path is already in the cache.
+  , onAttempt :: RetryStatus -> m ()
+  , on401 :: m r
+  , onError :: ServantError -> m r
+  , onDone :: m r
+  , withXzipCompressor :: forall a. (ConduitM ByteString ByteString (ResourceT IO) () -> m a) -> m a
+  }
+
+defaultWithXzipCompressor :: forall m a. (ConduitM ByteString ByteString (ResourceT IO) () -> m a) -> m a
+defaultWithXzipCompressor = ($ compress Nothing)
+
+
+pushSingleStorePath
+  :: (MonadMask m, MonadIO m)
+  => ClientEnv  -- ^ cachix base url, connection manager, see 'Cachix.Client.URI.defaultCachixBaseUrl', 'Servant.Client.mkClientEnv'
+  -> PushCache -- ^ details for pushing to cache
+  -> PushStrategy m r -- ^ how to report results, (some) errors, and do some things
+  -> Text -- ^ store path
+  -> m r -- ^ r is determined by the 'PushStrategy'
+pushSingleStorePath ce cache cb storePath = retryPath $ \retrystatus -> do
+  
+  let (storeHash, storeSuffix) = splitStorePath $ toS storePath
+      name = pushCacheName cache
+
+  -- Check if narinfo already exists
+  -- TODO: query also cache.nixos.org? server-side?
+  res <- liftIO $ (`runClientM` ce) $ Api.narinfoHead
+    (cachixBCClient name)
+    (pushCacheToken cache)
+    (Api.NarInfoC storeHash)
+  (case res of
+    Right NoContent -> onAlreadyPresent cb -- we're done as store path is already in the cache
+    Left err | isErr err status404 -> doUpload
+             | isErr err status401 -> on401 cb
+             | otherwise -> onError cb err
+     where
+      doUpload = do
+        onAttempt cb retrystatus
+
+        narSizeRef <- liftIO $ newIORef 0
+        fileSizeRef <- liftIO $ newIORef 0
+        narHashRef <- liftIO $ newIORef ("" :: Text)
+        fileHashRef <- liftIO $ newIORef ("" :: Text)
+
+        -- stream store path as xz compressed nar file
+        let cmd = proc "nix-store" ["--dump", toS storePath]
+        -- TODO: print process stderr?
+        (ClosedStream, (stdoutStream, closeStdout), ClosedStream, cph) <- liftIO $ streamingProcess cmd
+        withXzipCompressor cb $ \xzCompressor -> do
+          let stream'
+                = stdoutStream
+                    .| passthroughSizeSink narSizeRef
+                    .| passthroughHashSink narHashRef
+                    .| xzCompressor
+                    .| passthroughSizeSink fileSizeRef
+                    .| passthroughHashSink fileHashRef
+
+          -- for now we need to use letsencrypt domain instead of cloudflare due to its upload limits
+          let newClientEnv = ce {
+                  baseUrl = (baseUrl ce) { baseUrlHost = toS name <> "." <> baseUrlHost (baseUrl ce)}
+                }
+          discardNoContent $ liftIO $ (`withClientM` newClientEnv)
+              (Api.createNar (cachixBCStreamingClient name) stream')
+              $ escalate >=> \NoContent -> do
+                  closeStdout
+                  exitcode <- waitForStreamingProcess cph
+                  when (exitcode /= ExitSuccess) $ throwM $ NarStreamingError exitcode $ show cmd
+
+                  -- TODO: we're done, so we can leave withClientM. Doing so
+                  --       will allow more concurrent requests when the number
+                  --       of XZ compressors is limited
+                  narSize <- readIORef narSizeRef
+                  narHashB16 <- readIORef narHashRef
+                  fileHash <- readIORef fileHashRef
+                  fileSize <- readIORef fileSizeRef
+
+                  -- TODO: #3: implement using pure haskell
+                  narHash <- ("sha256:" <>) . T.strip . toS <$> readProcess "nix-hash" ["--type", "sha256", "--to-base32", toS narHashB16] mempty
+
+                  deriverRaw <- T.strip . toS <$> readProcess "nix-store" ["-q", "--deriver", toS storePath] mempty
+                  let deriver = if deriverRaw == "unknown-deriver"
+                                then deriverRaw
+                                else T.drop 11 deriverRaw
+
+                  references <- sort . T.lines . T.strip . toS <$> readProcess "nix-store" ["-q", "--references", toS storePath] mempty
+
+                  let
+                      fp = fingerprint storePath narHash narSize references
+                      sig = dsign (pushCacheSigningKey cache) fp
+                      nic = Api.NarInfoCreate
+                        { cStoreHash = storeHash
+                        , cStoreSuffix = storeSuffix
+                        , cNarHash = narHash
+                        , cNarSize = narSize
+                        , cFileSize = fileSize
+                        , cFileHash = fileHash
+                        , cReferences = fmap (T.drop 11) references
+                        , cDeriver = deriver
+                        , cSig = toS $ B64.encode $ unSignature sig
+                        }
+
+                  escalate $ Api.isNarInfoCreateValid nic
+
+                  -- Upload narinfo with signature
+                  escalate <=< (`runClientM` ce) $ Api.createNarinfo
+                    (cachixBCClient name)
+                    (Api.NarInfoC storeHash)
+                    nic
+          onDone cb
+    )
+  where 
+    -- Retry up to 5 times for each store path.
+    -- Catches all exceptions except skipAsyncExceptions
+    retryPath :: (MonadIO m, MonadMask m) => (RetryStatus -> m a) -> m a
+    retryPath = recoverAll defaultRetryPolicy
+
+    defaultRetryPolicy :: RetryPolicy
+    defaultRetryPolicy =
+      constantDelay 50000 <> limitRetries 3
+
+-- | Push an entire closure
+--
+-- Note: 'onAlreadyPresent' will be called less often in the future.
+pushClosure
+  :: (MonadIO m, MonadMask m)
+  => (forall a b. (a -> m b) -> [a] -> m [b])
+     -- ^ Traverse paths, responsible for bounding parallel processing of paths
+     --
+     -- For example: @'mapConcurrentlyBounded' 4@
+  -> ClientEnv -- ^ See 'pushSingleStorePath'
+  -> PushCache
+  -> (Text -> PushStrategy m r)
+  -> [Text] -- ^ Initial store paths
+  -> m [r] -- ^ Every @r@ per store path of the entire closure of store paths
+pushClosure traversal clientEnv pushCache pushStrategy inputStorePaths = do
+  
+  -- Get the transitive closure of dependencies
+  -- TODO: split args if too big
+  paths <- liftIO $ T.lines . toS <$> readProcess "nix-store" (fmap toS (["-qR"] <> inputStorePaths)) mempty
+
+  -- TODO: make pool size configurable, on beefier machines this could be doubled
+  traversal (\path -> pushSingleStorePath clientEnv pushCache (pushStrategy path) path) paths
+
+mapConcurrentlyBounded :: Traversable t => Int -> (a -> IO b) -> t a -> IO (t b)
+mapConcurrentlyBounded bound action items = do
+  qs <- QSem.newQSem bound
+  let wrapped x = bracket_ (QSem.waitQSem qs) (QSem.signalQSem qs) (action x)
+  mapConcurrently wrapped items
+
+-------------------
+-- Private terms --
+
+splitStorePath :: Text -> (Text, Text)
+splitStorePath storePath =
+  (T.take 32 (T.drop 11 storePath), T.drop 44 storePath)
+
+cachixClient :: Api.CachixAPI (AsClientT ClientM)
+cachixClient = fromServant $ client Api.servantApi
+
+cachixBCClient :: Text -> Api.BinaryCacheAPI (AsClientT ClientM)
+cachixBCClient name = fromServant $ Api.cache cachixClient name
+
+cachixBCStreamingClient :: Text -> Api.BinaryCacheStreamingAPI (AsClientT ClientM)
+cachixBCStreamingClient name = fromServant $ client (Proxy :: Proxy Api.BinaryCachStreamingServantAPI) name

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -44,11 +44,12 @@ import           Cachix.Api.Signing             (fingerprint, passthroughSizeSin
 import qualified Cachix.Types.NarInfoCreate    as Api
 import           Cachix.Client.Exception        ( CachixException(..) )
 import           Cachix.Client.Servant
+import           Cachix.Client.Secrets
 
 
 data PushCache = PushCache
   { pushCacheName :: Text
-  , pushCacheSigningKey :: SecretKey
+  , pushCacheSigningKey :: SigningKey
   , pushCacheToken :: Token
   }
 data PushStrategy m r = PushStrategy
@@ -140,7 +141,7 @@ pushSingleStorePath ce cache cb storePath = retryPath $ \retrystatus -> do
 
                   let
                       fp = fingerprint storePath narHash narSize references
-                      sig = dsign (pushCacheSigningKey cache) fp
+                      sig = dsign (signingSecretKey $ pushCacheSigningKey cache) fp
                       nic = Api.NarInfoCreate
                         { cStoreHash = storeHash
                         , cStoreSuffix = storeSuffix

--- a/cachix/src/Cachix/Client/Secrets.hs
+++ b/cachix/src/Cachix/Client/Secrets.hs
@@ -1,0 +1,44 @@
+-- A facade for working with secrets and their representations, without delving
+-- into cryptography libraries.
+module Cachix.Client.Secrets (
+
+  -- * NAR signing
+  SigningKey(..)
+  , parseSigningKeyLenient
+  , exportSigningKey
+
+  -- TODO: * Auth token
+
+) where
+
+import           Crypto.Sign.Ed25519
+import qualified Data.ByteString.Base64        as B64
+import qualified Data.ByteString.Char8         as BC
+import           Data.Char                      ( isSpace )
+import           Protolude
+
+-- | A secret key for signing nars.
+newtype SigningKey = SigningKey { signingSecretKey :: SecretKey }
+
+parseSigningKeyLenientBS
+  :: ByteString -- ^ ASCII (Base64)
+  -> Either Text SigningKey -- ^ Error message or signing key
+parseSigningKeyLenientBS raw =
+  let bcDropWhileEnd f = BC.reverse . BC.dropWhile f . BC.reverse
+      bcDropAround f = bcDropWhileEnd f . BC.dropWhile f
+      stripped = bcDropAround isSpace raw
+      nonNull = if BC.null stripped then Left "A signing key must not be empty" else pure stripped
+  in SigningKey . SecretKey . B64.decodeLenient <$> nonNull
+
+parseSigningKeyLenient
+  :: Text -- ^ Base64
+  -> Either Text SigningKey -- ^ Error message or signing key
+parseSigningKeyLenient = parseSigningKeyLenientBS . toSL
+
+exportSigningKeyBS
+  :: SigningKey
+  -> ByteString -- ^ ASCII (Base64)
+exportSigningKeyBS (SigningKey (SecretKey bs)) = B64.encode bs
+
+exportSigningKey :: SigningKey -> Text
+exportSigningKey = toS . exportSigningKeyBS

--- a/cachix/src/Cachix/Client/Servant.hs
+++ b/cachix/src/Cachix/Client/Servant.hs
@@ -6,10 +6,12 @@
 
 module Cachix.Client.Servant
   ( isErr
+  , discardNoContent
   ) where
 
 import Protolude
 import Network.HTTP.Types (Status)
+import Servant.API (NoContent)
 import Servant.Client
 
 #if !MIN_VERSION_servant_client(0,16,0)
@@ -24,3 +26,7 @@ isErr (FailureResponse resp) status
 #endif
   | responseStatusCode resp == status = True
 isErr _ _ = False
+
+-- | Convert 'NoContent' to '()' in order to silence a needless warning.
+discardNoContent :: Functor f => f NoContent -> f ()
+discardNoContent = void

--- a/cachix/src/Cachix/Client/Servant.hs
+++ b/cachix/src/Cachix/Client/Servant.hs
@@ -6,7 +6,6 @@
 
 module Cachix.Client.Servant
   ( isErr
-  , discardNoContent
   ) where
 
 import Protolude
@@ -26,7 +25,3 @@ isErr (FailureResponse resp) status
 #endif
   | responseStatusCode resp == status = True
 isErr _ _ = False
-
--- | Convert 'NoContent' to '()' in order to silence a needless warning.
-discardNoContent :: Functor f => f NoContent -> f ()
-discardNoContent = void

--- a/cachix/src/Cachix/Client/URI.hs
+++ b/cachix/src/Cachix/Client/URI.hs
@@ -1,16 +1,22 @@
--- | Ugly glue between URI and BaseUrl
--- | TODO: mark as Internal module
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuasiQuotes #-}
 module Cachix.Client.URI
   ( getBaseUrl
+  , defaultCachixURI
+  , defaultCachixBaseUrl
   ) where
 
 import Protolude
 import qualified URI.ByteString as UBS
 import URI.ByteString hiding (Scheme)
 import Servant.Client
+import URI.ByteString.QQ
 
 
+-- TODO: make getBaseUrl internal
+
+-- | Partial function from URI to BaseUrl
+--
 getBaseUrl :: URIRef Absolute -> BaseUrl
 getBaseUrl URI{..} =
   case uriAuthority of
@@ -35,3 +41,9 @@ getBaseUrl URI{..} =
         defaultPort = case getScheme of
           Http -> 80
           Https -> 443
+
+defaultCachixURI :: URIRef Absolute
+defaultCachixURI = [uri|https://cachix.org|]
+
+defaultCachixBaseUrl :: BaseUrl
+defaultCachixBaseUrl = getBaseUrl defaultCachixURI

--- a/stack2nix.nix
+++ b/stack2nix.nix
@@ -6135,10 +6135,10 @@ inherit (pkgs.xorg) libXfixes;};
          , cryptonite, dhall, directory, ed25519, filepath, fsnotify, here
          , hspec, hspec-discover, http-client, http-client-tls, http-conduit
          , http-types, lzma-conduit, megaparsec, memory, mmorph, netrc
-         , optparse-applicative, process, protolude, retry, safe-exceptions
-         , servant, servant-auth, servant-auth-client, servant-client
-         , servant-client-core, servant-conduit, stdenv, temporary, text
-         , unix, uri-bytestring, versions
+         , optparse-applicative, process, protolude, resourcet, retry
+         , safe-exceptions, servant, servant-auth, servant-auth-client
+         , servant-client, servant-client-core, servant-conduit, stdenv
+         , temporary, text, unix, uri-bytestring, versions
          }:
          mkDerivation {
            pname = "cachix";
@@ -6152,10 +6152,10 @@ inherit (pkgs.xorg) libXfixes;};
              cachix-api conduit conduit-extra cookie cryptonite dhall directory
              ed25519 filepath fsnotify here http-client http-client-tls
              http-conduit http-types lzma-conduit megaparsec memory mmorph netrc
-             optparse-applicative process protolude retry safe-exceptions
-             servant servant-auth servant-auth-client servant-client
-             servant-client-core servant-conduit text unix uri-bytestring
-             versions
+             optparse-applicative process protolude resourcet retry
+             safe-exceptions servant servant-auth servant-auth-client
+             servant-client servant-client-core servant-conduit text unix
+             uri-bytestring versions
            ];
            executableHaskellDepends = [ base cachix-api ];
            executableToolDepends = [ hspec-discover ];


### PR DESCRIPTION
The first commit is a careful refactor that preserves all behavior.
The second commit is mostly just refactoring as well but also detects empty signing keys as a distinct error case.

Splitting out functions like `mapConcurrentlyBounded` and `withXzCompressor` gives the user fine control over resource usage, which is desirable in contexts that are themselves already concurrent. In such use cases, now you can use a single semaphore, worker pool or whatnot that is shared between concurrent pushes and therefore doesn't blow up as much.
