### PR TITLE
Refactor deployment

### DIFF
--- a/cachix-api/cachix-api.cabal
+++ b/cachix-api/cachix-api.cabal
@@ -79,10 +79,12 @@ library
     , nix-narinfo
     , protolude
     , resourcet
+    , safe-exceptions
     , servant               >=0.14.1
     , servant-auth
     , servant-auth-swagger
     , servant-client
+    , stm-chans
     , string-conv
     , swagger2
     , text

--- a/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
+++ b/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
@@ -4,7 +4,7 @@ module Cachix.API.WebSocketSubprotocol where
 
 import qualified Control.Concurrent.Async as Async
 import qualified Control.Concurrent.STM.TMQueue as TMQueue
-import qualified Control.Exception.Safe as Exception
+import qualified Control.Exception.Safe as Safe
 import qualified Data.Aeson as Aeson
 import Data.Time (UTCTime)
 import Data.UUID (UUID)
@@ -73,10 +73,9 @@ receiveDataConcurrently connection action =
   where
     producer queue consumerThread =
       loop
-        `Exception.finally` closeGracefully queue consumerThread
+        `finally` closeGracefully queue consumerThread
+        `Safe.catch` closeRequest
       where
-        -- `Exception.catch` closeRequest
-
         loop = do
           payload <- WS.receiveData connection
           atomically $ TMQueue.writeTMQueue queue payload

--- a/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
+++ b/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cachix.API.WebSocketSubprotocol where
 

--- a/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
+++ b/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
@@ -73,9 +73,10 @@ receiveDataConcurrently connection action =
   where
     producer queue consumerThread =
       loop
-        `Exception.catch` closeRequest
         `Exception.finally` closeGracefully queue consumerThread
       where
+        -- `Exception.catch` closeRequest
+
         loop = do
           payload <- WS.receiveData connection
           atomically $ TMQueue.writeTMQueue queue payload

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -99,6 +99,7 @@ handleMessage withLog deployment websocketOptions connection payload =
     index = show $ WSS.index deploymentDetails
     profileName = Agent.profileName deployment
     agentToken = Agent.agentToken deployment
+    agentInformation = Agent.agentInformation deployment
 
     -- WebSocket options
     host = WebSocket.host websocketOptions
@@ -107,7 +108,7 @@ handleMessage withLog deployment websocketOptions connection payload =
     handleCommand :: WSS.BackendCommand -> IO ()
     handleCommand (WSS.Deployment _) =
       withLog $ K.logLocM K.ErrorS "cachix-deployment should have never gotten a deployment command directly."
-    handleCommand (WSS.AgentRegistered agentInformation) = do
+    handleCommand (WSS.AgentRegistered _) = do
       withLog $ K.logLocM K.InfoS $ K.ls $ "Deploying #" <> index <> ": " <> storePath
 
       let logPath = "/api/v1/deploy/log/" <> UUID.toText deploymentID

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Main
   ( main,
@@ -170,7 +169,6 @@ deploy withLog deployment websocketOptions backendQueue logStream = do
     -- WebSocket options
 
     host = WebSocket.host websocketOptions
-    headers = WebSocket.headers websocketOptions
 
     startDeployment :: Maybe Int64 -> IO ()
     startDeployment closureSize = do

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -73,8 +73,8 @@ main = do
         `finally` do
           withLog $ K.logLocM K.DebugS $ K.ls ("Cleaning up websocket connections" :: Text)
           atomically $ TMQueue.closeTMQueue logQueue
-          WebSocket.close service
-          Async.waitBoth loggingThread serviceThread
+          WebSocket.drainQueue service
+          Async.waitBoth serviceThread loggingThread
 
 -- | Open and maintain a websocket connection to the backend for sending deployment
 -- progress updates.

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -57,10 +57,23 @@ main = do
 
   Log.withLog logOptions $ \withLog ->
     void . Lock.withTryLock profile $
-      CachixWebsocket.runForever withLog websocketOptions (handleMessage input)
+      CachixWebsocket.runForever withLog websocketOptions (handleMessage withLog input)
 
-handleMessage :: CachixWebsocket.Input -> ByteString -> Log.WithLog -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> IO ()
-handleMessage input payload withLog connection _ agentToken =
+handleMessage ::
+  -- | Logging context
+  Log.WithLog ->
+  -- | Deployment information passed from the agent
+  CachixWebsocket.Input ->
+  -- | Backend WebSocket connection
+  WS.Connection ->
+  -- | Message from the backend
+  ByteString ->
+  -- | Agent information
+  CachixWebsocket.AgentState ->
+  -- | Agent token
+  ByteString ->
+  IO ()
+handleMessage withLog input connection payload _ agentToken =
   case WSS.parseMessage payload of
     Left err ->
       -- TODO: show the bytestring?

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -60,7 +60,7 @@ main = do
             WebSocket.path = "/api/v1/deploy/log/" <> UUID.toText deploymentID,
             WebSocket.useSSL = URI.requiresSSL (URI.getScheme host),
             WebSocket.headers = headers,
-            WebSocket.agentIdentifier = Agent.agentIdentifier agentName
+            WebSocket.identifier = Agent.agentIdentifier agentName
           }
   let serviceWebsocketOptions =
         WebSocket.Options
@@ -69,7 +69,7 @@ main = do
             WebSocket.path = "/ws-deployment",
             WebSocket.useSSL = URI.requiresSSL (URI.getScheme host),
             WebSocket.headers = headers,
-            WebSocket.agentIdentifier = Agent.agentIdentifier agentName
+            WebSocket.identifier = Agent.agentIdentifier agentName
           }
 
   Log.withLog logOptions $ \withLog ->

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE NamedFieldPuns #-}
 
 module Main
   ( main,
@@ -14,6 +13,7 @@ import qualified Cachix.Deploy.Lock as Lock
 import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.Websocket as WebSocket
 import qualified Control.Concurrent.Async as Async
+import qualified Control.Concurrent.MVar as MVar
 import qualified Control.Concurrent.STM.TMQueue as TMQueue
 import qualified Control.Exception.Safe as Safe
 import qualified Data.Aeson as Aeson
@@ -31,15 +31,12 @@ import qualified Network.WebSockets as WS
 import Protolude hiding (toS)
 import Protolude.Conv
 import System.IO (BufferMode (..), hSetBuffering)
-import qualified System.Timeout as Timeout
 import qualified Wuss
 
 -- | Activate the new deployment.
 --
 -- If the target profile is already locked by another deployment, exit
 -- immediately and rely on the backend to reschedule.
---
--- TODO: what if websocket gets closed while deploying?
 main :: IO ()
 main = do
   setLocaleEncoding utf8
@@ -68,39 +65,50 @@ main = do
             WebSocket.agentIdentifier = Agent.agentIdentifier agentName
           }
 
-  Log.withLog logOptions $ \withLog -> do
+  Log.withLog logOptions $ \withLog ->
     void . Lock.withTryLock profileName $ do
-      backendQueue <- atomically TMQueue.newTMQueue
-      logQueue <- atomically TMQueue.newTMQueue
+      -- Open a connection to logging stream
+      (logQueue, loggingThread) <- runLogStream withLog host logPath (WebSocket.headers websocketOptions)
 
-      Async.withAsync (streamLog withLog host logPath (WebSocket.headers websocketOptions) logQueue) $ \logThread ->
-        Async.withAsync (connectToBackend withLog websocketOptions agentInformation backendQueue) $ \backendThread ->
-          deploy withLog deployment websocketOptions backendQueue (Conduit.sinkTMQueue logQueue)
-            `finally` do
-              withLog $ K.logLocM K.DebugS $ K.ls ("Cleaning up websocket connections" :: Text)
-              atomically $ do
-                TMQueue.closeTMQueue logQueue
-                TMQueue.closeTMQueue backendQueue
-              Async.waitBoth logThread backendThread
+      -- Open a connection to Cachix and block until it's ready.
+      (service, serviceThread) <- connectToService withLog websocketOptions agentInformation
 
--- | Maintain a websocket connection to the backend for sending deployment
+      deploy withLog deployment service (Conduit.sinkTMQueue logQueue)
+        `finally` do
+          withLog $ K.logLocM K.DebugS $ K.ls ("Cleaning up websocket connections" :: Text)
+          atomically $ TMQueue.closeTMQueue logQueue
+          WebSocket.close service
+          Async.waitBoth loggingThread serviceThread
+
+-- | Open and maintain a websocket connection to the backend for sending deployment
 -- progress updates.
-connectToBackend ::
+connectToService ::
   Log.WithLog ->
   WebSocket.Options ->
   WSS.AgentInformation ->
-  TMQueue.TMQueue WSS.AgentCommand ->
-  IO ()
-connectToBackend withLog websocketOptions agentInformation backendQueue =
-  WebSocket.withConnection withLog websocketOptions $ \connection -> do
-    Conduit.runConduit $
-      Conduit.sourceTMQueue backendQueue
-        .| Conduit.mapM_ (sendMessage connection)
+  IO (WebSocket.WebSocket WSS.AgentCommand WSS.BackendCommand, Async.Async ())
+connectToService withLog websocketOptions agentInformation = do
+  initialConnection <- MVar.newEmptyMVar
+
+  thread <- Async.async $
+    WebSocket.withConnection withLog websocketOptions $ \websocket ->
+      do
+        MVar.putMVar initialConnection websocket
+        Async.withAsync (WebSocket.consumeIntoVoid websocket) $ \_ ->
+          Conduit.runConduit $
+            Conduit.sourceTBMQueue (WebSocket.tx websocket)
+              .| Conduit.mapM_ (sendMessage websocket)
+
+  -- Block until the connection has been established
+  websocket <- MVar.readMVar initialConnection
+
+  return (websocket, thread)
   where
-    sendMessage :: WS.Connection -> WSS.AgentCommand -> IO ()
-    sendMessage connection cmd = do
-      command <- createMessage cmd
-      WSS.sendMessage connection command
+    sendMessage :: WebSocket.WebSocket WSS.AgentCommand WSS.BackendCommand -> WebSocket.Message WSS.AgentCommand -> IO ()
+    sendMessage WebSocket.WebSocket {connection} (WebSocket.DataMessage msg) = do
+      command <- createMessage msg
+      activeConnection <- MVar.readMVar connection
+      WS.sendTextData activeConnection $ Aeson.encode command
 
     createMessage :: WSS.AgentCommand -> IO (WSS.Message WSS.AgentCommand)
     createMessage command = do
