### PR TITLE
Serve nar contents

### DIFF
--- a/cachix-api/cachix-api.cabal
+++ b/cachix-api/cachix-api.cabal
@@ -46,6 +46,7 @@ library
     Cachix.Types.CreateToken
     Cachix.Types.GitHubTeam
     Cachix.Types.NarInfoCreate
+    Cachix.Types.NarFileName
     Cachix.Types.Servant
     Cachix.Types.Session
     Cachix.Types.SigningKeyCreate

--- a/cachix-api/src/Cachix/Api.hs
+++ b/cachix-api/src/Cachix/Api.hs
@@ -116,7 +116,7 @@ data BinaryCacheStreamingAPI route
                :- "nar"
                :> StreamBody NoFraming XNixNar (ConduitT () ByteString (ResourceT IO) ())
                :> Post '[JSON] NoContent,
-        serveNar 
+        serveNarContent
           :: route
               :- CachixAuth
               :> "serve"

--- a/cachix-api/src/Cachix/Api.hs
+++ b/cachix-api/src/Cachix/Api.hs
@@ -14,11 +14,13 @@ module Cachix.Api
     BinaryCacheStreamingAPI (..),
     BinaryCachStreamingServantAPI,
     module Cachix.Api.Types,
-    module Cachix.Types.ContentTypes
+    module Cachix.Types.ContentTypes,
+    module Cachix.Types.NarFileName
     )
 where
 
 import Cachix.Api.Types
+import Cachix.Types.NarFileName (NarFileName(..))
 import qualified Cachix.Types.BinaryCacheAuthenticated as BinaryCacheAuthenticated
 import qualified Cachix.Types.BinaryCacheCreate as BinaryCacheCreate
 import Cachix.Types.ContentTypes
@@ -106,7 +108,7 @@ data BinaryCacheStreamingAPI route
           :: route
                :- CachixAuth
                :> "nar"
-               :> Capture "nar" NarC
+               :> Capture "nar" NarFileName
                :> StreamGet NoFraming OctetStream (ConduitT () ByteString (ResourceT IO) ()),
         createNar
           :: route

--- a/cachix-api/src/Cachix/Api.hs
+++ b/cachix-api/src/Cachix/Api.hs
@@ -120,7 +120,7 @@ data BinaryCacheStreamingAPI route
           :: route
               :- CachixAuth
               :> "serve"
-              :> Capture "storepath" Text
+              :> Capture "storehash" Text
               :> CaptureAll "filepath" Text
               :> Summary "Serve a file from a given store path"
               :> Get '[OctetStream] BSL.ByteString

--- a/cachix-api/src/Cachix/Api.hs
+++ b/cachix-api/src/Cachix/Api.hs
@@ -34,6 +34,7 @@ import Cachix.Types.SwaggerOrphans ()
 import Control.Lens
 import Control.Monad.Trans.Resource
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as BSL
 import Data.Conduit (ConduitT)
 import Data.Swagger hiding (Header)
 import Protolude
@@ -114,7 +115,15 @@ data BinaryCacheStreamingAPI route
           :: route
                :- "nar"
                :> StreamBody NoFraming XNixNar (ConduitT () ByteString (ResourceT IO) ())
-               :> Post '[JSON] NoContent
+               :> Post '[JSON] NoContent,
+        serveNar 
+          :: route
+              :- CachixAuth
+              :> "serve"
+              :> Capture "storepath" Text
+              :> CaptureAll "filepath" Text
+              :> Summary "Serve a file from a given store path"
+              :> Get '[OctetStream] BSL.ByteString
         }
   deriving (Generic)
 

--- a/cachix-api/src/Cachix/Api.hs
+++ b/cachix-api/src/Cachix/Api.hs
@@ -123,7 +123,7 @@ data BinaryCacheStreamingAPI route
               :> Capture "storehash" Text
               :> CaptureAll "filepath" Text
               :> Summary "Serve a file from a given store path"
-              :> Get '[OctetStream] BSL.ByteString
+              :> Get '[OctetStream] (Headers '[Header "X-Content-Type-Options" Text] BSL.ByteString)
         }
   deriving (Generic)
 

--- a/cachix-api/src/Cachix/Api/Types.hs
+++ b/cachix-api/src/Cachix/Api/Types.hs
@@ -63,20 +63,6 @@ newtype BinaryCacheError
         }
   deriving (Generic, FromJSON, ToJSON)
 
--- | Hash of nar.xz file
-newtype NarC = NarC Text deriving (Generic, ToSchema, ToParamSchema)
-
-instance FromHttpApiData NarC where
-
-  parseUrlPiece s =
-    if takeEnd 7 s == ".nar.xz"
-      then Right $ NarC (dropEnd 7 s)
-      else Left ""
-
-instance ToHttpApiData NarC where
-
-  toUrlPiece (NarC n) = n <> ".nar.xz"
-
 -- | Store path hash
 newtype NarInfoC = NarInfoC Text deriving (Generic, ToSchema, ToParamSchema)
 

--- a/cachix-api/src/Cachix/Types/NarFileName.hs
+++ b/cachix-api/src/Cachix/Types/NarFileName.hs
@@ -1,0 +1,23 @@
+module Cachix.Types.NarFileName 
+  (NarFileName(..)) where 
+
+import Protolude
+import Servant.API
+import Data.Text (dropEnd, takeEnd)
+
+-- | <hash>.nar.xz file
+data NarFileName = NarFileName 
+  { contentHash :: Text 
+  , extension :: Text
+  } deriving (Generic)
+
+instance FromHttpApiData NarFileName where
+
+  parseUrlPiece s =
+    if takeEnd 7 s == ".nar.xz"
+      then Right $ NarFileName (dropEnd 7 s) "xz"
+      else Left "Wrong extension"
+
+instance ToHttpApiData NarFileName where
+
+  toUrlPiece narfilename = contentHash narfilename <> ".nar." <> extension narfilename


### PR DESCRIPTION
I've also factored out `NarC` into separate module and renamed it to `NarFileName`, but then decided this shouldn't use nar hash, but rather store path hash.