### PR TITLE
Remove the workaround for flushing logs when deploying

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -169,6 +169,7 @@ executable .cachix-deployment
     , protolude
     , safe-exceptions
     , stm
+    , stm-chans
     , stm-conduit
     , time
     , uuid

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -60,8 +60,6 @@ activate options connection sourceStream deploymentDetails agentInfo agentToken 
         now <- liftIO getCurrentTime
         K.logLocM K.InfoS $ K.ls $ "Deploying #" <> index <> " failed."
         sendMessage $ deploymentFinished False now
-        -- hack to flush logs
-        liftIO $ threadDelay (5 * 1000 * 1000)
   K.logLocM K.InfoS $ K.ls $ "Deploying #" <> index <> ": " <> WSS.storePath deploymentDetails
   -- notify the service deployment started
   now <- liftIO getCurrentTime
@@ -117,8 +115,6 @@ activate options connection sourceStream deploymentDetails agentInfo agentToken 
               now <- liftIO getCurrentTime
               sendMessage $ deploymentFinished True now
               liftIO $ log "Successfully activated the deployment."
-              -- TODO: this is a hack to make sure the deployment is finished
-              liftIO $ threadDelay (5 * 1000 * 1000)
               K.logLocM K.InfoS $ K.ls $ "Deployment #" <> index <> " finished"
   where
     -- TODO: prevent service from being restarted while deploying


### PR DESCRIPTION
The workaround was a delay, added at the end of the deployment activation, to give the logger some time to catch up with upstreaming the logs. This became necessary because the logging and activation threads were being run concurrently with `race`. As soon as the activation was complete, the logging thread would be immediately cancelled.

The fix is to run the threads `concurrently` and use a closable channel (TMQueue) to control the lifecycle of the logger, instead of relying on asynchronous exceptions.

The goodbye message for the deployment socket has also been moved out of the logger.