@@ -124,35 +132,69 @@ deploy ::
   Log.WithLog ->
   -- | Deployment information passed from the agent
   Agent.Deployment ->
-  -- | Websocket options
-  WebSocket.Options ->
-  -- | Message queue for the backend websocket connection
-  TMQueue.TMQueue WSS.AgentCommand ->
+  WebSocket.WebSocket WSS.AgentCommand WSS.BackendCommand ->
+  -- WebSocket.Receive WSS.AgentCommand ->
+
   -- | Logging Websocket connection
   Log.LogStream ->
   IO ()
-deploy withLog deployment websocketOptions backendQueue logStream = do
+deploy withLog deployment service logStream = do
   withLog $ K.logLocM K.InfoS $ K.ls $ "Deploying #" <> deploymentIndex <> ": " <> storePath
 
-  deploymentStatus <- Safe.tryIO $
+  activationStatus <- Safe.tryIO $
     Activate.withCacheArgs host agentInformation agentToken $ \cacheArgs -> do
-      -- TODO: what if this fails
+      startDeployment Nothing
+
+      Activate.downloadStorePaths logStream deploymentDetails cacheArgs
+
+      -- Read the closure size and report
+      --
+      -- TODO: query the remote store to get the size before downloading (and
+      -- possibly running out of disk space)
       closureSize <- fromRight Nothing <$> Activate.getClosureSize cacheArgs storePath
-      startDeployment closureSize
+      when (isJust closureSize) $ startDeployment closureSize
 
-      Activate.activate logStream profileName deploymentDetails cacheArgs
+      rollbackAction <- Activate.activate logStream profileName (toS storePath)
 
-  -- TODO: Test network, run rollback script, and optionally trigger rollback
+      -- Run tests on the new deployment
+      testResults <- Safe.tryIO $ do
+        -- Run network test
+        pong <- WebSocket.waitForPong 10 service
+        when (isNothing pong) $ throwIO Activate.NetworkTestFailure
 
-  case deploymentStatus of
-    Left _ -> do
-      Log.streamLine logStream "Failed to activate the deployment."
+        for (WSS.rollbackScript deploymentDetails) $ \rollbackScript -> do
+          Log.streamLine logStream "Running rollback script."
+          rollbackScriptResult <- Safe.tryIO $ Activate.runShellWithExitCode logStream (toS rollbackScript) []
+          case rollbackScriptResult of
+            Left e -> throwIO (Activate.RollbackScriptFailure e)
+            Right exitCode ->
+              case exitCode of
+                ExitSuccess -> pure ()
+                ExitFailure _ -> throwIO Activate.RollbackFailure
+
+      -- Roll back if any of the tests have failed
+      when (isLeft testResults) $
+        case rollbackAction of
+          Just rollback -> do
+            Log.streamLine logStream "Deployment failed, rolling back ..."
+            rollback
+          Nothing ->
+            Log.streamLine logStream "Skipping rollback as this is the first deployment."
+
+  case activationStatus of
+    Left e -> do
+      Log.streamLine logStream $
+        toS $
+          unwords
+            [ "Failed to activate the deployment.",
+              toS $ displayException e
+            ]
       withLog $ K.logLocM K.InfoS $ K.ls $ "Deploying #" <> deploymentIndex <> " failed."
     Right _ -> do
       Log.streamLine logStream "Successfully activated the deployment."
       withLog $ K.logLocM K.InfoS $ K.ls $ "Deployment #" <> deploymentIndex <> " finished"
 
-  endDeployment (isRight deploymentStatus)
+  endDeployment (isRight activationStatus)
   where
     -- TODO: cut down record access boilerplate
 
@@ -162,19 +204,16 @@ deploy withLog deployment websocketOptions backendQueue logStream = do
     deploymentDetails = Agent.deploymentDetails deployment
     deploymentID = WSS.id (deploymentDetails :: WSS.DeploymentDetails)
     deploymentIndex = show $ WSS.index deploymentDetails
+    host = Agent.host deployment
     profileName = Agent.profileName deployment
     agentToken = Agent.agentToken deployment
     agentInformation = Agent.agentInformation deployment
 
-    -- WebSocket options
-
-    host = WebSocket.host websocketOptions
-
     startDeployment :: Maybe Int64 -> IO ()
     startDeployment closureSize = do
       now <- getCurrentTime
