### PR TITLE
Revert "Stream nars without using a process"

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -57,7 +57,6 @@ library
       async
     , base >=4.7 && <5
     , base64-bytestring
-    , binary
     , bytestring
     , cachix-api
     , conduit >=1.3.0


### PR DESCRIPTION
This reverts commit 8b85d4b72f6f5897395f8c40d84ed5973955ab7c.

It's broken: https://github.com/haskell-nix/hnix-store/issues/51