### PR TITLE
Regression: use auth token when using signing key with private caches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,11 @@ jobs:
     - uses: cachix/cachix-action@v7
       with:
         name: cachix
+    - uses: cachix/cachix-action@v7
+      with:
+        name: cachix
         installCommand: nix-env -if .
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: echo " " >> cachix/CHANGELOG.md
     - run: nix-build ci.nix
+    # make sure it's all uploaded to cachix
+    - run: sudo bash -c "echo > /tmp/store-path-pre-build" 


### PR DESCRIPTION
Also fix a bug: signing key from shell environment should override the
one from the config file.