-      atomically $
-        TMQueue.writeTMQueue backendQueue $
+      WebSocket.send service $
+        WebSocket.DataMessage $
           WSS.DeploymentStarted
             { WSS.id = deploymentID,
               WSS.time = now,
@@ -184,8 +223,8 @@ deploy withLog deployment websocketOptions backendQueue logStream = do
     endDeployment :: Bool -> IO ()
     endDeployment hasSucceeded = do
       now <- getCurrentTime
-      atomically $
-        TMQueue.writeTMQueue backendQueue $
+      WebSocket.send service $
+        WebSocket.DataMessage $
           WSS.DeploymentFinished
             { WSS.id = deploymentID,
               WSS.time = now,
@@ -195,7 +234,8 @@ deploy withLog deployment websocketOptions backendQueue logStream = do
 -- Log
 
 -- TODO: prepend katip-like format to each line
-streamLog ::
+-- TODO: use the WebSocket module here (without ping?)
+runLogStream ::
   -- | Logging context
   Log.WithLog ->
   -- | Host
@@ -204,11 +244,13 @@ streamLog ::
   Text ->
   -- | HTTP headers
   HTTP.RequestHeaders ->
-  -- | Queue of messages to stream
-  TMQueue.TMQueue ByteString ->
-  IO ()
-streamLog withLog host path headers queue = do
-  WebSocket.reconnectWithLog withLog $
-    Wuss.runSecureClientWith (toS host) 443 (toS path) WS.defaultConnectionOptions headers $ \connection ->
-      Log.streamLog withLog connection queue
-        `finally` WebSocket.waitForGracefulShutdown connection
+  -- | Returns a queue for writing messages and the thread handle
+  IO (TMQueue.TMQueue ByteString, Async.Async ())
+runLogStream withLog host path headers = do
+  queue <- TMQueue.newTMQueueIO
+  thread <- Async.async $
+    WebSocket.reconnectWithLog withLog $
+      Wuss.runSecureClientWith (toS host) 443 (toS path) WS.defaultConnectionOptions headers $ \connection ->
+        Log.streamLog withLog connection queue
+          `finally` WebSocket.waitForGracefulShutdown connection
+  return (queue, thread)

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -25,6 +25,7 @@ common defaults
     DeriveAnyClass
     DeriveGeneric
     DerivingVia
+    LambdaCase
     NamedFieldPuns
     OverloadedStrings
 

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -201,12 +201,17 @@ test-suite cachix-test
     NixConfSpec
     NixVersionSpec
     Spec
+    URISpec
 
   build-depends:
+    , aeson
     , base                 >=4.7 && <5
+    , bytestring
     , cachix
     , cachix-api
+    , dhall
     , directory
+    , extra
     , here
     , hspec
     , protolude

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -134,7 +134,6 @@ library
     , text
     , time
     , unix
-    , unliftio
     , unordered-containers
     , uri-bytestring
     , uuid

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -68,6 +68,7 @@ library
     Cachix.Deploy.ActivateCommand
     Cachix.Deploy.Agent
     Cachix.Deploy.Lock
+    Cachix.Deploy.Log
     Cachix.Deploy.OptionsParser
     Cachix.Deploy.StdinProcess
     Cachix.Deploy.Websocket
@@ -132,6 +133,7 @@ library
     , text
     , time
     , unix
+    , unliftio
     , unordered-containers
     , uri-bytestring
     , uuid

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -127,6 +127,7 @@ library
     , servant-client-core     >=0.16
     , servant-conduit
     , stm
+    , stm-chans
     , stm-conduit
     , systemd
     , temporary

--- a/cachix/src/Cachix/Client/Config.hs
+++ b/cachix/src/Cachix/Client/Config.hs
@@ -26,7 +26,6 @@ where
 
 import Cachix.Client.Config.Orphans ()
 import Cachix.Client.Exception (CachixException (..))
-import Cachix.Client.URI (URI)
 import Cachix.Client.URI as URI
 import qualified Control.Exception.Safe as Safe
 import Data.Either.Extra (eitherToMaybe)

--- a/cachix/src/Cachix/Client/Config/Orphans.hs
+++ b/cachix/src/Cachix/Client/Config/Orphans.hs
@@ -1,18 +1,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# LANGUAGE FlexibleInstances #-}
 
-module Cachix.Client.Config.Orphans
-  (
-  )
-where
+module Cachix.Client.Config.Orphans where
 
 import qualified Dhall
 import qualified Dhall.Core
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Auth.Client
-import qualified URI.ByteString as URI
-import Data.Either.Validation ( Validation(Failure, Success) )
 
 instance Dhall.FromDhall Token where
   autoWith _ = Dhall.strictText {Dhall.extract = ex}
@@ -25,29 +19,3 @@ instance Dhall.ToDhall Token where
     { Dhall.embed = Dhall.Core.TextLit . Dhall.Core.Chunks [] . toS . getToken,
       Dhall.declared = Dhall.Core.Text
     }
-
-instance Dhall.FromDhall (URI.URIRef URI.Absolute) where
-  autoWith opts =
-    Dhall.Decoder extract expected
-    where
-      textDecoder :: Dhall.Decoder Text
-      textDecoder = Dhall.autoWith opts
-
-      extract expression =
-        case Dhall.extract textDecoder expression of
-          Success x -> case URI.parseURI URI.strictURIParserOptions (toS x) of
-            Left exception -> Dhall.extractError (show exception)
-            Right path -> Success path
-          Failure e -> Failure e
-
-      expected = Dhall.expected textDecoder
-
-instance Dhall.ToDhall (URI.URIRef URI.Absolute) where
-  injectWith opts = Dhall.Encoder embed declared
-    where
-      textEncoder :: Dhall.Encoder Text
-      textEncoder = Dhall.injectWith opts
-
-      embed uri = Dhall.embed textEncoder $ toS (URI.serializeURIRef' uri)
-
-      declared = Dhall.Core.Text

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -12,16 +12,16 @@ where
 
 import qualified Cachix.Client.Config as Config
 import qualified Cachix.Client.InstallationMode as InstallationMode
+import Cachix.Client.URI (URI)
 import qualified Cachix.Client.URI as URI
 import qualified Cachix.Deploy.OptionsParser as DeployOptions
 import Options.Applicative
 import Protolude hiding (toS)
 import Protolude.Conv
-import qualified URI.ByteString as URI
 
 data Flags = Flags
   { configPath :: Config.ConfigPath,
-    hostname :: Maybe (URI.URIRef URI.Absolute),
+    hostname :: Maybe URI,
     verbose :: Bool
   }
 
@@ -61,11 +61,11 @@ flagParser defaultConfigPath = do
 
   pure Flags {hostname, configPath, verbose}
   where
-    defaultHostname = toS (URI.serializeURIRef' URI.defaultCachixURI)
+    defaultHostname = URI.serialize URI.defaultCachixURI
 
-uriOption :: ReadM (URI.URIRef URI.Absolute)
+uriOption :: ReadM URI
 uriOption = eitherReader $ \s ->
-  first show $ URI.parseURI URI.strictURIParserOptions $ toS s
+  first show $ URI.parseURI (toS s)
 
 type BinaryCacheName = Text
 

--- a/cachix/src/Cachix/Client/URI.hs
+++ b/cachix/src/Cachix/Client/URI.hs
@@ -1,48 +1,138 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Cachix.Client.URI
-  ( getBaseUrl,
+  ( URI,
+    fromURIRef,
+    getScheme,
+    getHostname,
+    appendSubdomain,
+    parseURI,
+    serialize,
+    getBaseUrl,
     defaultCachixURI,
     defaultCachixBaseUrl,
+    UBS.Host,
+    UBS.Scheme,
   )
 where
 
+import Control.Monad (fail)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import Data.Either.Validation (Validation (Failure, Success))
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromJust)
+import qualified Dhall
+import qualified Dhall.Core
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Client
-import URI.ByteString hiding (Scheme)
 import qualified URI.ByteString as UBS
-import URI.ByteString.QQ
+import qualified URI.ByteString.QQ as UBS
+
+-- Default URIs
+
+defaultCachixURI :: URI
+defaultCachixURI = fromURIRef [UBS.uri|https://cachix.org|]
+
+defaultCachixBaseUrl :: BaseUrl
+defaultCachixBaseUrl = getBaseUrl defaultCachixURI
+
+newtype URI = URI {getUri :: UBS.URIRef UBS.Absolute}
+  deriving newtype (Show)
+
+fromURIRef :: UBS.URIRef UBS.Absolute -> URI
+fromURIRef = URI
+
+getScheme :: URI -> UBS.Scheme
+getScheme = UBS.uriScheme . getUri
+
+getHostname :: URI -> UBS.Host
+getHostname = UBS.authorityHost . fromJust . UBS.uriAuthority . getUri
+
+-- TODO: lenses?
+appendSubdomain :: Text -> URI -> URI
+appendSubdomain domain uri =
+  let UBS.URI uScheme uAuthority uPath uQuery uFragment = getUri uri
+      UBS.Authority aUserInfo aHost aPort = fromJust uAuthority
+      newHost = UBS.Host $ toS domain <> show aHost
+   in URI $
+        UBS.URI
+          uScheme
+          (Just (UBS.Authority aUserInfo newHost aPort))
+          uPath
+          uQuery
+          uFragment
+
+getPortFor :: UBS.Scheme -> Maybe UBS.Port
+getPortFor scheme = Map.lookup scheme UBS.httpDefaultPorts
+
+parseURI :: ByteString -> Either UBS.URIParseError URI
+parseURI bs = fromURIRef <$> UBS.parseURI UBS.strictURIParserOptions bs
+
+serialize :: StringConv BS.ByteString s => URI -> s
+serialize = toS . UBS.normalizeURIRef' UBS.httpNormalization . getUri
+
+instance Aeson.ToJSON URI where
+  toJSON (URI uri) = Aeson.String . toS . UBS.serializeURIRef' $ uri
+
+instance Aeson.FromJSON URI where
+  parseJSON = Aeson.withText "URI" $ \text ->
+    either (fail . show) (return . URI) $
+      UBS.parseURI UBS.strictURIParserOptions (toS text)
+
+instance Dhall.FromDhall URI where
+  autoWith opts =
+    Dhall.Decoder extract expected
+    where
+      textDecoder :: Dhall.Decoder Text
+      textDecoder = Dhall.autoWith opts
+
+      extract expression =
+        case Dhall.extract textDecoder expression of
+          Success x -> case UBS.parseURI UBS.strictURIParserOptions (toS x) of
+            Left exception -> Dhall.extractError (show exception)
+            Right path -> Success (fromURIRef path)
+          Failure e -> Failure e
+
+      expected = Dhall.expected textDecoder
+
+instance Dhall.ToDhall URI where
+  injectWith opts = Dhall.Encoder embed declared
+    where
+      textEncoder :: Dhall.Encoder Text
+      textEncoder = Dhall.injectWith opts
+
+      embed (URI uri) = Dhall.embed textEncoder $ toS (UBS.serializeURIRef' uri)
+
+      declared = Dhall.Core.Text
 
 -- TODO: make getBaseUrl internal
 
 -- | Partial function from URI to BaseUrl
-getBaseUrl :: URIRef Absolute -> BaseUrl
-getBaseUrl uriref =
-  case uriAuthority uriref of
+getBaseUrl :: URI -> BaseUrl
+getBaseUrl (URI uriref) =
+  case UBS.uriAuthority uriref of
     Nothing -> panic "missing host in url"
     Just authority ->
       BaseUrl
-        getScheme
-        (toS (hostBS (authorityHost authority)))
-        getPort
-        (toS (uriPath uriref))
+        scheme
+        (toS (UBS.hostBS (UBS.authorityHost authority)))
+        port
+        (toS (UBS.uriPath uriref))
       where
-        getScheme :: Scheme
-        getScheme = case uriScheme uriref of
+        scheme :: Scheme
+        scheme = case UBS.uriScheme uriref of
           UBS.Scheme "http" -> Http
           UBS.Scheme "https" -> Https
           _ -> panic "uri can only be http/https"
-        getPort :: Int
-        getPort = maybe defaultPort portNumber $ authorityPort authority
+        port :: Int
+        port = maybe defaultPort UBS.portNumber $ UBS.authorityPort authority
         defaultPort :: Int
-        defaultPort = case getScheme of
+        defaultPort = case scheme of
           Http -> 80
           Https -> 443
-
-defaultCachixURI :: URIRef Absolute
-defaultCachixURI = [uri|https://cachix.org|]
-
-defaultCachixBaseUrl :: BaseUrl
-defaultCachixBaseUrl = getBaseUrl defaultCachixURI

--- a/cachix/src/Cachix/Client/URI.hs
+++ b/cachix/src/Cachix/Client/URI.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Cachix.Client.URI
@@ -47,7 +45,7 @@ defaultCachixBaseUrl :: BaseUrl
 defaultCachixBaseUrl = getBaseUrl defaultCachixURI
 
 newtype URI = URI {getUri :: UBS.URIRef UBS.Absolute}
-  deriving newtype (Show)
+  deriving stock (Eq, Show)
 
 fromURIRef :: UBS.URIRef UBS.Absolute -> URI
 fromURIRef = URI

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -6,6 +6,7 @@ module Cachix.Deploy.Activate where
 import qualified Cachix.API.WebSocketSubprotocol as WSS
 import qualified Cachix.Client.InstallationMode as InstallationMode
 import qualified Cachix.Client.NetRc as NetRc
+import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.Websocket as CachixWebsocket
 import qualified Cachix.Types.BinaryCache as BinaryCache
 import Cachix.Types.Permission (Permission (..))
@@ -63,13 +64,9 @@ activate logStream profileName deploymentDetails cacheArgs = do
 
     shellOutWithExitCode :: FilePath -> [String] -> IO ExitCode
     shellOutWithExitCode cmd args = do
-      log $ "$ " <> toS cmd <> " " <> toS (unwords $ fmap toS args)
+      Log.streamLine logStream $ "$ " <> toS cmd <> " " <> toS (unwords $ fmap toS args)
       (exitCode, _, _) <- Conduit.sourceProcessWithStreams (proc cmd args) Conduit.sinkNull logStream logStream
       pure exitCode
-
-    -- Move to Main.hs
-    log :: ByteString -> IO ()
-    log msg = Conduit.connect (Conduit.yieldMany ["\n" <> msg <> "\n"]) logStream
 
     -- TODO: home-manager
     -- TODO: move out of where clause

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -119,7 +119,7 @@ uri :: Text -> WSS.Cache -> Text
 uri host cache = "https://" <> domain host cache
 
 -- TODO: don't create tmpfile for public caches
-withCacheArgs :: Text -> WSS.AgentInformation -> ByteString -> ([String] -> IO a) -> IO a
+withCacheArgs :: Text -> WSS.AgentInformation -> Text -> ([String] -> IO a) -> IO a
 withCacheArgs host agentInfo agentToken m =
   withSystemTempDirectory "netrc" $ \dir -> do
     let filepath = dir </> "netrc"
@@ -135,7 +135,7 @@ withCacheArgs host agentInfo agentToken m =
                   BinaryCache.githubUsername = "",
                   BinaryCache.permission = Read
                 }
-        NetRc.add (Token agentToken) [bc] filepath
+        NetRc.add (Token (toS agentToken)) [bc] filepath
         return $ cachesArgs <> ["--option", "netrc-file", filepath]
       Nothing ->
         return cachesArgs

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -185,11 +185,11 @@ withCacheArgs host agentInfo agentToken m =
     cachesArgs cache =
       let cacheName = WSS.cacheName cache
           cacheURI = URI.appendSubdomain cacheName host
-          hostname = URI.getHostname cacheURI
+          hostname = (URI.hostBS . URI.getHostname) cacheURI
           officialCache = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           substituters = ["--option", "extra-substituters", URI.serialize cacheURI]
           noNegativeCaching = ["--option", "narinfo-cache-negative-ttl", "0"]
-          sigs = ["--option", "trusted-public-keys", officialCache <> " " <> show hostname <> "-1:" <> toS (WSS.publicKey cache)]
+          sigs = ["--option", "trusted-public-keys", officialCache <> " " <> toS hostname <> "-1:" <> toS (WSS.publicKey cache)]
        in substituters ++ sigs ++ noNegativeCaching
 
 runShell :: Log.LogStream -> FilePath -> [String] -> IO ()

--- a/cachix/src/Cachix/Deploy/ActivateCommand.hs
+++ b/cachix/src/Cachix/Deploy/ActivateCommand.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Cachix.Deploy.ActivateCommand where
 
 import qualified Cachix.API.Deploy as API

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -8,7 +8,7 @@ import Cachix.Client.URI (getBaseUrl)
 import Cachix.Client.Version (versionNumber)
 import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.OptionsParser as AgentOptions
-import Cachix.Deploy.StdinProcess (readProcess)
+import qualified Cachix.Deploy.StdinProcess as StdinProcess
 import qualified Cachix.Deploy.Websocket as WebSocket
 import Control.Exception.Safe (handleAny, onException)
 import qualified Data.Aeson as Aeson
@@ -107,7 +107,7 @@ run cachixOptions agentOpts =
             Nothing -> pure ()
             Just agentInformation -> do
               binDir <- toS <$> getBinDir
-              readProcess (binDir <> "/.cachix-deployment") [] $
+              StdinProcess.spawnProcess (binDir <> "/.cachix-deployment") [] $
                 toS . Aeson.encode $
                   Deployment
                     { agentName = agentName,

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -70,17 +70,14 @@ run cachixOptions agentOpts =
                 WebSocket.agentIdentifier = agentIdentifier agentName
               }
 
-      WebSocket.withConnection
-        withLog
-        websocketOptions
-        $ \websocket ->
-          WebSocket.handleJSONMessages @(WSS.Message WSS.AgentCommand) @(WSS.Message WSS.BackendCommand) websocket $
-            WebSocket.receive websocket >>= \channel ->
-              forever $
-                WebSocket.read channel >>= \case
-                  Just (WebSocket.DataMessage message) -> do
-                    handleMessage withLog agentState agentName agentToken message
-                  _ -> pure ()
+      WebSocket.withConnection withLog websocketOptions $ \websocket ->
+        WebSocket.handleJSONMessages @(WSS.Message WSS.AgentCommand) @(WSS.Message WSS.BackendCommand) websocket $
+          WebSocket.receive websocket >>= \channel ->
+            forever $
+              WebSocket.read channel >>= \case
+                Just (WebSocket.DataMessage message) -> do
+                  handleMessage withLog agentState agentName agentToken message
+                _ -> pure ()
   where
     host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
     profileName = fromMaybe "system" (AgentOptions.profile agentOpts)

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -42,8 +42,7 @@ run cachixOptions agentOpts =
         { CachixWebsocket.host = host,
           CachixWebsocket.name = name,
           CachixWebsocket.path = "/ws",
-          CachixWebsocket.profile = profile,
-          CachixWebsocket.isVerbose = Config.verbose cachixOptions
+          CachixWebsocket.profile = profile
         }
 
     handleMessage :: ByteString -> Log.WithLog -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> K.KatipContextT IO ()
@@ -66,7 +65,6 @@ run cachixOptions agentOpts =
                         { host = host,
                           name = name,
                           path = "/ws-deployment",
-                          profile = profile,
-                          isVerbose = Config.verbose cachixOptions
+                          profile = profile
                         }
                   }

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -5,6 +5,7 @@ module Cachix.Deploy.Agent where
 import qualified Cachix.API.WebSocketSubprotocol as WSS
 import qualified Cachix.Client.Config as Config
 import Cachix.Client.URI (getBaseUrl)
+import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.OptionsParser as AgentOptions
 import Cachix.Deploy.StdinProcess (readProcess)
 import qualified Cachix.Deploy.Websocket as CachixWebsocket
@@ -18,8 +19,21 @@ import qualified Servant.Client as Servant
 
 run :: Config.CachixOptions -> AgentOptions.AgentOptions -> IO ()
 run cachixOptions agentOpts =
-  CachixWebsocket.runForever options handleMessage
+  Log.withLog logOptions $ \logEnv -> do
+    CachixWebsocket.runForever logEnv options handleMessage
   where
+    verbosity =
+      if Config.verbose cachixOptions
+        then Log.Verbose
+        else Log.Normal
+
+    logOptions =
+      Log.Options
+        { verbosity = verbosity,
+          namespace = "agent",
+          environment = "production"
+        }
+
     host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
     name = AgentOptions.name agentOpts
     profile = fromMaybe "system" (AgentOptions.profile agentOpts)
@@ -31,8 +45,9 @@ run cachixOptions agentOpts =
           CachixWebsocket.profile = profile,
           CachixWebsocket.isVerbose = Config.verbose cachixOptions
         }
-    handleMessage :: ByteString -> (K.KatipContextT IO () -> IO ()) -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> K.KatipContextT IO ()
-    handleMessage payload _ _ agentState _ =
+
+    handleMessage :: ByteString -> Log.WithLog -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> K.KatipContextT IO ()
+    handleMessage payload _ _ agentState _ = do
       CachixWebsocket.parseMessage payload (handleCommand . WSS.command)
       where
         handleCommand :: WSS.BackendCommand -> K.KatipContextT IO ()
@@ -45,6 +60,7 @@ run cachixOptions agentOpts =
               toS . Aeson.encode $
                 CachixWebsocket.Input
                   { deploymentDetails = deploymentDetails,
+                    logOptions = logOptions,
                     websocketOptions =
                       CachixWebsocket.Options
                         { host = host,

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -70,7 +70,7 @@ run cachixOptions agentOpts =
                 WebSocket.path = "/ws",
                 WebSocket.useSSL = URI.requiresSSL (URI.getScheme host),
                 WebSocket.headers = WebSocket.createHeaders agentName agentToken,
-                WebSocket.agentIdentifier = agentIdentifier agentName
+                WebSocket.identifier = agentIdentifier agentName
               }
 
       WebSocket.withConnection withLog websocketOptions $ \websocket ->

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -19,8 +19,8 @@ import qualified Servant.Client as Servant
 
 run :: Config.CachixOptions -> AgentOptions.AgentOptions -> IO ()
 run cachixOptions agentOpts =
-  Log.withLog logOptions $ \logEnv -> do
-    CachixWebsocket.runForever logEnv options handleMessage
+  Log.withLog logOptions $ \withLog -> do
+    CachixWebsocket.runForever withLog options handleMessage
   where
     verbosity =
       if Config.verbose cachixOptions
@@ -57,7 +57,6 @@ run cachixOptions agentOpts =
         handleCommand :: WSS.BackendCommand -> IO ()
         handleCommand (WSS.AgentRegistered agentInformation) =
           withLog $ CachixWebsocket.registerAgent agentState agentInformation
-
         handleCommand (WSS.Deployment deploymentDetails) = do
           binDir <- toS <$> getBinDir
           readProcess (binDir <> "/.cachix-deployment") [] $

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -73,11 +73,8 @@ run cachixOptions agentOpts =
       WebSocket.withConnection withLog websocketOptions $ \websocket ->
         WebSocket.handleJSONMessages @(WSS.Message WSS.AgentCommand) @(WSS.Message WSS.BackendCommand) websocket $
           WebSocket.receive websocket >>= \channel ->
-            forever $
-              WebSocket.read channel >>= \case
-                Just (WebSocket.DataMessage message) -> do
-                  handleMessage withLog agentState agentName agentToken message
-                _ -> pure ()
+            WebSocket.readDataMessages channel $ \message ->
+              handleMessage withLog agentState agentName agentToken message
   where
     host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
     profileName = fromMaybe "system" (AgentOptions.profile agentOpts)

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -67,7 +67,7 @@ run cachixOptions agentOpts =
 
       WebSocket.withConnection withLog websocketOptions $ \connection ->
         WSS.receiveDataConcurrently connection $ \message ->
-          handleMessage withLog agentState agentName agentToken connection message
+          handleMessage withLog agentState agentName agentToken message
   where
     host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
     profileName = fromMaybe "system" (AgentOptions.profile agentOpts)
@@ -88,8 +88,8 @@ run cachixOptions agentOpts =
           environment = "production"
         }
 
-    handleMessage :: Log.WithLog -> AgentState -> Text -> Text -> WS.Connection -> ByteString -> IO ()
-    handleMessage withLog agentState agentName agentToken _ payload =
+    handleMessage :: Log.WithLog -> AgentState -> Text -> Text -> ByteString -> IO ()
+    handleMessage withLog agentState agentName agentToken payload =
       case WSS.parseMessage payload of
         Left err ->
           -- TODO: show the bytestring?

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -20,7 +20,7 @@ import qualified Servant.Client as Servant
 run :: Config.CachixOptions -> AgentOptions.AgentOptions -> IO ()
 run cachixOptions agentOpts =
   Log.withLog logOptions $ \withLog -> do
-    CachixWebsocket.runForever withLog options handleMessage
+    CachixWebsocket.runForever withLog options (handleMessage withLog)
   where
     verbosity =
       if Config.verbose cachixOptions
@@ -45,8 +45,8 @@ run cachixOptions agentOpts =
           CachixWebsocket.profile = profile
         }
 
-    handleMessage :: ByteString -> Log.WithLog -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> IO ()
-    handleMessage payload withLog _ agentState _ =
+    handleMessage :: Log.WithLog -> WS.Connection -> ByteString -> CachixWebsocket.AgentState -> ByteString -> IO ()
+    handleMessage withLog _ payload agentState _ =
       case WSS.parseMessage payload of
         Left err ->
           -- TODO: show the bytestring?

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -65,7 +65,9 @@ run cachixOptions agentOpts =
                 WebSocket.agentIdentifier = agentIdentifier agentName
               }
 
-      WebSocket.runForever withLog websocketOptions (handleMessage withLog agentState agentName agentToken)
+      WebSocket.withConnection withLog websocketOptions $ \connection ->
+        WSS.recieveDataConcurrently connection $ \message ->
+          handleMessage withLog agentState agentName agentToken connection message
   where
     host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
     profileName = fromMaybe "system" (AgentOptions.profile agentOpts)

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -66,7 +66,7 @@ run cachixOptions agentOpts =
               }
 
       WebSocket.withConnection withLog websocketOptions $ \connection ->
-        WSS.recieveDataConcurrently connection $ \message ->
+        WSS.receiveDataConcurrently connection $ \message ->
           handleMessage withLog agentState agentName agentToken connection message
   where
     host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -5,31 +5,74 @@ module Cachix.Deploy.Agent where
 import qualified Cachix.API.WebSocketSubprotocol as WSS
 import qualified Cachix.Client.Config as Config
 import Cachix.Client.URI (getBaseUrl)
+import Cachix.Client.Version (versionNumber)
 import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.OptionsParser as AgentOptions
 import Cachix.Deploy.StdinProcess (readProcess)
 import qualified Cachix.Deploy.Websocket as WebSocket
+import Control.Exception.Safe (handleAny, onException)
 import qualified Data.Aeson as Aeson
+import Data.IORef
+import Data.String (String)
 import qualified Katip as K
 import qualified Network.WebSockets as WS
 import Paths_cachix (getBinDir)
-import Protolude hiding (toS)
+import Protolude hiding (onException, toS)
 import Protolude.Conv
 import qualified Servant.Client as Servant
+import qualified System.Directory as Directory
+import System.Environment (getEnv, lookupEnv)
+import qualified System.Posix.Files as Posix.Files
+import qualified System.Posix.User as Posix.User
+
+type AgentState = IORef (Maybe WSS.AgentInformation)
 
 data Deployment = Deployment
-  { profileName :: Text,
+  { agentName :: Text,
+    agentToken :: Text,
+    profileName :: Text,
+    host :: Text,
     deploymentDetails :: WSS.DeploymentDetails,
-    logOptions :: Log.Options,
-    websocketOptions :: WebSocket.Options
+    logOptions :: Log.Options
   }
   deriving (Show, Generic, Aeson.ToJSON, Aeson.FromJSON)
 
+registerAgent :: AgentState -> WSS.AgentInformation -> K.KatipContextT IO ()
+registerAgent agentState agentInformation = do
+  K.logLocM K.InfoS "Agent registered."
+  liftIO $ atomicWriteIORef agentState (Just agentInformation)
+
+agentIdentifier :: Text -> Text
+agentIdentifier agentName = agentName <> " " <> toS versionNumber
+
 run :: Config.CachixOptions -> AgentOptions.AgentOptions -> IO ()
 run cachixOptions agentOpts =
-  Log.withLog logOptions $ \withLog -> do
-    WebSocket.runForever withLog options (handleMessage withLog)
+  Log.withLog logOptions $ \withLog ->
+    handleAny (logAndExit withLog) $ do
+      checkUserOwnsHome
+
+      -- TODO: error if token is missing
+      agentToken <- toS <$> getEnv "CACHIX_AGENT_TOKEN"
+      agentState <- newIORef Nothing
+
+      let agentName = AgentOptions.name agentOpts
+      let websocketOptions =
+            WebSocket.Options
+              { WebSocket.host = host,
+                WebSocket.path = "/ws",
+                WebSocket.headers = WebSocket.createHeaders agentName agentToken,
+                WebSocket.agentIdentifier = agentIdentifier agentName
+              }
+
+      WebSocket.runForever withLog websocketOptions (handleMessage withLog agentState agentName agentToken)
   where
+    host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
+    profileName = fromMaybe "system" (AgentOptions.profile agentOpts)
+
+    logAndExit withLog e = do
+      void $ withLog $ K.logLocM K.ErrorS $ K.ls (displayException e)
+      exitFailure
+
     verbosity =
       if Config.verbose cachixOptions
         then Log.Verbose
@@ -42,18 +85,8 @@ run cachixOptions agentOpts =
           environment = "production"
         }
 
-    host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
-    name = AgentOptions.name agentOpts
-    profileName = fromMaybe "system" (AgentOptions.profile agentOpts)
-    options =
-      WebSocket.Options
-        { WebSocket.host = host,
-          WebSocket.name = name,
-          WebSocket.path = "/ws"
-        }
-
-    handleMessage :: Log.WithLog -> WS.Connection -> ByteString -> WebSocket.AgentState -> ByteString -> IO ()
-    handleMessage withLog _ payload agentState _ =
+    handleMessage :: Log.WithLog -> AgentState -> Text -> Text -> WS.Connection -> ByteString -> IO ()
+    handleMessage withLog agentState agentName agentToken _ payload =
       case WSS.parseMessage payload of
         Left err ->
           -- TODO: show the bytestring?
@@ -63,19 +96,56 @@ run cachixOptions agentOpts =
       where
         handleCommand :: WSS.BackendCommand -> IO ()
         handleCommand (WSS.AgentRegistered agentInformation) =
-          withLog $ WebSocket.registerAgent agentState agentInformation
+          withLog $ registerAgent agentState agentInformation
         handleCommand (WSS.Deployment deploymentDetails) = do
           binDir <- toS <$> getBinDir
           readProcess (binDir <> "/.cachix-deployment") [] $
             toS . Aeson.encode $
               Deployment
-                { profileName = profileName,
+                { agentName = agentName,
+                  agentToken = agentToken,
+                  profileName = profileName,
+                  host = host,
                   deploymentDetails = deploymentDetails,
-                  logOptions = logOptions,
-                  websocketOptions =
-                    WebSocket.Options
-                      { host = host,
-                        name = name,
-                        path = "/ws-deployment"
-                      }
+                  logOptions = logOptions
                 }
+
+-- | Fetch the home directory and verify that the owner matches the current user.
+-- Throws either 'NoHomeFound' or 'UserDoesNotOwnHome'.
+checkUserOwnsHome :: IO ()
+checkUserOwnsHome = do
+  home <- Directory.getHomeDirectory `onException` throwIO NoHomeFound
+  stat <- Posix.Files.getFileStatus home
+  userId <- Posix.User.getEffectiveUserID
+
+  when (userId /= Posix.Files.fileOwner stat) $ do
+    userName <- Posix.User.userName <$> Posix.User.getUserEntryForID userId
+    sudoUser <- lookupEnv "SUDO_USER"
+    throwIO $
+      UserDoesNotOwnHome
+        { userName = userName,
+          sudoUser = sudoUser,
+          home = home
+        }
+
+data Error
+  = -- | No home directory.
+    NoHomeFound
+  | -- | Safeguard against creating root-owned files in user directories.
+    -- This is an issue on macOS, where, by default, sudo does not reset $HOME.
+    UserDoesNotOwnHome
+      { userName :: String,
+        sudoUser :: Maybe String,
+        home :: FilePath
+      }
+  deriving (Show)
+
+instance Exception Error where
+  displayException NoHomeFound = "Could not find the user’s home directory. Make sure to set the $HOME variable."
+  displayException UserDoesNotOwnHome {userName = userName, sudoUser = sudoUser, home = home} =
+    if isJust sudoUser
+      then toS $ unlines [warningMessage, suggestSudoFlagH]
+      else toS warningMessage
+    where
+      warningMessage = "The current user (" <> toS userName <> ") does not own the home directory (" <> toS home <> ")"
+      suggestSudoFlagH = "Try running the agent with `sudo -H`."

--- a/cachix/src/Cachix/Deploy/Log.hs
+++ b/cachix/src/Cachix/Deploy/Log.hs
@@ -3,10 +3,10 @@
 
 module Cachix.Deploy.Log where
 
+import Control.Exception.Safe (MonadMask, bracket)
 import qualified Data.Aeson as Aeson
 import qualified Katip
 import Protolude hiding (bracket)
-import UnliftIO (MonadUnliftIO, bracket)
 
 -- A temporary crutch while we fix up the types
 type WithLog = Katip.KatipContextT IO () -> IO ()
@@ -29,7 +29,7 @@ data Verbosity
   deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)
 
 withLog ::
-  MonadUnliftIO m =>
+  (MonadIO m, MonadMask m) =>
   Options ->
   (Katip.LogEnv -> m a) ->
   m a

--- a/cachix/src/Cachix/Deploy/Log.hs
+++ b/cachix/src/Cachix/Deploy/Log.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Cachix.Deploy.Log where
+
+import qualified Data.Aeson as Aeson
+import qualified Katip
+import Protolude hiding (bracket)
+import UnliftIO (MonadUnliftIO, bracket)
+
+-- A temporary crutch while we fix up the types
+type WithLog = Katip.KatipContextT IO () -> IO ()
+
+data Options = Options
+  { -- | The minimum verbosity level
+    verbosity :: Verbosity,
+    -- | The logging namespace, e.g. agent
+    namespace :: Katip.Namespace,
+    -- | The logging environment, e.g. production
+    environment :: Katip.Environment
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)
+
+data Verbosity
+  = Normal
+  | Verbose
+  deriving stock (Show, Generic)
+  deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)
+
+withLog ::
+  MonadUnliftIO m =>
+  Options ->
+  (Katip.LogEnv -> m a) ->
+  m a
+withLog Options {..} =
+  let permit = case verbosity of
+        Verbose -> Katip.DebugS
+        Normal -> Katip.InfoS
+
+      createLogEnv = liftIO $ do
+        logEnv <- Katip.initLogEnv namespace environment
+        stdoutScribe <- Katip.mkHandleScribe Katip.ColorIfTerminal stdout (Katip.permitItem permit) Katip.V2
+        Katip.registerScribe "stdout" stdoutScribe Katip.defaultScribeSettings logEnv
+
+      closeLog = liftIO . Katip.closeScribes
+   in bracket createLogEnv closeLog

