### PR TITLE
Use file locks to limit concurrent profile deployments

### DIFF
--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -45,7 +45,7 @@ main = do
   input <- escalateAs (FatalError . toS) . Aeson.eitherDecode . toS =<< getContents
   let profile = toS . CachixWebsocket.profile . Input.websocketOptions $ input
   void $
-    Lock.withTryLock profile $
+    Lock.withTryLock ("/nix/var/nix/profiles/" <> profile) $
       CachixWebsocket.runForever (CachixWebsocket.websocketOptions input) (handleMessage input)
 
 handleMessage :: CachixWebsocket.Input -> ByteString -> (K.KatipContextT IO () -> IO ()) -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> K.KatipContextT IO ()

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -43,10 +43,9 @@ main = do
   hSetBuffering stderr LineBuffering
 
   input <- escalateAs (FatalError . toS) . Aeson.eitherDecode . toS =<< getContents
-  let profile = toS . CachixWebsocket.profile . Input.websocketOptions $ input
-  void $
-    Lock.withTryLock ("/nix/var/nix/profiles/" <> profile) $
-      CachixWebsocket.runForever (CachixWebsocket.websocketOptions input) (handleMessage input)
+  let profile = CachixWebsocket.profile . Input.websocketOptions $ input
+  void . Lock.withTryLock profile $
+    CachixWebsocket.runForever (CachixWebsocket.websocketOptions input) (handleMessage input)
 
 handleMessage :: CachixWebsocket.Input -> ByteString -> (K.KatipContextT IO () -> IO ()) -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> K.KatipContextT IO ()
 handleMessage input payload runKatip connection _ agentToken =

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -65,6 +65,7 @@ library
     Cachix.Deploy.Activate
     Cachix.Deploy.ActivateCommand
     Cachix.Deploy.Agent
+    Cachix.Deploy.Lock
     Cachix.Deploy.OptionsParser
     Cachix.Deploy.StdinProcess
     Cachix.Deploy.Websocket
@@ -101,6 +102,7 @@ library
     , http-types
     , inline-c-cpp
     , katip
+    , lukko
     , lzma-conduit
     , megaparsec              >=7.0.0
     , memory

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -22,12 +22,13 @@ run cachixOptions agentOpts =
   where
     host = toS $ Servant.baseUrlHost $ getBaseUrl $ CachixOptions.host cachixOptions
     name = AgentOptions.name agentOpts
+    profile = fromMaybe "system" (AgentOptions.profile agentOpts)
     options =
       CachixWebsocket.Options
         { CachixWebsocket.host = host,
           CachixWebsocket.name = name,
           CachixWebsocket.path = "/ws",
-          CachixWebsocket.profile = AgentOptions.profile agentOpts,
+          CachixWebsocket.profile = profile,
           CachixWebsocket.isVerbose = CachixOptions.verbose cachixOptions
         }
     handleMessage :: ByteString -> (K.KatipContextT IO () -> IO ()) -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> K.KatipContextT IO ()
@@ -49,7 +50,7 @@ run cachixOptions agentOpts =
                         { host = host,
                           name = name,
                           path = "/ws-deployment",
-                          profile = AgentOptions.profile agentOpts,
+                          profile = profile,
                           isVerbose = CachixOptions.verbose cachixOptions
                         }
                   }

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -5,7 +5,6 @@ module Cachix.Deploy.Agent where
 import qualified Cachix.API.WebSocketSubprotocol as WSS
 import qualified Cachix.Client.OptionsParser as CachixOptions
 import Cachix.Client.URI (getBaseUrl)
-import qualified Cachix.Deploy.Lock as Lock
 import qualified Cachix.Deploy.OptionsParser as AgentOptions
 import Cachix.Deploy.StdinProcess (readProcess)
 import qualified Cachix.Deploy.Websocket as CachixWebsocket

