### PR TITLE
Fix instructions for adding user to trustedUsers

### DIFF
--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -92,7 +92,7 @@ a) Run the same command as root to write NixOS configuration.
 b) Add the following to your configuration.nix to add your user as trusted 
    and then try again:
 
-  trustedUsers = [ "root" "${user}" ];
+  nix.trustedUsers = [ "root" "${user}" ];
 
     |]
 addBinaryCache _ _ _ UntrustedRequiresSudo = do


### PR DESCRIPTION
I don't know if this is correct for all versions of Nixpkgs but it's what I had to do on 20.09.