--- a/cachix/src/Cachix/Deploy/StdinProcess.hs
+++ b/cachix/src/Cachix/Deploy/StdinProcess.hs
@@ -3,12 +3,12 @@ module Cachix.Deploy.StdinProcess where
 import Protolude hiding (stdin)
 import System.IO (hClose)
 import System.Process
-import Prelude (String, userError)
+import Prelude (String)
 
--- | Run a process with only stdin as an input
-readProcess :: FilePath -> [String] -> String -> IO ()
-readProcess cmd args input = do
-  (Just stdin, _, _, ph) <-
+-- | Spawn a process with only stdin as an input
+spawnProcess :: FilePath -> [String] -> String -> IO ()
+spawnProcess cmd args input = do
+  (Just stdin, _, _, _) <-
     createProcess
       (proc cmd args)
         { std_in = CreatePipe,
@@ -19,7 +19,3 @@ readProcess cmd args input = do
         }
   hPutStr stdin input
   hClose stdin
-  exitcode <- waitForProcess ph
-  case exitcode of
-    ExitSuccess -> return ()
-    ExitFailure code -> ioError $ userError $ "Process " <> show cmd <> " failed with exit code " <> show code

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -30,7 +30,6 @@ data Options = Options
   { host :: Text,
     path :: Text,
     name :: Text,
-    isVerbose :: Bool,
     profile :: Text
   }
   deriving (Show, Generic, ToJSON, FromJSON)

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -102,7 +102,11 @@ reconnectWithLog withLog inner =
 
     delay :: Maybe Int -> String
     delay Nothing = "0 seconds"
