### PR TITLE
Optimize servant generic

### DIFF
--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -22,11 +22,8 @@ import           Data.String.Here
 import qualified Data.Text                      as T
 import           Network.HTTP.Types             (status404, status401)
 import           Protolude
-import           Servant.Auth                   ()
 import           Servant.Auth.Client
 import           Servant.API                    ( NoContent )
-import           Servant.API.Generic
-import           Servant.Client.Generic
 import           Servant.Client.Streaming
 import           Servant.Conduit                ()
 import           System.Directory               ( doesFileExist )
@@ -56,12 +53,6 @@ import           Cachix.Client.Secrets          ( SigningKey(SigningKey)
                                                 )
 import           Cachix.Client.Servant
 
-
-cachixClient :: Api.CachixAPI (AsClientT ClientM)
-cachixClient = fromServant $ client Api.servantApi
-
-cachixBCClient :: Text -> Api.BinaryCacheAPI (AsClientT ClientM)
-cachixBCClient name = fromServant $ Api.cache cachixClient name
 
 authtoken :: Env -> Text -> IO ()
 authtoken env token = do

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -32,8 +32,6 @@ import           Protolude
 import           Servant.API
 import           Servant.Auth                   ()
 import           Servant.Auth.Client
-import           Servant.API.Generic
-import           Servant.Client.Generic
 import           Servant.Client.Streaming hiding (ClientError)
 import           Servant.Conduit                ()
 import           System.Process                 ( readProcess )
@@ -207,12 +205,3 @@ mapConcurrentlyBounded bound action items = do
 splitStorePath :: Text -> (Text, Text)
 splitStorePath storePath =
   (T.take 32 (T.drop 11 storePath), T.drop 44 storePath)
-
-cachixClient :: Api.CachixAPI (AsClientT ClientM)
-cachixClient = fromServant $ client Api.servantApi
-
-cachixBCClient :: Text -> Api.BinaryCacheAPI (AsClientT ClientM)
-cachixBCClient name = fromServant $ Api.cache cachixClient name
-
-cachixBCStreamingClient :: Text -> Api.BinaryCacheStreamingAPI (AsClientT ClientM)
-cachixBCStreamingClient name = fromServant $ client (Proxy :: Proxy Api.BinaryCachStreamingServantAPI) name

--- a/cachix/src/Cachix/Client/Servant.hs
+++ b/cachix/src/Cachix/Client/Servant.hs
@@ -6,9 +6,31 @@
 
 module Cachix.Client.Servant
   ( isErr
+  , cachixClient
+  , cachixBCClient
+  , cachixBCStreamingClient
+  , runAuthenticatedClient
   , Cachix.Client.Servant.ClientError
   ) where
 
+import Protolude
+import Network.HTTP.Types (Status)
+import Servant.API (NoContent)
+import Servant.Client
+import           Protolude
+
+import qualified Cachix.Api as Api
+import           Cachix.Api.Error
+import           Network.HTTP.Types (Status)
+import           Servant.API.Generic
+import           Servant.Auth             ()
+import           Servant.Auth.Client      (Token)
+import           Servant.Client.Generic
+import           Servant.Client.Streaming
+import           Servant.Conduit          ()
+import qualified Cachix.Client.Env as Env
+import qualified Cachix.Client.Config as Config
+import qualified Cachix.Client.Exception as Exception
 import Protolude
 import Network.HTTP.Types (Status)
 import qualified Servant.Client
@@ -28,3 +50,20 @@ isErr (Servant.Client.FailureResponse resp) status
 #endif
   | Servant.Client.responseStatusCode resp == status = True
 isErr _ _ = False
+
+cachixClient :: Api.CachixAPI (AsClientT ClientM)
+cachixClient = fromServant $ client Api.servantApi
+
+cachixBCClient :: Text -> Api.BinaryCacheAPI (AsClientT ClientM)
+cachixBCClient name = fromServant $ Api.cache cachixClient name
+
+cachixBCStreamingClient :: Text -> Api.BinaryCacheStreamingAPI (AsClientT ClientM)
+cachixBCStreamingClient name = fromServant $ client (Proxy :: Proxy Api.BinaryCachStreamingServantAPI) name
+
+runAuthenticatedClient :: NFData a => Env.Env -> (Token -> ClientM a) -> IO a
+runAuthenticatedClient env m = do
+  config <- escalate $ maybeToEither (Exception.NoConfig
+     "Start with visiting https://cachix.org and copying the token to $ cachix authtoken <token>") (Env.config env)
+  escalate
+    =<< ((`runClientM` Env.clientenv env)
+    $ m (Config.authToken config))

--- a/cachix/src/Cachix/Client/Servant.hs
+++ b/cachix/src/Cachix/Client/Servant.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -O0 #-} -- TODO https://github.com/haskell-servant/servant/issues/986
 
 module Cachix.Client.Servant
   ( isErr
@@ -13,27 +14,21 @@ module Cachix.Client.Servant
   , Cachix.Client.Servant.ClientError
   ) where
 
-import Protolude
-import Network.HTTP.Types (Status)
-import Servant.API (NoContent)
-import Servant.Client
 import           Protolude
 
 import qualified Cachix.Api as Api
 import           Cachix.Api.Error
+import qualified Cachix.Client.Config as Config
+import qualified Cachix.Client.Env as Env
+import qualified Cachix.Client.Exception as Exception
 import           Network.HTTP.Types (Status)
 import           Servant.API.Generic
 import           Servant.Auth             ()
 import           Servant.Auth.Client      (Token)
-import           Servant.Client.Generic
+import qualified Servant.Client
+import           Servant.Client.Generic   (AsClientT)
 import           Servant.Client.Streaming
 import           Servant.Conduit          ()
-import qualified Cachix.Client.Env as Env
-import qualified Cachix.Client.Config as Config
-import qualified Cachix.Client.Exception as Exception
-import Protolude
-import Network.HTTP.Types (Status)
-import qualified Servant.Client
 
 type ClientError =
 #if !MIN_VERSION_servant_client(0,16,0)


### PR DESCRIPTION
Improve build time, working around haskell-servant/servant#986 
Saves about 20s, anecdotally.
