### PR TITLE
Add --omit-deriver

### DIFF
--- a/cachix-api/test/Main.hs
+++ b/cachix-api/test/Main.hs
@@ -2,7 +2,6 @@ module Main where
 
 import Protolude
 import qualified Spec
-import Test.Hspec.Formatters
 import Test.Hspec.Runner
 
 main :: IO ()

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -230,7 +230,8 @@ pushStrategy env opts name storePath =
         -- we append newline instead of putStrLn due to https://github.com/haskell/text/issues/242
         putStr $ retryText retrystatus <> "compressing and pushing " <> storePath <> " (" <> humanSize (fromIntegral size) <> ")\n",
       onDone = pass,
-      withXzipCompressor = defaultWithXzipCompressorWithLevel (compressionLevel opts)
+      withXzipCompressor = defaultWithXzipCompressorWithLevel (compressionLevel opts),
+      Cachix.Client.Push.omitDeriver = Cachix.Client.OptionsParser.omitDeriver opts
     }
 
 pushStorePath :: Env -> PushOptions -> Text -> Text -> IO ()

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -77,7 +77,8 @@ data PushArguments
 data PushOptions
   = PushOptions
       { compressionLevel :: Int,
-        numJobs :: Int
+        numJobs :: Int,
+        omitDeriver :: Bool
       }
   deriving (Show)
 
@@ -118,6 +119,7 @@ parserCachixCommand =
               <> showDefault
               <> value 4
           )
+        <*> switch (long "omit-deriver" <> help "Do not publish which derivations built the store paths.")
     push = (\opts cache f -> Push $ f opts cache) <$> pushOptions <*> nameArg <*> (pushPaths <|> pushWatchStore)
     pushPaths =
       (\paths opts cache -> PushPaths opts cache paths)

--- a/cachix/src/Cachix/Client/Store.hs
+++ b/cachix/src/Cachix/Client/Store.hs
@@ -15,6 +15,7 @@ module Cachix.Client.Store
     validPathInfoNarSize,
     validPathInfoNarHash,
     validPathInfoDeriver,
+    unknownDeriver,
     validPathInfoReferences,
 
     -- * Get closures
@@ -134,6 +135,8 @@ validPathInfoNarHash vpi =
       |]
 
 -- | Deriver field of a ValidPathInfo struct. Source: store-api.hh
+--
+-- Returns 'unknownDeriver' when missing.
 validPathInfoDeriver :: ForeignPtr (Ref ValidPathInfo) -> IO ByteString
 validPathInfoDeriver vpi =
   unsafePackMallocCString
@@ -143,6 +146,11 @@ validPathInfoDeriver vpi =
           return strdup((deriver == "" ? "unknown-deriver" : deriver->c_str()));
         }
       |]
+
+-- | String constant representing the case when the deriver of a store path does
+-- not exist or is not known. Value: @unknown-deriver@
+unknownDeriver :: Text
+unknownDeriver = "unknown-deriver"
 
 -- | References field of a ValidPathInfo struct. Source: store-api.hh
 validPathInfoReferences :: ForeignPtr (Ref ValidPathInfo) -> IO PathSet

--- a/cachix/test/NetRcSpec.hs
+++ b/cachix/test/NetRcSpec.hs
@@ -37,11 +37,11 @@ config =
 
 -- TODO: poor man's golden tests, use https://github.com/stackbuilders/hspec-golden
 test :: [BinaryCache] -> Text -> Expectation
-test binaryCaches goldenName = withSystemTempFile "hspec-netrc" $ \filepath _ -> do
+test caches goldenName = withSystemTempFile "hspec-netrc" $ \filepath _ -> do
   let input = "test/data/" <> toS goldenName <> ".input"
       output = "test/data/" <> toS goldenName <> ".output"
   copyFile input filepath
-  NetRc.add config binaryCaches filepath
+  NetRc.add config caches filepath
   real <- readFile filepath
   expected <- readFile output
   real `shouldBe` expected


### PR DESCRIPTION
This adds an option to unset the deriver field. It's useful as an _extra_ line of defense for those who distribute binaries through cachix and have to deal with confidential source code.