-    delay (Just s) = show (floor (fromIntegral s / 1000 / 1000)) <> " seconds"
+    delay (Just t) = show (toSeconds t) <> " seconds"
+
+    toSeconds :: Int -> Int
+    toSeconds t =
+      floor $ (fromIntegral t :: Double) / 1000 / 1000
 
 -- | Try to gracefully close the WebSocket.
 --

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -45,11 +45,8 @@ data Input = Input
 system :: String
 system = System.Info.arch <> "-" <> System.Info.os
 
-runForever :: K.LogEnv -> Options -> (ByteString -> Log.WithLog -> WS.Connection -> AgentState -> ByteString -> IO ()) -> IO ()
-runForever logEnv options cmd = do
-  -- TODO: do we need the context part, or is KatipT enough for us?
-  let withLog = K.runKatipContextT logEnv () "agent"
-
+runForever :: Log.WithLog -> Options -> (ByteString -> Log.WithLog -> WS.Connection -> AgentState -> ByteString -> IO ()) -> IO ()
+runForever withLog options cmd = do
   checkUserOwnsHome `catchAny` \e -> do
     withLog $ K.logLocM K.ErrorS $ K.ls (displayException e)
     exitFailure

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -1,38 +1,32 @@
 -- high level interface for websocket clients
 module Cachix.Deploy.Websocket where
 