--- a/cachix/src/Cachix/Deploy/Lock.hs
+++ b/cachix/src/Cachix/Deploy/Lock.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cachix.Deploy.Lock (withLock) where
+
+import qualified Lukko as Lock
+import Protolude hiding ((<.>))
+import qualified System.Directory as Directory
+import System.FilePath ((<.>), (</>))
+import qualified System.Posix.Files as Files
+import qualified System.Posix.Types as Posix
+
+defaultLockDirectory :: FilePath
+defaultLockDirectory = "cachix" </> "deploy" </> "locks"
+
+-- | Get a path to the lock directory
+getLockDirectoryFromProfile :: FilePath -> IO FilePath
+getLockDirectoryFromProfile profile = do
+  userId <- Files.fileOwner <$> Files.getFileStatus profile
+  if isRoot userId
+    then pure $ "/var/run" </> defaultLockDirectory
+    else Directory.getXdgDirectory Directory.XdgCache defaultLockDirectory
+  where
+    isRoot :: Posix.UserID -> Bool
+    isRoot = (==) 0
+
+-- | Run an IO action with an acquired profile lock.
+--
+-- Lock files are stored in either the user’s or system’s cache directory,
+-- depending on the ownership of the profile.
+--
+-- Lock files are not deleted after use.
+withLock :: forall a. FilePath -> IO a -> IO a
+withLock path action = do
+  lockDirectory <- getLockDirectoryFromProfile path
+
+  Directory.createDirectoryIfMissing True lockDirectory
+  Directory.setPermissions lockDirectory $
+    Directory.emptyPermissions
+      & Directory.setOwnerReadable True
+      & Directory.setOwnerWritable True
+      & Directory.setOwnerExecutable True
+      & Directory.setOwnerSearchable True
+
+  let lockFile = lockDirectory </> path <.> "lock"
+
+  bracket
+    (Lock.fdOpen lockFile)
+    (Lock.fdUnlock *> Lock.fdClose)
+    loop
+  where
+    loop :: Lock.FD -> IO a
+    loop fd = do
+      lock <- Lock.fdTryLock fd Lock.ExclusiveLock
+      if lock
+        then action
+        else do
+          threadDelay (1 * 1000 * 1000)
+          loop fd

--- a/cachix/src/Cachix/Deploy/Lock.hs
+++ b/cachix/src/Cachix/Deploy/Lock.hs
@@ -4,6 +4,7 @@ import qualified Lukko as Lock
 import Protolude hiding ((<.>))
 import qualified System.Directory as Directory
 import System.FilePath ((<.>), (</>))
+import qualified System.FilePath as FilePath
 import qualified System.Posix.Files as Files
 import qualified System.Posix.Types as Posix
 
@@ -28,8 +29,8 @@ getLockDirectoryFromProfile profile = do
 --
 -- Lock files are not deleted after use.
 withTryLock :: FilePath -> IO a -> IO (Maybe a)
-withTryLock path action = do
-  lockDirectory <- getLockDirectoryFromProfile path
+withTryLock profilePath action = do
+  lockDirectory <- getLockDirectoryFromProfile profilePath
 
   Directory.createDirectoryIfMissing True lockDirectory
   Directory.setPermissions lockDirectory $
@@ -39,7 +40,8 @@ withTryLock path action = do
       & Directory.setOwnerExecutable True
       & Directory.setOwnerSearchable True
 
-  let lockFile = lockDirectory </> path <.> "lock"
+  let profile = FilePath.takeFileName profilePath
+  let lockFile = lockDirectory </> profile <.> "lock"
 
   bracket
     (Lock.fdOpen lockFile)

--- a/cachix/src/Cachix/Deploy/Lock.hs
+++ b/cachix/src/Cachix/Deploy/Lock.hs
@@ -4,36 +4,18 @@ import qualified Lukko as Lock
 import Protolude hiding ((<.>))
 import qualified System.Directory as Directory
 import System.FilePath ((<.>), (</>))
-import qualified System.FilePath as FilePath
-import qualified System.Posix.Files as Files
-import qualified System.Posix.Types as Posix
 
 defaultLockDirectory :: FilePath
 defaultLockDirectory = "cachix" </> "deploy" </> "locks"
 
--- | Get the path to the lock directory based on the ownership of the profile.
---
--- For user-owned profiles: $XDG_CACHE_DIR/cachix/deploy/locks
--- For root-owned profiles: /var/run/cachix/deploy/locks
-getLockDirectoryFromProfile :: FilePath -> IO FilePath
-getLockDirectoryFromProfile profilePath = do
-  userId <- Files.fileOwner <$> Files.getFileStatus (FilePath.takeDirectory profilePath)
-  if isRoot userId
-    then pure $ "/var/run" </> defaultLockDirectory
-    else Directory.getXdgDirectory Directory.XdgCache defaultLockDirectory
-  where
-    isRoot :: Posix.UserID -> Bool
-    isRoot = (==) 0
-
 -- | Run an IO action with an acquired profile lock. Returns immediately if the profile is already locked.
 --
