### PR TITLE
Bump gitignore to latest version

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "hercules-ci",
         "repo": "gitignore",
-        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
-        "sha256": "0va0janxvmilm67nbl81gdbpppal4aprxzb25gp9pqvf76ahxsci",
+        "rev": "f2ea0f8ff1bce948ccb6b893d15d5ea3efaf1364",
+        "sha256": "02q2yvakyh9x9h9x9az2rr3h6h0zymhrl0z2xflc6blvz6zzqkf2",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore/archive/bff2832ec341cf30acb3a4d3e2e7f1f7b590116a.tar.gz",
+        "url": "https://github.com/hercules-ci/gitignore/archive/f2ea0f8ff1bce948ccb6b893d15d5ea3efaf1364.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
It is not possible to build cachix using `nix build`:

```
➜  cachix git:(master) nix build
error (ignored): error: end of string reached
error: the path '~/.gitconfig' can not be resolved in pure mode
(use '--show-trace' to show detailed location information)
➜  cachix git:(master)
```

The latest version of gitignore.nix [permits](https://github.com/hercules-ci/gitignore.nix/commit/f840a659d57e53fa751a9248b17149fd0cf2a221) building with pure evaluation mode.