-import Cachix.API.WebSocketSubprotocol (AgentInformation)
 import qualified Cachix.API.WebSocketSubprotocol as WSS
 import Cachix.Client.Retry
 import Cachix.Client.Version (versionNumber)
 import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.WebsocketPong as WebsocketPong
-import Control.Exception.Safe (catchAny, onException)
 import Control.Retry (RetryStatus (..))
 import qualified Control.Retry as Retry
-import Data.Aeson (FromJSON, ToJSON)
-import Data.IORef
+import qualified Data.Aeson as Aeson
 import Data.String (String)
 import qualified Katip as K
 import Network.HTTP.Types (Header)
 import qualified Network.WebSockets as WS
-import Protolude hiding (catch, onException, toS)
+import Protolude hiding (toS)
 import Protolude.Conv
-import qualified System.Directory as Directory
-import System.Environment (getEnv, lookupEnv)
 import qualified System.Info
-import qualified System.Posix.Files as Posix.Files
-import qualified System.Posix.User as Posix.User
 import qualified Wuss
-
-type AgentState = IORef (Maybe WSS.AgentInformation)
 
 data Options = Options
   { host :: Text,
     path :: Text,
-    name :: Text
+    headers :: [Header],
+    -- | The identifier used when logging. Usually a combination of the agent
+    -- name and the CLI version.
+    agentIdentifier :: Text
   }
-  deriving (Show, Generic, ToJSON, FromJSON)
+  deriving (Show)
 
 system :: String
 system = System.Info.arch <> "-" <> System.Info.os
@@ -42,53 +36,48 @@ runForever ::
   Log.WithLog ->
   -- | WebSocket options
   Options ->
-  (WS.Connection -> ByteString -> AgentState -> ByteString -> IO ()) ->
+  -- | The app to run inside the socket
+  (WS.Connection -> ByteString -> IO ()) ->
   IO ()
 runForever withLog options inner = do
-  checkUserOwnsHome `catchAny` \e -> do
-    withLog $ K.logLocM K.ErrorS $ K.ls (displayException e)
-    exitFailure
-
-  -- TODO: error if token is missing
-  agentToken <- getEnv "CACHIX_AGENT_TOKEN"
-  agentState <- newIORef Nothing
-
-  pongState <- WebsocketPong.newState
   mainThreadID <- myThreadId
+  pongState <- WebsocketPong.newState
 
+  let pingEvery = 30
+  let pongTimeout = pingEvery * 2
   let pingHandler = do
         last <- WebsocketPong.secondsSinceLastPong pongState
         withLog $ K.logLocM K.DebugS $ K.ls $ "Sending WebSocket keep-alive ping, last pong was " <> (show last :: Text) <> " seconds ago"
         WebsocketPong.pingHandler pongState mainThreadID pongTimeout
-      connectionOptions = WebsocketPong.installPongHandler pongState WS.defaultConnectionOptions
+  let connectionOptions = WebsocketPong.installPongHandler pongState WS.defaultConnectionOptions
 
   -- TODO: use exponential retry with reset: https://github.com/Soostone/retry/issues/25
   -- retryWithLogging endlessConstantRetryPolicy (logRetry withLog) $ do
-  withLog $ K.logLocM K.InfoS $ K.ls ("Agent " <> agentIdentifier <> " connecting to " <> toS (host options) <> toS (path options))
+  withLog $
+    K.logLocM K.InfoS $ K.ls $ "Agent " <> agentIdentifier options <> " connecting to " <> host options <> path options
 
   -- refresh pong state in case we're reconnecting
   WebsocketPong.pongHandler pongState
 
   -- TODO: https://github.com/jaspervdj/websockets/issues/229
-  Wuss.runSecureClientWith (toS $ host options) 443 (toS $ path options) connectionOptions (headers options (toS agentToken)) $ \connection -> do
+  Wuss.runSecureClientWith (toS $ host options) 443 (toS $ path options) connectionOptions (headers options) $ \connection -> do
     withLog $ K.logLocM K.InfoS "Connected to Cachix Deploy service"
     WS.withPingThread connection pingEvery pingHandler $
-      WSS.recieveDataConcurrently
-        connection
-        (\message -> inner connection message agentState (toS agentToken))
-  where
-    agentIdentifier = name options <> " " <> toS versionNumber
-    pingEvery = 30
-    pongTimeout = pingEvery * 2
+      WSS.recieveDataConcurrently connection (inner connection)
 
 exitWithCloseRequest :: WS.ConnectionException -> IO ()
 exitWithCloseRequest (WS.CloseRequest _ _) = return ()
 exitWithCloseRequest e = throwIO e
 
-headers :: Options -> ByteString -> [Header]
-headers options agentToken =
+createHeaders ::
+  -- | Agent name
+  Text ->
+  -- | Agent Token
+  Text ->
+  [Header]
+createHeaders agentName agentToken =
   [ ("Authorization", "Bearer " <> toS agentToken),
-    ("name", toS (name options)),
+    ("name", toS agentName),
     ("version", toS versionNumber),
     ("system", toS system)
   ]
@@ -104,7 +93,7 @@ logRetry withLog _ exception retryStatus =
 
 -- TODO: Move to the agent. If the websocket is going to parse messages then it
 -- can’t also swallow errors like this.
-parseMessage :: K.KatipContext m => FromJSON cmd => ByteString -> (WSS.Message cmd -> m ()) -> m ()
+parseMessage :: K.KatipContext m => Aeson.FromJSON cmd => ByteString -> (WSS.Message cmd -> m ()) -> m ()
 parseMessage payload m = do
   case WSS.parseMessage payload of
     Left err ->
@@ -112,50 +101,3 @@ parseMessage payload m = do
       K.logLocM K.ErrorS $ K.ls $ "Failed to parse websocket payload: " <> err
     Right message ->
       m message
-
--- commands
-
-registerAgent :: AgentState -> AgentInformation -> K.KatipContextT IO ()
-registerAgent agentState agentInformation = do
-  K.logLocM K.InfoS "Agent registered."
-  liftIO $ atomicWriteIORef agentState (Just agentInformation)
-
--- | Fetch the home directory and verify that the owner matches the current user.
--- Throws either 'NoHomeFound' or 'UserDoesNotOwnHome'.
-checkUserOwnsHome :: IO ()
-checkUserOwnsHome = do
-  home <- Directory.getHomeDirectory `onException` throwIO NoHomeFound
-  stat <- Posix.Files.getFileStatus home
-  userId <- Posix.User.getEffectiveUserID
-
-  when (userId /= Posix.Files.fileOwner stat) $ do
-    userName <- Posix.User.userName <$> Posix.User.getUserEntryForID userId
-    sudoUser <- lookupEnv "SUDO_USER"
-    throwIO $
-      UserDoesNotOwnHome
-        { userName = userName,
-          sudoUser = sudoUser,
-          home = home
-        }
-
-data Error
-  = -- | No home directory.
-    NoHomeFound
-  | -- | Safeguard against creating root-owned files in user directories.
-    -- This is an issue on macOS, where, by default, sudo does not reset $HOME.
-    UserDoesNotOwnHome
-      { userName :: String,
-        sudoUser :: Maybe String,
-        home :: FilePath
-      }
-  deriving (Show)
-
-instance Exception Error where
-  displayException NoHomeFound = "Could not find the user’s home directory. Make sure to set the $HOME variable."
-  displayException UserDoesNotOwnHome {userName = userName, sudoUser = sudoUser, home = home} =
-    if isJust sudoUser
-      then toS $ unlines [warningMessage, suggestSudoFlagH]
-      else toS warningMessage
-    where
-      warningMessage = "The current user (" <> toS userName <> ") does not own the home directory (" <> toS home <> ")"
-      suggestSudoFlagH = "Try running the agent with `sudo -H`."

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -30,15 +30,7 @@ type AgentState = IORef (Maybe WSS.AgentInformation)
 data Options = Options
   { host :: Text,
     path :: Text,
-    name :: Text,
-    profile :: Text
-  }
-  deriving (Show, Generic, ToJSON, FromJSON)
-
-data Input = Input
-  { deploymentDetails :: WSS.DeploymentDetails,
-    logOptions :: Log.Options,
-    websocketOptions :: Options
+    name :: Text
   }
   deriving (Show, Generic, ToJSON, FromJSON)
 

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -1,19 +1,21 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- high level interface for websocket clients
 module Cachix.Deploy.Websocket where
 
 import qualified Cachix.API.WebSocketSubprotocol as WSS
-import Cachix.Client.Retry
+import qualified Cachix.Client.Retry as Retry
 import Cachix.Client.Version (versionNumber)
 import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.WebsocketPong as WebsocketPong