--- Lock files are stored in either the user’s or system’s cache directory,
--- depending on the ownership of the profile.
---
 -- Lock files are not deleted after use.
-withTryLock :: FilePath -> IO a -> IO (Maybe a)
-withTryLock profilePath action = do
-  lockDirectory <- getLockDirectoryFromProfile profilePath
+--
+-- macOS: if using sudo, make sure to use `-H` to reset the home directory.
+withTryLock :: Text -> IO a -> IO (Maybe a)
+withTryLock profileName action = do
+  lockDirectory <- Directory.getXdgDirectory Directory.XdgCache defaultLockDirectory
 
   Directory.createDirectoryIfMissing True lockDirectory
   Directory.setPermissions lockDirectory $
@@ -43,8 +25,7 @@ withTryLock profilePath action = do
       & Directory.setOwnerExecutable True
       & Directory.setOwnerSearchable True
 
-  let profile = FilePath.takeFileName profilePath
-  let lockFile = lockDirectory </> profile <.> "lock"
+  let lockFile = lockDirectory </> toS profileName <.> "lock"
 
   bracket
     (Lock.fdOpen lockFile)

--- a/cachix/src/Cachix/Deploy/Lock.hs
+++ b/cachix/src/Cachix/Deploy/Lock.hs
@@ -11,10 +11,13 @@ import qualified System.Posix.Types as Posix
 defaultLockDirectory :: FilePath
 defaultLockDirectory = "cachix" </> "deploy" </> "locks"
 
--- | Get a path to the lock directory
+-- | Get the path to the lock directory based on the ownership of the profile.
+--
+-- For user-owned profiles: $XDG_CACHE_DIR/cachix/deploy/locks
+-- For root-owned profiles: /var/run/cachix/deploy/locks
 getLockDirectoryFromProfile :: FilePath -> IO FilePath
-getLockDirectoryFromProfile profile = do
-  userId <- Files.fileOwner <$> Files.getFileStatus profile
+getLockDirectoryFromProfile profilePath = do
+  userId <- Files.fileOwner <$> Files.getFileStatus (FilePath.takeDirectory profilePath)
   if isRoot userId
     then pure $ "/var/run" </> defaultLockDirectory
     else Directory.getXdgDirectory Directory.XdgCache defaultLockDirectory

--- a/cachix/src/Cachix/Deploy/OptionsParser.hs
+++ b/cachix/src/Cachix/Deploy/OptionsParser.hs
@@ -27,7 +27,7 @@ parser =
 
 data AgentOptions = AgentOptions
   { name :: Text,
-    profile :: Text
+    profile :: Maybe Text
   }
   deriving (Show)
 
@@ -43,10 +43,11 @@ parserAgentOptions =
       ( metavar "AGENT-NAME"
           <> help "Unique identifier (usually hostname)."
       )
-    <*> strArgument
-      ( value ""
-          <> metavar "NIX-PROFILE"
-          <> help "Nix profile to manage. Defaults to 'system' on NixOS and 'system-profiles/system' on nix-darwin."
+    <*> optional
+      ( strArgument
+          ( metavar "NIX-PROFILE"
+              <> help "Nix profile to manage. Defaults to 'system' on NixOS and 'system-profiles/system' on nix-darwin."
+          )
       )
 
 parserActivateOptions :: Parser ActivateOptions


### PR DESCRIPTION
This handles the edge case where the agent launches multiple concurrent deployments.

The design is as follows:
1. The agent launches the deployer binary as usual.
2. The deployer tries to acquire a lock on a lock file, stored in either the user cache directory or in `/var/run` and named after the target profile.
3. Either:
    - The lock is acquired and the deployment continues.
    - The lock is busy. The deployer exits immediately. The backend reschedules the deployment.

To avoid race conditions, the lock files are not removed.
If the owner of the lock crashes, the lock file is unlocked.

### Update

To avoid creating root-owned files inside user directories, we check that the home directory is owned by the current user. `withTryLock` should ideally sanity check this as well in case we remove the check from the agent.

Here’s what the error looks like on macOS:
```sh
❯ sudo result/bin/cachix deploy agent cachix-test-darwin test
[2022-08-31 16:03:07][agent.agent][Error][asdf.local][PID 8390][ThreadId 7][cachix-0.9.0-5e0pDsosASb1tBWytm0Ma9:Cachix.Deploy.Websocket src/Cachix/Deploy/Websocket.hs:47:16] The current user (root) does not own the home directory (/Users/Sander)
Try running the agent with `sudo -H`.
```