### PR TITLE
cachix-api: use protolude

### DIFF
--- a/cachix-api/cachix-api.cabal
+++ b/cachix-api/cachix-api.cabal
@@ -16,6 +16,7 @@ extra-source-files:
 
 common defaults
   default-extensions:
+    NoImplicitPrelude
     DeriveAnyClass
     DeriveGeneric
     OverloadedStrings
@@ -64,6 +65,7 @@ library
     , http-media
     , lens
     , memory
+    , protolude
     , resourcet
     , servant               >=0.14.1
     , servant-auth

--- a/cachix-api/src/Cachix/Api.hs
+++ b/cachix-api/src/Cachix/Api.hs
@@ -32,10 +32,8 @@ import Control.Lens
 import Control.Monad.Trans.Resource
 import Data.ByteString (ByteString)
 import Data.Conduit (ConduitT)
-import Data.Proxy (Proxy (..))
 import Data.Swagger hiding (Header)
-import Data.Text
-import GHC.Generics (Generic)
+import Protolude
 import Servant.API hiding (BasicAuth)
 import Servant.API.Generic
 import Servant.Auth

--- a/cachix-api/src/Cachix/Api/Error.hs
+++ b/cachix-api/src/Cachix/Api/Error.hs
@@ -6,6 +6,7 @@ where
 
 import Control.Exception (Exception)
 import Control.Monad.Catch (MonadThrow (throwM))
+import Protolude
 
 {- | Examples:
     > escalate . maybeToEither err404
@@ -23,4 +24,4 @@ escalate
   :: (Exception exc, MonadThrow m)
   => Either exc a
   -> m a
-escalate = escalateAs id
+escalate = escalateAs identity

--- a/cachix-api/src/Cachix/Api/Signing.hs
+++ b/cachix-api/src/Cachix/Api/Signing.hs
@@ -15,9 +15,8 @@ import Data.ByteString (ByteString)
 import Data.Conduit
 import qualified Data.Conduit.Combinators as CC
 import Data.IORef
-import Data.String.Conv (toS)
 import qualified Data.Text as T
-import Data.Text (Text)
+import Protolude
 
 -- perl/lib/Nix/Manifest.pm:fingerprintPath
 -- NB: references must be sorted
@@ -25,7 +24,7 @@ fingerprint :: Text -> Text -> Integer -> [Text] -> ByteString
 fingerprint storePath narHash narSize references =
   toS
     $ T.intercalate ";"
-        ["1", storePath, narHash, T.pack (show narSize), T.intercalate "," references]
+        ["1", storePath, narHash, show narSize, T.intercalate "," references]
 
 -- Useful sinks for streaming nars
 sizeSink :: MonadIO m => ConduitT ByteString o m Integer

--- a/cachix-api/src/Cachix/Api/Types.hs
+++ b/cachix-api/src/Cachix/Api/Types.hs
@@ -2,10 +2,9 @@ module Cachix.Api.Types where
 
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Monoid ((<>))
 import Data.Swagger (ToParamSchema, ToSchema)
-import Data.Text (Text, dropEnd, takeEnd)
-import GHC.Generics (Generic)
+import Data.Text (dropEnd, takeEnd)
+import Protolude
 import Servant.API
 
 data NixCacheInfo

--- a/cachix-api/src/Cachix/Types/BinaryCacheAuthenticated.hs
+++ b/cachix-api/src/Cachix/Types/BinaryCacheAuthenticated.hs
@@ -8,8 +8,7 @@ import Data.Aeson
     ToJSON
     )
 import Data.Swagger
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Protolude
 
 -- | Binary Cache response content when user is authenticated
 data BinaryCacheAuthenticated

--- a/cachix-api/src/Cachix/Types/BinaryCacheCreate.hs
+++ b/cachix-api/src/Cachix/Types/BinaryCacheCreate.hs
@@ -8,8 +8,7 @@ import Data.Aeson
     ToJSON
     )
 import Data.Swagger
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Protolude
 
 data BinaryCacheCreate
   = BinaryCacheCreate

