### PR TITLE
Add --compression-level

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,2 @@
+[ {"ignore": {"name": "Use newtype instead of data"}}
+]

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -17,6 +17,6 @@ main = do
     AuthToken token -> Commands.authtoken env token
     Create name -> Commands.create env name
     GenerateKeypair name -> Commands.generateKeypair env name
-    Push name paths watchStore -> Commands.push env name paths watchStore
+    Push pushArgs -> Commands.push env pushArgs
     Use name useOptions -> Commands.use env name useOptions
     Version -> putText cachixVersion

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -42,7 +42,9 @@ import           Cachix.Client.Config           ( Config(..)
 import qualified Cachix.Client.Config          as Config
 import           Cachix.Client.Env              ( Env(..) )
 import           Cachix.Client.Exception        ( CachixException(..) )
-import           Cachix.Client.OptionsParser    ( CachixOptions(..), UseOptions(..) )
+import           Cachix.Client.OptionsParser    ( CachixOptions(..), UseOptions(..)
+                                                , PushArguments(..) -- , PushOptions(..)
+                                                )
 import           Cachix.Client.InstallationMode
 import           Cachix.Client.NixVersion       ( getNixVersion )
 import qualified Cachix.Client.NixConf         as NixConf
@@ -145,8 +147,8 @@ use env name useOptions = do
 
 
 -- TODO: lots of room for perfomance improvements
-push :: Env -> Text -> [Text] -> Bool -> IO ()
-push env name rawPaths False = do
+push :: Env -> PushArguments -> IO ()
+push env (PushPaths _opts name rawPaths) = do
   hasNoStdin <- hIsTerminalDevice stdin
   when (not hasNoStdin && not (null rawPaths)) $ throwIO $ AmbiguousInput "You provided both stdin and store path arguments, pick only one to proceed."
   inputStorePaths <-
@@ -170,7 +172,7 @@ push env name rawPaths False = do
     inputStorePaths
   putText "All done."
 
-push env name _ True = withManager $ \mgr -> do
+push env (PushWatchStore _opts name) = withManager $ \mgr -> do
   _ <- watchDir mgr "/nix/store" filterF action
   putText "Watching /nix/store for new builds ..."
   forever $ threadDelay 1000000

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -8,6 +8,7 @@ module Cachix.Client.Push
   , PushCache(..)
   , PushStrategy(..)
   , defaultWithXzipCompressor
+  , defaultWithXzipCompressorWithLevel
 
     -- * Pushing a closure of store paths
   , pushClosure
@@ -60,8 +61,10 @@ data PushStrategy m r = PushStrategy
   }
 
 defaultWithXzipCompressor :: forall m a. (ConduitM ByteString ByteString (ResourceT IO) () -> m a) -> m a
-defaultWithXzipCompressor = ($ compress Nothing)
+defaultWithXzipCompressor = ($ compress (Just 2))
 
+defaultWithXzipCompressorWithLevel :: Int -> forall m a. (ConduitM ByteString ByteString (ResourceT IO) () -> m a) -> m a
+defaultWithXzipCompressorWithLevel l = ($ compress (Just l))
 
 pushSingleStorePath
   :: (MonadMask m, MonadIO m)

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -1,0 +1,10 @@
+{ ghc }:
+let pkgs = import ../nixpkgs.nix;
+in pkgs.haskell.lib.buildStackProject {
+  inherit ghc;
+  name = "cachix-stack-shell";
+  buildInputs = [
+    pkgs.lzma
+    pkgs.zlib
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ./nixpkgs.nix }:
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.stack
+    # hie can't find hspec-discover via stack
+    pkgs.haskellPackages.hspec-discover
+    ];
+  NIX_PATH = "nixpkgs=${pkgs.path}";
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,8 @@ packages:
 - cachix-api
 - cachix
 nix:
-    packages: [zlib,lzma]
+    packages: []
+    shell-file: ./nix/stack-shell.nix
     pure: false
 extra-deps:
 - netrc-0.2.0.0


### PR DESCRIPTION
- Includes a project shell and a shell for `stack` (I don't have a system `stack`)
- Compression level :tada:
- Default is 2 as [suggested](https://github.com/cachix/cachix/issues/55#issuecomment-508134594) 

```
$ cachix push --help
Usage: cachix push [--compression-level [0..9]] NAME ([PATHS...] |
                   [-w|--watch-store])
  Upload Nix store paths to the binary cache

Available options:
  -h,--help                Show this help text
  --compression-level [0..9]
                           The compression level for XZ compression. Take
                           compressor *and* decompressor memory usage into
                           account before using [7..9]! (default: 2)
  -w,--watch-store         Run in daemon mode and push store paths as they are
                           added to /nix/store

```

default (2):
```
FileHash: sha256:8e55d7721b734b8e0ab2c5185571168776e93599ea0649463e062f7ec9dd4091
FileSize: 1949624
NarSize: 10124712
```

`--compression-level 9`:
```
FileHash: sha256:56fc70c763ce90d68a977754d61c5b61ebb7e1e79b954c9a97b0832097b0714e
FileSize: 1744024
NarSize: 10124712
```