-import Control.Retry (RetryStatus (..))
+import Control.Exception.Safe (Handler (..), MonadMask, isSyncException)
 import qualified Control.Retry as Retry
 import qualified Data.Aeson as Aeson
 import Data.String (String)
 import qualified Katip as K
 import Network.HTTP.Types (Header)
 import qualified Network.WebSockets as WS
-import Protolude hiding (toS)
+import Protolude hiding (Handler, toS)
 import Protolude.Conv
 import qualified System.Info
 import qualified Wuss
@@ -51,23 +53,48 @@ runForever withLog options inner = do
         WebsocketPong.pingHandler pongState mainThreadID pongTimeout
   let connectionOptions = WebsocketPong.installPongHandler pongState WS.defaultConnectionOptions
 
-  -- TODO: use exponential retry with reset: https://github.com/Soostone/retry/issues/25
-  -- retryWithLogging endlessConstantRetryPolicy (logRetry withLog) $ do
-  withLog $
-    K.logLocM K.InfoS $ K.ls $ "Agent " <> agentIdentifier options <> " connecting to " <> host options <> path options
+  reconnectWithLog withLog $ do
+    withLog $
+      K.logLocM K.InfoS $ K.ls $ "Agent " <> agentIdentifier options <> " connecting to " <> host options <> path options
 
-  -- refresh pong state in case we're reconnecting
-  WebsocketPong.pongHandler pongState
+    -- refresh pong state in case we're reconnecting
+    WebsocketPong.pongHandler pongState
 
-  -- TODO: https://github.com/jaspervdj/websockets/issues/229
-  Wuss.runSecureClientWith (toS $ host options) 443 (toS $ path options) connectionOptions (headers options) $ \connection -> do
-    withLog $ K.logLocM K.InfoS "Connected to Cachix Deploy service"
-    WS.withPingThread connection pingEvery pingHandler $
-      WSS.recieveDataConcurrently connection (inner connection)
+    -- TODO: https://github.com/jaspervdj/websockets/issues/229
+    Wuss.runSecureClientWith (toS $ host options) 443 (toS $ path options) connectionOptions (headers options) $ \connection -> do
+      withLog $ K.logLocM K.InfoS "Connected to Cachix Deploy service"
+      WS.withPingThread connection pingEvery pingHandler $
+        WSS.recieveDataConcurrently connection (inner connection)
 
-exitWithCloseRequest :: WS.ConnectionException -> IO ()
-exitWithCloseRequest (WS.CloseRequest _ _) = return ()
-exitWithCloseRequest e = throwIO e
+-- TODO: use exponential retry with reset: https://github.com/Soostone/retry/issues/25
+reconnectWithLog :: (MonadMask m, MonadIO m) => Log.WithLog -> m a -> m a
+reconnectWithLog withLog inner =
+  Retry.recovering Retry.endlessConstantRetryPolicy handlers $ const inner
+  where
+    handlers = Retry.skipAsyncExceptions ++ [exitOnSuccess, exitOnCloseRequest, logSyncExceptions]
+
+    exitOnSuccess _ = Handler $ \(_ :: ExitCode) -> return False
+
+    exitOnCloseRequest _ = Handler $ \(e :: WS.ConnectionException) ->
+      case e of
+        WS.CloseRequest _ _ -> do
+          liftIO . withLog $
+            K.logLocM K.DebugS . K.ls $
+              ("Received close request from peer. Closing connection." :: Text)
+          return False
+        _ -> return True
+
+    logSyncExceptions = Retry.logRetries (return . isSyncException) logRetries
+
+    logRetries :: (MonadIO m) => Bool -> SomeException -> Retry.RetryStatus -> m ()
+    logRetries _ exception retryStatus =
+      liftIO . withLog $
+        K.logLocM K.ErrorS . K.ls $
+          "Retrying in " <> delay (Retry.rsPreviousDelay retryStatus) <> " due to an exception: " <> displayException exception
+
+    delay :: Maybe Int -> String
+    delay Nothing = "0 seconds"
+    delay (Just s) = show (floor (fromIntegral s / 1000 / 1000)) <> " seconds"
 
 createHeaders ::
   -- | Agent name
@@ -81,15 +108,6 @@ createHeaders agentName agentToken =
     ("version", toS versionNumber),
     ("system", toS system)
   ]
-
--- TODO: log the exception
-logRetry :: Log.WithLog -> Bool -> SomeException -> RetryStatus -> IO ()
-logRetry withLog _ exception retryStatus =
-  withLog $ K.logLocM K.ErrorS $ K.ls $ "Retrying in " <> delay (rsPreviousDelay retryStatus) <> " due to an exception: " <> displayException exception
-  where
-    delay :: Maybe Int -> String
-    delay Nothing = "0 seconds"
-    delay (Just s) = show (floor (fromIntegral s / 1000 / 1000)) <> " seconds"
 
 -- TODO: Move to the agent. If the websocket is going to parse messages then it
 -- can’t also swallow errors like this.

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -68,6 +68,7 @@ withConnection withLog options app = do
       WS.withPingThread connection pingEvery pingHandler $
         app connection
 
+-- Log all exceptions and retry, except when the websocket receives a close request.
 -- TODO: use exponential retry with reset: https://github.com/Soostone/retry/issues/25
 reconnectWithLog :: (MonadMask m, MonadIO m) => Log.WithLog -> m () -> m ()
 reconnectWithLog withLog inner =

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -1,16 +1,22 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
--- high level interface for websocket clients
+-- | A high-level, multiple reader, single writer interface for Websocket clients.
 module Cachix.Deploy.Websocket where
 
 import qualified Cachix.Client.Retry as Retry
 import Cachix.Client.Version (versionNumber)
 import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.WebsocketPong as WebsocketPong
+import qualified Control.Concurrent.Async as Async
+import qualified Control.Concurrent.MVar as MVar
+import qualified Control.Concurrent.STM.TBMQueue as TBMQueue
+import qualified Control.Concurrent.STM.TMChan as TMChan
 import Control.Exception.Safe (Handler (..), MonadMask, isSyncException)
 import qualified Control.Exception.Safe as Safe
 import qualified Control.Retry as Retry
+import qualified Data.ByteString as BS
 import Data.String (String)
+import qualified Data.Time.Clock as Time
 import qualified Katip as K
 import qualified Network.HTTP.Simple as HTTP
 import qualified Network.WebSockets as WS
@@ -19,6 +25,48 @@ import Protolude.Conv
 import qualified System.Info
 import qualified System.Timeout as Timeout
 import qualified Wuss
+
+-- | A reliable WebSocket connection that can be run ergonomically in a
+-- separate thread.
+--
+-- Maintains the connection by periodically sending pings.
+data WebSocket tx rx = WebSocket
+  { -- | The active WebSocket connection, if available
+    connection :: MVar.MVar WS.Connection,
+    -- | A timestamp of the last pong message received
+    lastPong :: WebsocketPong.LastPongState,
+    -- | See 'Transmit'
+    tx :: Transmit tx,
+    -- | See 'Receive'
+    rx :: Receive rx
+  }
+
+-- | A more ergonomic version of the Websocket 'Message' data type
+data Message msg
+  = ControlMessage WS.ControlMessage
+  | DataMessage msg
+
+-- | A bounded queue of outbound messages.
+type Transmit msg = TBMQueue.TBMQueue (Message msg)
+
+-- | A broadcast channel for incoming messages.
+type Receive msg = TMChan.TMChan (Message msg)
+
+-- | Send messages over the socket.
+send :: WebSocket tx rx -> Message tx -> IO ()
+send WebSocket {tx} = atomically . TBMQueue.writeTBMQueue tx
+
+-- | Open a new receiving channel.
+receive :: WebSocket tx rx -> IO (Receive rx)
+receive WebSocket {rx} = atomically $ TMChan.dupTMChan rx
+
+-- | Read incoming messages on a channel opened with 'receive'.
+read :: Receive rx -> IO (Maybe (Message rx))
+read = atomically . TMChan.readTMChan
+
+-- | Close the outgoing queue.
+close :: WebSocket tx rx -> IO ()
+close WebSocket {tx} = atomically $ TBMQueue.closeTBMQueue tx
 
 data Options = Options
   { host :: Text,
@@ -30,44 +78,52 @@ data Options = Options
   }
   deriving (Show)
 
-system :: String
-system = System.Info.arch <> "-" <> System.Info.os
-
 withConnection ::
   -- | Logging context for logging socket status
   Log.WithLog ->
   -- | WebSocket options
   Options ->
   -- | The app to run inside the socket
-  WS.ClientApp () ->
+  (WebSocket tx rx -> IO ()) ->
   IO ()
 withConnection withLog options app = do
   mainThreadID <- myThreadId
-  pongState <- WebsocketPong.newState
+  lastPong <- WebsocketPong.newState
 
   let pingEvery = 30
   let pongTimeout = pingEvery * 2
   let pingHandler = do
-        last <- WebsocketPong.secondsSinceLastPong pongState
+        last <- WebsocketPong.secondsSinceLastPong lastPong
         withLog $ K.logLocM K.DebugS $ K.ls $ "Sending WebSocket keep-alive ping, last pong was " <> (show last :: Text) <> " seconds ago"
-        WebsocketPong.pingHandler pongState mainThreadID pongTimeout
-  let connectionOptions = WebsocketPong.installPongHandler pongState WS.defaultConnectionOptions
+        WebsocketPong.pingHandler lastPong mainThreadID pongTimeout
+  let connectionOptions = WebsocketPong.installPongHandler lastPong WS.defaultConnectionOptions
 
-  reconnectWithLog withLog $ do
-    withLog $
-      K.logLocM K.InfoS $ K.ls $ "Agent " <> agentIdentifier options <> " connecting to " <> host options <> path options
+  connection <- MVar.newEmptyMVar
+  tx <- TBMQueue.newTBMQueueIO 100
+  rx <- TMChan.newBroadcastTMChanIO
+  let websocket = WebSocket {connection, tx, rx, lastPong}
 
-    -- refresh pong state in case we're reconnecting
-    WebsocketPong.pongHandler pongState
+  reconnectWithLog withLog $
+    do
+      withLog $
+        K.logLocM K.InfoS $ K.ls $ "Agent " <> agentIdentifier options <> " connecting to " <> host options <> path options
 
