### PR TITLE
cachix-deployment: create a new group when running a deployment

### DIFF
--- a/cachix/src/Cachix/Deploy/StdinProcess.hs
+++ b/cachix/src/Cachix/Deploy/StdinProcess.hs
@@ -8,7 +8,15 @@ import Prelude (String, userError)
 -- | Run a process with only stdin as an input
 readProcess :: FilePath -> [String] -> String -> IO ()
 readProcess cmd args input = do
-  (Just stdin, _, _, ph) <- createProcess (proc cmd args) {std_in = CreatePipe}
+  (Just stdin, _, _, ph) <-
+    createProcess
+      (proc cmd args)
+        { std_in = CreatePipe,
+          -- When launching cachix-deployment we need to make sure it's not killed when the main process is killed
+          create_group = True,
+          -- Same, but with posix api
+          new_session = True
+        }
   hPutStr stdin input
   hClose stdin
   exitcode <- waitForProcess ph


### PR DESCRIPTION
This is to ensure that process monitors don't kill the deployment
when restarting the agent (usually due to an upgrade).