### PR TITLE
Fix #251: Assert nar hash before creating narinfo

### DIFF
--- a/cachix/src/Cachix/Client/Exception.hs
+++ b/cachix/src/Cachix/Client/Exception.hs
@@ -12,6 +12,7 @@ data CachixException
   | NoConfig Text
   | NetRcParseError Text
   | NarStreamingError ExitCode Text
+  | NarHashMismatch Text
   | DeprecatedCommand Text
   | AccessDeniedBinaryCache Text
   | BinaryCacheNotFound Text

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -164,6 +164,8 @@ uploadStorePath clientEnv store cache cb storePath retrystatus = do
             --       of XZ compressors is limited
             narSize <- readIORef narSizeRef
             narHash <- ("sha256:" <>) . System.Nix.Base32.encode <$> readIORef narHashRef
+            narHashNix <- Store.validPathInfoNarHash pathinfo
+            when (narHash /= toS narHashNix) $ throwM $ NarHashMismatch "Nar hash mismatch between nix-store --dump and nix db"
             fileHash <- readIORef fileHashRef
             fileSize <- readIORef fileSizeRef
             deriverRaw <- T.strip . toS <$> readProcess "nix-store" ["-q", "--deriver", toS storePath] mempty

--- a/cachix/src/Cachix/Client/Store.hs
+++ b/cachix/src/Cachix/Client/Store.hs
@@ -123,7 +123,7 @@ validPathInfoNarSize vpi =
         { (*$fptr-ptr:(refValidPathInfo* vpi))->narSize }
       |]
 
--- | The narHash.to_string field of a ValidPathInfo struct. Source: store-api.hh
+-- | Copy the narHash field of a ValidPathInfo struct. Source: store-api.hh
 validPathInfoNarHash :: ForeignPtr (Ref ValidPathInfo) -> IO ByteString
 validPathInfoNarHash vpi =
   unsafePackMallocCString

--- a/cachix/src/Cachix/Client/Store.hs
+++ b/cachix/src/Cachix/Client/Store.hs
@@ -13,6 +13,7 @@ module Cachix.Client.Store
     followLinksToStorePath,
     queryPathInfo,
     validPathInfoNarSize,
+    validPathInfoNarHash,
 
     -- * Get closures
     computeFSClosure,
@@ -120,6 +121,14 @@ validPathInfoNarSize vpi =
     toInteger
       [C.pure| long
         { (*$fptr-ptr:(refValidPathInfo* vpi))->narSize }
+      |]
+
+-- | The narHash.to_string field of a ValidPathInfo struct. Source: store-api.hh
+validPathInfoNarHash :: ForeignPtr (Ref ValidPathInfo) -> IO ByteString
+validPathInfoNarHash vpi =
+  unsafePackMallocCString
+    =<< [C.exp| const char
+        *{ strdup((*$fptr-ptr:(refValidPathInfo* vpi))->narHash.to_string().c_str()) }
       |]
 
 ----- PathSet -----


### PR DESCRIPTION
Fixes uncommon but annoying bug of "bad nar archive" from Nix.

Never managed to reproduce. One theory is that the path disappears as
its deleted by GC or nix-store --delete.