### PR TITLE
Emit login token in netrc file even though it's empty

### DIFF
--- a/cachix/src/Cachix/Client/NetRc.hs
+++ b/cachix/src/Cachix/Client/NetRc.hs
@@ -48,7 +48,9 @@ add cachixAuthToken binarycaches filename = do
     mkHost bc =
       NetRcHost
         { nrhName = toS $ stripPrefix "http://" $ stripPrefix "https://" (BinaryCache.uri bc),
-          nrhLogin = "",
+          -- Workaround for bug in libcurl where netrc is not respected
+          -- in the absence of the login token.
+          nrhLogin = "\"\"",
           nrhPassword = getToken cachixAuthToken,
           nrhAccount = "",
           nrhMacros = []

--- a/cachix/test/data/add.input
+++ b/cachix/test/data/add.input
@@ -1,1 +1,1 @@
-machine name.cachix.org password token123
+machine name.cachix.org login "" password token123

--- a/cachix/test/data/add.output
+++ b/cachix/test/data/add.output
@@ -1,3 +1,3 @@
-machine name2.cachix.org password token123
+machine name2.cachix.org login "" password token123
 
-machine name.cachix.org password token123
+machine name.cachix.org login "" password token123

--- a/cachix/test/data/empty.output
+++ b/cachix/test/data/empty.output
@@ -1,3 +1,3 @@
-machine name.cachix.org password token123
+machine name.cachix.org login "" password token123
 
-machine name2.cachix.org password token123
+machine name2.cachix.org login "" password token123

--- a/cachix/test/data/override.input
+++ b/cachix/test/data/override.input
@@ -1,3 +1,3 @@
-machine name.cachix.org password token123
+machine name.cachix.org login "" password token123
 
-machine name2.cachix.org password abc123
+machine name2.cachix.org login "" password abc123

--- a/cachix/test/data/override.output
+++ b/cachix/test/data/override.output
@@ -1,3 +1,3 @@
-machine name2.cachix.org password token123
+machine name2.cachix.org login "" password token123
 
-machine name.cachix.org password token123
+machine name.cachix.org login "" password token123


### PR DESCRIPTION
This is a workaround for https://github.com/curl/curl/issues/9148.