### PR TITLE
Deploy: communicate closure size

### DIFF
--- a/cachix-api/src/Cachix/API/Deploy.hs
+++ b/cachix-api/src/Cachix/API/Deploy.hs
@@ -5,11 +5,8 @@
 module Cachix.API.Deploy where
 
 import Cachix.API (CachixAuth)
-import qualified Cachix.Types.ByteStringStreaming as ByteStringStreaming
 import qualified Cachix.Types.Deploy as Deploy
 import qualified Cachix.Types.DeployResponse as DeployResponse
-import Conduit (ConduitT, ResourceT)
-import qualified Data.UUID as UUID
 import Protolude
 import Servant.API
 import Servant.API.Generic

--- a/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
+++ b/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
@@ -45,7 +45,7 @@ data BackendCommand
   deriving (Show, Eq, Generic, Aeson.FromJSON, Aeson.ToJSON)
 
 data AgentCommand
-  = DeploymentStarted {id :: UUID, time :: UTCTime}
+  = DeploymentStarted {id :: UUID, time :: UTCTime, closureSize :: Maybe Int64}
   | DeploymentFinished {id :: UUID, time :: UTCTime, hasSucceeded :: Bool}
   deriving (Show, Eq, Generic, Aeson.FromJSON, Aeson.ToJSON)
 

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module Cachix.Deploy.Activate where
@@ -8,11 +9,18 @@ import qualified Cachix.Client.NetRc as NetRc
 import qualified Cachix.Deploy.Websocket as CachixWebsocket
 import qualified Cachix.Types.BinaryCache as BinaryCache
 import Cachix.Types.Permission (Permission (..))
+import qualified Data.Aeson as Aeson
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap as HM
+#else
+import qualified Data.HashMap.Strict as HM
+#endif
 import qualified Data.Conduit as Conduit
 import qualified Data.Conduit.Combinators as Conduit
 import qualified Data.Conduit.Process as Conduit
 import Data.Time.Clock (getCurrentTime)
 import qualified Data.UUID.V4 as UUID
+import qualified Data.Vector as Vector
 import qualified Katip as K
 import qualified Network.WebSockets as WS
 import Protolude hiding (log, toS)
@@ -42,16 +50,8 @@ activate ::
   WSS.AgentInformation ->
   ByteString ->
   K.KatipContextT IO ()
-activate options connection sourceStream deploymentDetails agentInfo agentToken = do
+activate options connection sourceStream deploymentDetails agentInfo agentToken = withCacheArgs options agentInfo agentToken $ \cacheArgs -> do
   let storePath = WSS.storePath deploymentDetails
-      cachesArgs :: [String]
-      cachesArgs = case WSS.cache agentInfo of
-        Just cache ->
-          let officialCache = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-              substituters = ["--option", "extra-substituters", toS (uri options cache)]
-              sigs = ["--option", "trusted-public-keys", officialCache <> " " <> toS (domain options cache) <> "-1:" <> toS (WSS.publicKey cache)]
-           in substituters ++ sigs
-        Nothing -> []
       deploymentID = WSS.id (deploymentDetails :: WSS.DeploymentDetails)
       deploymentFinished hasSucceeded now =
         WSS.DeploymentFinished
@@ -66,37 +66,19 @@ activate options connection sourceStream deploymentDetails agentInfo agentToken 
         hackFlush
   K.logLocM K.InfoS $ K.ls $ "Deploying #" <> index <> ": " <> WSS.storePath deploymentDetails
   -- notify the service deployment started
-  now <- liftIO getCurrentTime
-  sendMessage $
-    WSS.DeploymentStarted
-      { WSS.id = deploymentID,
-        WSS.time = now
-      }
-  -- TODO: don't create tmpfile for public caches
+  (_, pathInfoJSON, _) <- liftIO $ shellNoStream "nix" (cacheArgs <> ["--extra-experimental-features", "nix-command", "path-info", "-S", "--json", toS storePath])
+  do
+    now <- liftIO getCurrentTime
+    sendMessage $
+      WSS.DeploymentStarted
+        { WSS.id = deploymentID,
+          WSS.time = now,
+          WSS.closureSize = maybe Nothing extractClosureSize (Aeson.decode (toS pathInfoJSON) :: Maybe Aeson.Value)
+        }
   -- TODO: add GC root so it's preserved for the next command
   -- get the store path using caches
