### PR TITLE
cabal: add category: Nix

### DIFF
--- a/cachix-api/cachix-api.cabal
+++ b/cachix-api/cachix-api.cabal
@@ -7,6 +7,7 @@ bug-reports:        https://github.com/cachix/cachix/issues
 author:             Domen Kožar
 maintainer:         domen@enlambda.com
 copyright:          2018 Domen Kožar
+category:           Nix
 license:            Apache-2.0
 license-file:       LICENSE
 build-type:         Simple

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -4,6 +4,7 @@ version:            0.3.7
 license:            Apache-2.0
 license-file:       LICENSE
 copyright:          2018 Domen Kožar
+category:           Nix
 maintainer:         domen@enlambda.com
 author:             Domen Kožar
 homepage:           https://github.com/cachix/cachix#readme


### PR DESCRIPTION
So it shows up in http://hackage.haskell.org/packages/#cat:Nix
