### PR TITLE
cachix authtoken now reads from stdin if no token is provided on the command line

### DIFF
--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -67,7 +67,7 @@ authtoken env (Just token) = do
   writeConfig (configPath (cachixoptions env)) $ case config env of
     Just cfg -> Config.setAuthToken cfg $ Token (toS token)
     Nothing -> mkConfig token
-authtoken env Nothing = authtoken env . Just =<< T.IO.getContents
+authtoken env Nothing = authtoken env . Just . T.strip =<< T.IO.getContents
 
 generateKeypair :: Env -> Text -> IO ()
 generateKeypair env name = do

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -48,6 +48,7 @@ import Crypto.Sign.Ed25519 (PublicKey (PublicKey), createKeypair)
 import qualified Data.ByteString.Base64 as B64
 import Data.String.Here
 import qualified Data.Text as T
+import qualified Data.Text.IO as T.IO
 import Network.HTTP.Types (status401, status404)
 import Protolude hiding (toS)
 import Protolude.Conv
@@ -60,12 +61,13 @@ import System.IO (hIsTerminalDevice)
 import qualified System.Posix.Signals as Signals
 import qualified System.Process
 
-authtoken :: Env -> Text -> IO ()
-authtoken env token = do
+authtoken :: Env -> Maybe Text -> IO ()
+authtoken env (Just token) = do
   -- TODO: check that token actually authenticates!
   writeConfig (configPath (cachixoptions env)) $ case config env of
     Just cfg -> Config.setAuthToken cfg $ Token (toS token)
     Nothing -> mkConfig token
+authtoken env Nothing = authtoken env . Just =<< T.IO.getContents
 
 generateKeypair :: Env -> Text -> IO ()
 generateKeypair env name = do

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -95,7 +95,10 @@ parserCachixCommand =
       <> command "use" (infoH use (progDesc "Configure a binary cache by writing nix.conf and netrc files"))
   where
     nameArg = strArgument (metavar "CACHE-NAME")
-    authtoken = AuthToken <$> optional (strArgument (metavar "AUTH-TOKEN"))
+    authtoken = AuthToken <$> (stdinFlag <|> (Just <$> authTokenArg))
+      where
+        stdinFlag = flag' Nothing (long "stdin" <> help "Read the token from stdin rather than accepting it as an argument.")
+        authTokenArg = strArgument (metavar "AUTH-TOKEN")
     generateKeypair = GenerateKeypair <$> nameArg
     validatedLevel l =
       l <$ unless (l `elem` [0 .. 9]) (readerError $ "value " <> show l <> " not in expected range: [0..9]")

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -62,7 +62,7 @@ uriOption = eitherReader $ \s ->
 type BinaryCacheName = Text
 
 data CachixCommand
-  = AuthToken Text
+  = AuthToken (Maybe Text)
   | GenerateKeypair BinaryCacheName
   | Push PushArguments
   | WatchStore PushOptions Text
@@ -95,7 +95,7 @@ parserCachixCommand =
       <> command "use" (infoH use (progDesc "Configure a binary cache by writing nix.conf and netrc files"))
   where
     nameArg = strArgument (metavar "CACHE-NAME")
-    authtoken = AuthToken <$> strArgument (metavar "AUTH-TOKEN")
+    authtoken = AuthToken <$> optional (strArgument (metavar "AUTH-TOKEN"))
     generateKeypair = GenerateKeypair <$> nameArg
     validatedLevel l =
       l <$ unless (l `elem` [0 .. 9]) (readerError $ "value " <> show l <> " not in expected range: [0..9]")


### PR DESCRIPTION
Closes #363.

Should I change the docs to recommend this as well? Passing secrets as command line arguments is, in general, insecure, since other users can snoop on them via `/proc/*/cmdline`.