### PR TITLE
Fixed wrong suggestion for trusted users

### DIFF
--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -71,7 +71,7 @@ getInstallationMode nixenv
 addBinaryCache :: Maybe Config -> Api.BinaryCache -> UseOptions -> InstallationMode -> IO ()
 addBinaryCache _ _ _ UntrustedRequiresSudo =
   throwIO $
-    MustBeRoot "Run command as root OR execute: $ echo \"trusted-users = root $USER\" | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon"
+    MustBeRoot "Run command as root OR execute: $ echo 'trusted-users = root $USER' | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon"
 addBinaryCache maybeConfig bc useOptions WriteNixOS =
   nixosBinaryCache maybeConfig bc useOptions
 addBinaryCache maybeConfig bc _ (Install ncl) = do

--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -71,7 +71,7 @@ getInstallationMode nixenv
 addBinaryCache :: Maybe Config -> Api.BinaryCache -> UseOptions -> InstallationMode -> IO ()
 addBinaryCache _ _ _ UntrustedRequiresSudo =
   throwIO $
-    MustBeRoot "Run command as root OR execute: $ echo 'trusted-users = root $USER' | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon"
+    MustBeRoot "Run command as root OR execute: $ echo 'trusted-users = root '$USER | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon"
 addBinaryCache maybeConfig bc useOptions WriteNixOS =
   nixosBinaryCache maybeConfig bc useOptions
 addBinaryCache maybeConfig bc _ (Install ncl) = do


### PR DESCRIPTION
If you come across this error the suggestion will append "trusted-users = root $USER" with the double ticks into nix.conf. Somehow the escaping will be printed out with the string.

To avoid this we can use single ticks instead of double ticks.