-  (downloadExitCode, _, _) <- liftIO $
-    withSystemTempDirectory "netrc" $
-      \dir -> do
-        let filepath = dir <> "netrc"
-        args <- case WSS.cache agentInfo of
-          Just cache -> do
-            -- TODO: ugh
-            let bc =
-                  BinaryCache.BinaryCache
-                    { BinaryCache.name = "",
-                      BinaryCache.uri = toS (uri options cache),
-                      BinaryCache.publicSigningKeys = [],
-                      BinaryCache.isPublic = WSS.isPublic cache,
-                      BinaryCache.githubUsername = "",
-                      BinaryCache.permission = Read
-                    }
-            NetRc.add (Token agentToken) [bc] filepath
-            return $ cachesArgs <> ["--option", "netrc-file", filepath]
-          Nothing ->
-            return cachesArgs
-        -- don't do negative caching of narinfos
-        shellOut "nix-store" (["-r", toS storePath] <> args <> ["--option", "narinfo-cache-negative-ttl", "0"])
+  (downloadExitCode, _, _) <-
+    liftIO $ shellOut "nix-store" (["-r", toS storePath] <> cacheArgs)
   -- TODO: use exceptions to simplify this code
   case downloadExitCode of
     ExitFailure _ -> deploymentFailed
@@ -124,6 +106,14 @@ activate options connection sourceStream deploymentDetails agentInfo agentToken 
   where
     index :: Text
     index = show $ WSS.index deploymentDetails
+    -- TODO: it would be better to stream and also return the text
+    shellNoStream :: FilePath -> [String] -> IO (ExitCode, String, String)
+    shellNoStream cmd args = do
+      log $ "$ " <> toS cmd <> " " <> toS (unwords $ fmap toS args)
+      (exitCode, procstdout, procstderr) <- readProcessWithExitCode cmd args ""
+      log $ toS procstderr
+      return (exitCode, toS procstdout, toS procstderr)
+    shellOut :: FilePath -> [String] -> IO (ExitCode, (), ())
     shellOut cmd args = do
       log $ "$ " <> toS cmd <> " " <> toS (unwords $ fmap toS args)
       Conduit.sourceProcessWithStreams (proc cmd args) Conduit.sinkNull sourceStream sourceStream
@@ -145,6 +135,7 @@ activate options connection sourceStream deploymentDetails agentInfo agentToken 
         method = case command of
           WSS.DeploymentStarted {} -> "DeploymentStarted"
           WSS.DeploymentFinished {} -> "DeploymentFinished"
+    -- TODO: home-manager
     getActivationScript :: Text -> Text -> IO (Text, [Command])
     getActivationScript storePath profile = do
       isNixOS <- doesPathExist $ toS $ storePath <> "/nixos-version"
@@ -166,4 +157,43 @@ activate options connection sourceStream deploymentDetails agentInfo agentToken 
 
 type Command = (String, [String])
 
--- TODO: home-manager
+extractClosureSize :: Aeson.Value -> Maybe Int64
+extractClosureSize (Aeson.Array vector) = case Vector.toList vector of
+  [Aeson.Object obj] -> case HM.lookup "closureSize" obj of
+    Just (Aeson.Number num) -> Just $ floor num
+    _ -> Nothing
+  _ -> Nothing
+extractClosureSize _ = Nothing
+
+-- TODO: don't create tmpfile for public caches
+withCacheArgs :: CachixWebsocket.Options -> WSS.AgentInformation -> ByteString -> ([String] -> K.KatipContextT IO ()) -> K.KatipContextT IO ()
+withCacheArgs options agentInfo agentToken m =
+  withSystemTempDirectory "netrc" $ \dir -> do
+    let filepath = dir <> "netrc"
+    args <- case WSS.cache agentInfo of
+      Just cache -> do
+        -- TODO: ugh
+        let bc =
+              BinaryCache.BinaryCache
+                { BinaryCache.name = "",
+                  BinaryCache.uri = toS (uri options cache),
+                  BinaryCache.publicSigningKeys = [],
+                  BinaryCache.isPublic = WSS.isPublic cache,
+                  BinaryCache.githubUsername = "",
+                  BinaryCache.permission = Read
+                }
+        liftIO $ NetRc.add (Token agentToken) [bc] filepath
+        return $ cachesArgs <> ["--option", "netrc-file", filepath]
+      Nothing ->
+        return cachesArgs
+    m args
+  where
+    cachesArgs :: [String]
+    cachesArgs = case WSS.cache agentInfo of
+      Just cache ->
+        let officialCache = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+            substituters = ["--option", "extra-substituters", toS (uri options cache)]
+            noNegativeCaching = ["--option", "narinfo-cache-negative-ttl", "0"]
+            sigs = ["--option", "trusted-public-keys", officialCache <> " " <> toS (domain options cache) <> "-1:" <> toS (WSS.publicKey cache)]
+         in substituters ++ sigs ++ noNegativeCaching
+      Nothing -> []

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -122,9 +122,6 @@ activate options connection sourceStream deploymentDetails agentInfo agentToken 
               K.logLocM K.InfoS $ K.ls $ "Deployment #" <> index <> " finished"
               hackFlush
   where
-    -- TODO: prevent service from being restarted while deploying
-    -- TODO: upgrade agent
-
     index :: Text
     index = show $ WSS.index deploymentDetails
     shellOut cmd args = do


### PR DESCRIPTION
I wasn't able to make `shellOut` to return `stdout` so I create a similar function with a slightly different behaviour :sweat_smile: 

While I was at it, I refactored all cache setup into a separate function.