### PR TITLE
Env: expose customManagerSettings for Push module users

### DIFF
--- a/cachix/src/Cachix/Client/Env.hs
+++ b/cachix/src/Cachix/Client/Env.hs
@@ -2,6 +2,7 @@ module Cachix.Client.Env
   ( Env (..),
     mkEnv,
     cachixVersion,
+    customManagerSettings,
   )
 where
 


### PR DESCRIPTION
This allows applications that don't have a single fixed `Config` to use the `Push` module without accidentally misconfiguring the http client manager.