-    -- TODO: https://github.com/jaspervdj/websockets/issues/229
-    Wuss.runSecureClientWith (toS $ host options) 443 (toS $ path options) connectionOptions (headers options) $
-      \connection ->
-        do
-          withLog $ K.logLocM K.InfoS "Connected to Cachix Deploy service"
-          WS.withPingThread connection pingEvery pingHandler $
-            app connection
-          `finally` waitForGracefulShutdown connection
+      -- TODO: https://github.com/jaspervdj/websockets/issues/229
+      Wuss.runSecureClientWith (toS $ host options) 443 (toS $ path options) connectionOptions (headers options) $
+        \newConnection ->
+          do
+            withLog $ K.logLocM K.InfoS "Connected to Cachix Deploy service"
+
+            -- Reset the pong state in case we're reconnecting
+            WebsocketPong.pongHandler lastPong
+
+            -- Update the connection
+            MVar.putMVar connection newConnection
+
+            WS.withPingThread newConnection pingEvery pingHandler $
+              app websocket
+            `finally` waitForGracefulShutdown newConnection
+      `Safe.finally` void (MVar.tryTakeMVar connection)
 
 -- Log all exceptions and retry, except when the websocket receives a close request.
 -- TODO: use exponential retry with reset: https://github.com/Soostone/retry/issues/25
@@ -108,6 +164,31 @@ reconnectWithLog withLog inner =
     toSeconds t =
       floor $ (fromIntegral t :: Double) / 1000 / 1000
 
+-- | Open a receiving channel and discard incoming messages.
+consumeIntoVoid :: WebSocket tx rx -> IO ()
+consumeIntoVoid websocket = do
+  rx <- receive websocket
+  fix $ \keepReading -> do
+    msg <- read rx
+    when (isJust msg) keepReading
+
+waitForPong :: Int -> WebSocket tx rx -> IO (Maybe Time.UTCTime)
+waitForPong seconds websocket =
+  Async.withAsync (sendPingEvery 1 websocket) $ \_ ->
+    Timeout.timeout (seconds * 1000 * 1000) $ do
+      channel <- receive websocket
+      fix $ \waitForNextMsg -> do
+        msg <- read channel
+        case msg of
+          Just (ControlMessage (WS.Pong _)) -> Time.getCurrentTime
+          _ -> waitForNextMsg
+
+sendPingEvery :: Int -> WebSocket tx rx -> IO ()
+sendPingEvery seconds WebSocket {connection} = forever $ do
+  activeConnection <- MVar.readMVar connection
+  WS.sendPing activeConnection BS.empty
+  threadDelay (seconds * 1000 * 1000)
+
 -- | Try to gracefully close the WebSocket.
 --
 -- Do not run with asynchronous exceptions masked, ie. Control.Exception.Safe.finally.
@@ -124,6 +205,11 @@ waitForGracefulShutdown connection = do
 
   when (isNothing response) $
     throwIO $ WS.CloseRequest 1000 "No response to close request"
+
+-- Cachix Deploy authorization headers
+
+system :: String
+system = System.Info.arch <> "-" <> System.Info.os
 
 createHeaders ::
   -- | Agent name

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -4,6 +4,7 @@
 module Cachix.Deploy.Websocket where
 
 import qualified Cachix.Client.Retry as Retry
+import qualified Cachix.Client.URI as URI
 import Cachix.Client.Version (versionNumber)
 import qualified Cachix.Deploy.Log as Log
 import qualified Cachix.Deploy.WebsocketPong as WebsocketPong
@@ -100,7 +101,7 @@ shutdownNow websocket@WebSocket {rx} code msg = do
   throwIO $ WS.CloseRequest code msg
 
 data Options = Options
-  { host :: Text,
+  { host :: URI.Host,
     path :: Text,
     headers :: HTTP.RequestHeaders,
     -- | The identifier used when logging. Usually a combination of the agent
@@ -143,10 +144,10 @@ withConnection withLog Options {host, path, headers, agentIdentifier} app = do
     reconnectWithLog withLog $
       do
         withLog $
-          K.logLocM K.InfoS $ K.ls $ "Agent " <> agentIdentifier <> " connecting to " <> host <> path
+          K.logLocM K.InfoS $ K.ls $ "Agent " <> agentIdentifier <> " connecting to " <> show host <> path
 
         -- TODO: https://github.com/jaspervdj/websockets/issues/229
-        Wuss.runSecureClientWith (toS host) 443 (toS path) connectionOptions headers $
+        Wuss.runSecureClientWith (show host) 443 (toS path) connectionOptions headers $
           \newConnection ->
             do
               withLog $ K.logLocM K.InfoS "Connected to Cachix Deploy service"

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -59,7 +59,7 @@ data Options = Options
     headers :: HTTP.RequestHeaders,
     -- | The identifier used when logging. Usually a combination of the agent
     -- name and the CLI version.
-    agentIdentifier :: Text
+    identifier :: Text
   }
   deriving (Show)
 
@@ -120,7 +120,7 @@ withConnection ::
   -- | The client app to run inside the socket
   (WebSocket tx rx -> IO ()) ->
   IO ()
-withConnection withLog options@Options {host, path, agentIdentifier} app = do
+withConnection withLog options@Options {host, path, identifier} app = do
   threadId <- myThreadId
   lastPong <- WebsocketPong.newState
 
@@ -146,7 +146,7 @@ withConnection withLog options@Options {host, path, agentIdentifier} app = do
     reconnectWithLog withLog $
       do
         withLog $
-          K.logLocM K.InfoS $ K.ls $ "Agent " <> toS agentIdentifier <> " connecting to " <> toS (URI.hostBS host) <> path
+          K.logLocM K.InfoS $ K.ls $ "Agent " <> toS identifier <> " connecting to " <> toS (URI.hostBS host) <> path
 
         -- TODO: https://github.com/jaspervdj/websockets/issues/229
         runClientWith options connectionOptions $

--- a/cachix/test/URISpec.hs
+++ b/cachix/test/URISpec.hs
@@ -1,0 +1,79 @@
+module URISpec where
+
+import qualified Cachix.Client.URI as URI
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as BL
+import Data.Either.Extra
+import qualified Dhall
+import qualified Dhall.Core
+import Protolude
+import Test.Hspec
+
+secureScheme :: ByteString
+secureScheme = "https"
+
+unsecureScheme :: ByteString
+unsecureScheme = "http"
+
+host :: ByteString
+host = "cachix.org"
+
+subdomain :: Text
+subdomain = "foo"
+
+secureUri :: ByteString
+secureUri = secureScheme <> "://" <> host
+
+unsecureUri :: ByteString
+unsecureUri = unsecureScheme <> "://" <> host
+
+secureUriWithSubdomain :: ByteString
+secureUriWithSubdomain = secureScheme <> "://" <> encodeUtf8 subdomain <> "." <> host
+
+-- A helper that throws an error when parsing fails.
+parseURI' :: ByteString -> URI.URI
+parseURI' = fromRight' . URI.parseURI
+
+spec :: Spec
+spec =
+  describe "URI" $ do
+    it "parses a URI" $
+      URI.parseURI secureUri `shouldSatisfy` isRight
+
+    it "re-serializes a URI" $
+      URI.serialize <$> URI.parseURI secureUri `shouldBe` Right secureUri
+
+    it "appends a subdomain" $
+      let parsedURI = parseURI' secureUri
+          newURI = URI.appendSubdomain subdomain parsedURI
+       in URI.serialize newURI `shouldBe` secureUriWithSubdomain
+
+    it "returns the hostname" $
+      URI.getHostname (parseURI' secureUri) `shouldBe` URI.Host host
+
+    it "returns port 80 for HTTP URIs" $
+      let scheme = URI.getScheme (parseURI' unsecureUri)
+       in URI.getPortFor scheme `shouldBe` Just (URI.Port 80)
+
+    it "returns port 443 for HTTPS URIs" $
+      let scheme = URI.getScheme (parseURI' secureUri)
+       in URI.getPortFor scheme `shouldBe` Just (URI.Port 443)
+
+    it "detects if SSL is required" $
+      let getScheme = URI.getScheme . parseURI'
+       in do
+            URI.requiresSSL (getScheme secureUri) `shouldBe` True
+            URI.requiresSSL (getScheme unsecureUri) `shouldBe` False
+
+    it "converts to JSON" $
+      Aeson.encode (parseURI' secureUri) `shouldBe` "\"" <> BL.fromStrict secureUri <> "\""
+
+    it "converts from JSON" $
+      Aeson.decodeStrict' ("\"" <> secureUri <> "\"") `shouldBe` Just (parseURI' secureUri)
+
+    it "converts to Dhall" $
+      let asDhall = Dhall.embed Dhall.inject (parseURI' secureUri)
+       in Dhall.Core.pretty asDhall `shouldBe` "\"" <> decodeUtf8 secureUri <> "\""
+
+    it "converts from Dhall" $
+      Dhall.input Dhall.auto ("\"" <> decodeUtf8 secureUri <> "\"") `shouldReturn` parseURI' secureUri


### PR DESCRIPTION
## Summary

#### Agent

- The websocket module is not longer in charge of setting up the agent and logging.
- :bug: Resolves an issue where the agent would queue and run several copies of the same deployment if the `StartDeployment` message was not sent quickly enough. The agent now spawns the deployment binary without blocking message processing. 

#### Deployment binary

- The deployment receives all of the information it needs for the deployment from the agent via stdin.
- :bug: The deployment no longer runs within the websocket message handler. Any errors within the socket won’t cause an infinite loop of socket reconnects.
- The logging and backend websockets run in their own separate threads.
- Activation now throws IO errors whenever any of the commands return a non-zero exit code.
- Logs and deployment commands are sent outside of activation, greatly simplifying data flow.

#### Websockets

- :bug: Queued messages are processed even when the websocket throws exceptions. See `receiveDataConcurrently`.
- :bug: Websockets are closed according to the spec. We send a `close` request and wait for a close request from the peer. The grace period for the response is 5 seconds, after which we close anyways. Resolves #441.
- ❗ Fixed a typo in the `receiveDataConcurrently` method.

#### Logging

- :star: The new `Log.withLog` method setups a Katip scribe and yields a ready-to-go logging context.
- Most functions are now plain IO. `KatipContextT` has been removed because it wasn’t being used. The result is: simpler typing and no `liftIO`.
- :star: `verbose` mode now mirrors the log stream to the local log.

## TODO

- [x] Rebase
- [x] Apply rollback and deployment fixes
- [x] Upgrade cachix-api on the backend to fix #441
- [x] Allow SSL-less connections for testing
- [ ] Bump cachix-api