### PR TITLE
Ensure watch-* commands are cleaned up just once

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -90,6 +90,7 @@ library
     , dhall                   >=1.28.0
     , directory
     , ed25519
+    , extra
     , filepath
     , fsnotify
     , hercules-ci-cnix-store

--- a/cachix/src/Cachix/Client/WatchStore.hs
+++ b/cachix/src/Cachix/Client/WatchStore.hs
@@ -6,7 +6,6 @@ where
 import Cachix.Client.Push
 import qualified Cachix.Client.PushQueue as PushQueue
 import qualified Control.Concurrent.STM.TBQueue as TBQueue
-import Data.List (isSuffixOf)
 import Hercules.CNix.Store (Store)
 import qualified Hercules.CNix.Store as Store
 import Protolude
@@ -15,7 +14,7 @@ import qualified System.Systemd.Daemon as Systemd
 
 startWorkers :: Store -> Int -> PushParams IO () -> IO ()
 startWorkers store numWorkers pushParams = do
-  Systemd.notifyReady
+  void Systemd.notifyReady
   withManager $ \mgr -> PushQueue.startWorkers numWorkers (producer store mgr) pushParams
 
 producer :: Store -> WatchManager -> PushQueue.Queue -> IO (IO ())


### PR DESCRIPTION
This addresses one possible source of #430.