### PR TITLE
Build cachix in ci.nix

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,4 +1,4 @@
 {
-  cachix = import ./default.nix;
+  cachix = import ./default.nix {};
   pre-commit-check = (import ./nix {}).pre-commit-check;
 }


### PR DESCRIPTION
With Hercules CI you would notice that it is missing.

See https://hercules-ci.com/github/hercules-ci/cachix/jobs/1 (master)
and https://hercules-ci.com/github/hercules-ci/cachix/jobs/2 (branch)

For context, its expression traversal is mostly identical to
`nix-build`, which is used in the github actions test.yml
workflow.