--- a/cachix-api/src/Cachix/Types/ContentTypes.hs
+++ b/cachix-api/src/Cachix/Types/ContentTypes.hs
@@ -8,10 +8,10 @@ module Cachix.Types.ContentTypes
 where
 
 import Cachix.Api.Types
-import Data.ByteString (ByteString)
-import Data.ByteString.Lazy (fromStrict, toStrict)
+import qualified Data.ByteString.Lazy as BSL
 import Data.Typeable (Typeable)
 import qualified Network.HTTP.Media as M
+import Protolude
 import Servant.API
 
 data XNixNar deriving (Typeable)
@@ -42,8 +42,8 @@ instance MimeUnrender XNixNarInfo NarInfo where
 
 instance MimeRender XNixNar ByteString where
 
-  mimeRender _ = fromStrict
+  mimeRender _ = BSL.fromStrict
 
 instance MimeUnrender XNixNar ByteString where
 
-  mimeUnrender _ = Right . toStrict
+  mimeUnrender _ = Right . BSL.toStrict

--- a/cachix-api/src/Cachix/Types/GitHubTeam.hs
+++ b/cachix-api/src/Cachix/Types/GitHubTeam.hs
@@ -8,8 +8,7 @@ import Data.Aeson
     ToJSON
     )
 import Data.Swagger
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Protolude
 
 data GitHubTeam
   = GitHubTeam

--- a/cachix-api/src/Cachix/Types/NarInfoCreate.hs
+++ b/cachix-api/src/Cachix/Types/NarInfoCreate.hs
@@ -5,14 +5,12 @@ module Cachix.Types.NarInfoCreate
     )
 where
 
-import Control.Exception (Exception)
 import Data.Aeson
   ( FromJSON,
     ToJSON
     )
 import Data.Swagger
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Protolude
 
 -- TODO: get rid of c prefix
 

--- a/cachix-api/src/Cachix/Types/Servant.hs
+++ b/cachix-api/src/Cachix/Types/Servant.hs
@@ -10,7 +10,7 @@ module Cachix.Types.Servant
     )
 where
 
-import Data.Text (Text)
+import Protolude
 import Servant.API
 
 -- Location header as per https://github.com/haskell-servant/servant/issues/117#issuecomment-381398666

--- a/cachix-api/src/Cachix/Types/Session.hs
+++ b/cachix-api/src/Cachix/Types/Session.hs
@@ -9,7 +9,7 @@ module Cachix.Types.Session
 where
 
 import Data.Aeson (FromJSON, ToJSON)
-import GHC.Generics (Generic)
+import Protolude
 -- TODO: move these two into Servant.Auth
 import Servant.Auth.Server (FromJWT, ToJWT)
 

--- a/cachix-api/src/Cachix/Types/SigningKeyCreate.hs
+++ b/cachix-api/src/Cachix/Types/SigningKeyCreate.hs
@@ -8,8 +8,7 @@ import Data.Aeson
     ToJSON
     )
 import Data.Swagger
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Protolude
 
 -- | Conveys that a signing secret key was created, by sharing the public key.
 newtype SigningKeyCreate

--- a/cachix-api/src/Cachix/Types/SwaggerOrphans.hs
+++ b/cachix-api/src/Cachix/Types/SwaggerOrphans.hs
@@ -8,8 +8,7 @@
 module Cachix.Types.SwaggerOrphans
   where
 
-import Control.DeepSeq (NFData)
-import Data.Proxy   (Proxy(..))
+import Protolude
 import Data.Conduit (ConduitT)
 import Data.Swagger (ToSchema(..))
 import Servant.API  (NoContent)


### PR DESCRIPTION
`ghcide` chokes on this, which in turn chokes on TH.

I'd rather have less cognitive overhead with this approach than adding forgetting to use protolude in some module.