### PR TITLE
Allow configuring a persistent hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@
 $ cachix --help
 https://cachix.org command line interface
 
-Usage: cachix [--host URI] [-c|--config CONFIGPATH] [-v|--verbose] 
+Usage: cachix [--hostname URI] [-c|--config CONFIGPATH] [-v|--verbose]
               (COMMAND | (-V|--version))
+
   To get started log in to https://app.cachix.org
 
 Available options:
   -h,--help                Show this help text
-  --host URI               Host to connect to (default: https://cachix.org)
+  --hostname URI           Host to connect to (default: https://cachix.org)
   -c,--config CONFIGPATH   Cachix configuration file
                            (default: "/home/domen/.config/cachix/cachix.dhall")
   -v,--verbose             Verbose mode
@@ -24,6 +25,7 @@ Available options:
 Available commands:
   authtoken                Configure authentication token for communication to
                            HTTP API
+  config                   Manage configuration settings for cachix
   generate-keypair         Generate signing key pair for a binary cache
   push                     Upload Nix store paths to a binary cache
   watch-exec               Run a command while it's running watch /nix/store for

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -93,6 +93,7 @@ library
     , dhall                   >=1.28.0
     , directory
     , ed25519
+    , either
     , extra
     , filepath
     , fsnotify

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -25,6 +25,7 @@ common defaults
     DeriveAnyClass
     DeriveGeneric
     DerivingVia
+    NamedFieldPuns
     OverloadedStrings
 
   ghc-options:
@@ -111,6 +112,7 @@ library
     , netrc
     , optparse-applicative
     , pretty-terminal
+    , prettyprinter
     , process
     , protolude
     , resourcet

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -5,7 +5,7 @@ where
 
 import Cachix.Client.Commands as Commands
 import qualified Cachix.Client.Config as Config
-import Cachix.Client.Env (mkEnv)
+import Cachix.Client.Env (cachixoptions, mkEnv)
 import Cachix.Client.OptionsParser (CachixCommand (..), getOpts)
 import Cachix.Client.Version (cachixVersion)
 import Cachix.Deploy.ActivateCommand as ActivateCommand
@@ -15,11 +15,12 @@ import Protolude
 
 main :: IO ()
 main = do
-  (cachixoptions, command) <- getOpts
-  env <- mkEnv cachixoptions
+  (flags, command) <- getOpts
+  env <- mkEnv flags
+  let cachixOptions = cachixoptions env
   case command of
     AuthToken token -> Commands.authtoken env token
-    Config configCommand -> Config.run cachixoptions configCommand
+    Config configCommand -> Config.run cachixOptions configCommand
     GenerateKeypair name -> Commands.generateKeypair env name
     Push pushArgs -> Commands.push env pushArgs
     WatchStore watchArgs name -> Commands.watchStore env watchArgs name
@@ -28,5 +29,5 @@ main = do
     Version -> putText cachixVersion
     DeployCommand deployCommand ->
       case deployCommand of
-        DeployOptions.Agent opts -> AgentCommand.run cachixoptions opts
-        DeployOptions.Activate opts -> ActivateCommand.run cachixoptions opts
+        DeployOptions.Agent opts -> AgentCommand.run cachixOptions opts
+        DeployOptions.Activate opts -> ActivateCommand.run cachixOptions opts

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -18,6 +18,7 @@ main = do
   env <- mkEnv cachixoptions
   case command of
     AuthToken token -> Commands.authtoken env token
+    Config _ -> pure ()
     GenerateKeypair name -> Commands.generateKeypair env name
     Push pushArgs -> Commands.push env pushArgs
     WatchStore watchArgs name -> Commands.watchStore env watchArgs name

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -4,6 +4,7 @@ module Cachix.Client
 where
 
 import Cachix.Client.Commands as Commands
+import qualified Cachix.Client.Config as Config
 import Cachix.Client.Env (mkEnv)
 import Cachix.Client.OptionsParser (CachixCommand (..), getOpts)
 import Cachix.Client.Version (cachixVersion)
@@ -18,7 +19,7 @@ main = do
   env <- mkEnv cachixoptions
   case command of
     AuthToken token -> Commands.authtoken env token
-    Config _ -> pure ()
+    Config configCommand -> Config.run cachixoptions configCommand
     GenerateKeypair name -> Commands.generateKeypair env name
     Push pushArgs -> Commands.push env pushArgs
     WatchStore watchArgs name -> Commands.watchStore env watchArgs name

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -51,7 +51,7 @@ import Data.String.Here
 import qualified Data.Text as T
 import qualified Data.Text.IO as T.IO
 import GHC.IO.Handle (hDuplicate, hDuplicateTo)
-import Hercules.CNix.Store (Store, StorePath, followLinksToStorePath, isValidPath, storePathToPath)
+import Hercules.CNix.Store (Store, StorePath, followLinksToStorePath, storePathToPath)
 import Network.HTTP.Types (status401, status404)
 import Protolude hiding (toS)
 import Protolude.Conv

--- a/cachix/src/Cachix/Client/Config.hs
+++ b/cachix/src/Cachix/Client/Config.hs
@@ -35,7 +35,6 @@ import Data.String.Here
 import qualified Dhall
 import qualified Dhall.Pretty
 import qualified Options.Applicative as Opt
-import qualified Options.Applicative.Help as Opt.Help
 import qualified Prettyprinter as Pretty
 import qualified Prettyprinter.Render.Text as Pretty
 import Protolude hiding (toS)
@@ -82,26 +81,11 @@ setConfigOption CachixOptions {configPath} (HostName hostname) = do
 parser :: Opt.ParserInfo Command
 parser =
   Opt.info (Opt.helper <*> commandParser) $
-    mconcat
-      [ Opt.fullDesc,
-        Opt.progDesc "Manage the configuration for cachix",
-        Opt.footer (toS $ Opt.Help.renderHelp 80 (Opt.Help.bodyHelp printAllConfigurationKeys))
-      ]
-  where
-    printAllConfigurationKeys =
-      Opt.Help.vcatChunks $
-        map snd $
-          Opt.Help.cmdDesc Opt.defaultPrefs $
-            Opt.subparser (mconcat supportedConfigKeys)
+    Opt.progDesc "Manage the configuration for cachix"
 
 commandParser :: Opt.Parser Command
 commandParser =
-  Opt.subparser $
-    mconcat
-      [ Opt.command "set" $
-          Opt.info (Opt.helper <*> configKeyParser Set) $
-            Opt.progDesc "Set a configuration option"
-      ]
+  configKeyParser Set
 
 configKeyParser :: (ConfigKey -> Command) -> Opt.Parser Command
 configKeyParser cmd = do

--- a/cachix/src/Cachix/Client/Config/Orphans.hs
+++ b/cachix/src/Cachix/Client/Config/Orphans.hs
@@ -1,24 +1,53 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Cachix.Client.Config.Orphans
   (
   )
 where
 
-import Dhall hiding (Text)
-import Dhall.Core (Chunks (..), Expr (..))
+import qualified Dhall
+import qualified Dhall.Core
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Auth.Client
+import qualified URI.ByteString as URI
+import Data.Either.Validation ( Validation(Failure, Success) )
 
-instance FromDhall Token where
-  autoWith _ = strictText {extract = ex}
+instance Dhall.FromDhall Token where
+  autoWith _ = Dhall.strictText {Dhall.extract = ex}
     where
-      ex (TextLit (Chunks [] t)) = pure (Token (toS t))
+      ex (Dhall.Core.TextLit (Dhall.Core.Chunks [] t)) = pure (Token (toS t))
       ex _ = panic "Unexpected Dhall value. Did it typecheck?"
 
-instance ToDhall Token where
-  injectWith _ = Encoder
-    { embed = TextLit . Chunks [] . toS . getToken,
-      declared = Text
+instance Dhall.ToDhall Token where
+  injectWith _ = Dhall.Encoder
+    { Dhall.embed = Dhall.Core.TextLit . Dhall.Core.Chunks [] . toS . getToken,
+      Dhall.declared = Dhall.Core.Text
     }
+
+instance Dhall.FromDhall (URI.URIRef URI.Absolute) where
+  autoWith opts =
+    Dhall.Decoder extract expected
+    where
+      textDecoder :: Dhall.Decoder Text
+      textDecoder = Dhall.autoWith opts
+
+      extract expression =
+        case Dhall.extract textDecoder expression of
+          Success x -> case URI.parseURI URI.strictURIParserOptions (toS x) of
+            Left exception -> Dhall.extractError (show exception)
+            Right path -> Success path
+          Failure e -> Failure e
+
+      expected = Dhall.expected textDecoder
+
+instance Dhall.ToDhall (URI.URIRef URI.Absolute) where
+  injectWith opts = Dhall.Encoder embed declared
+    where
+      textEncoder :: Dhall.Encoder Text
+      textEncoder = Dhall.injectWith opts
+
+      embed uri = Dhall.embed textEncoder $ toS (URI.serializeURIRef' uri)
+
+      declared = Dhall.Core.Text

--- a/cachix/src/Cachix/Client/Env.hs
+++ b/cachix/src/Cachix/Client/Env.hs
@@ -6,8 +6,7 @@ module Cachix.Client.Env
   )
 where
 
-import Cachix.Client.Config (Config, readConfig)
-import Cachix.Client.OptionsParser (CachixOptions (..))
+import Cachix.Client.Config (CachixOptions (..), Config, getConfig)
 import Cachix.Client.URI (getBaseUrl)
 import Cachix.Client.Version (cachixVersion)
 import Hercules.CNix.Store (Store, openStore)
@@ -25,7 +24,7 @@ import Servant.Client.Streaming (ClientEnv, mkClientEnv)
 import System.Directory (canonicalizePath)
 
 data Env = Env
-  { config :: Maybe Config,
+  { config :: Config,
     clientenv :: ClientEnv,
     cachixoptions :: CachixOptions,
     storeAsync :: Async Store
@@ -37,7 +36,7 @@ mkEnv rawcachixoptions = do
   -- make sure path to the config is passed as absolute to dhall logic
   canonicalConfigPath <- canonicalizePath (configPath rawcachixoptions)
   let cachixOptions = rawcachixoptions {configPath = canonicalConfigPath}
-  cfg <- readConfig $ configPath cachixOptions
+  cfg <- getConfig (configPath cachixOptions)
   clientEnv <- createClientEnv cachixOptions
   return
     Env

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -1,6 +1,5 @@
 module Cachix.Client.OptionsParser
   ( CachixCommand (..),
-    CachixOptions (..),
     PushArguments (..),
     PushOptions (..),
     BinaryCacheName,
@@ -23,16 +22,9 @@ import URI.ByteString
     strictURIParserOptions,
   )
 
-data CachixOptions = CachixOptions
-  { host :: URIRef Absolute,
-    configPath :: Config.ConfigPath,
-    verbose :: Bool
-  }
-  deriving (Show)
-
-parserCachixOptions :: Config.ConfigPath -> Parser CachixOptions
+parserCachixOptions :: Config.ConfigPath -> Parser Config.CachixOptions
 parserCachixOptions defaultConfigPath =
-  CachixOptions
+  Config.CachixOptions
     <$> option
       uriOption
       ( long "host"
@@ -169,12 +161,12 @@ parserCachixCommand =
                   )
             )
 
-getOpts :: IO (CachixOptions, CachixCommand)
+getOpts :: IO (Config.CachixOptions, CachixCommand)
 getOpts = do
   configpath <- Config.getDefaultFilename
   customExecParser (prefs showHelpOnEmpty) (optsInfo configpath)
 
-optsInfo :: Config.ConfigPath -> ParserInfo (CachixOptions, CachixCommand)
+optsInfo :: Config.ConfigPath -> ParserInfo (Config.CachixOptions, CachixCommand)
 optsInfo configpath = infoH parser desc
   where
     parser = (,) <$> parserCachixOptions configpath <*> (parserCachixCommand <|> versionParser)

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -13,7 +13,7 @@ import qualified Cachix.Client.InstallationMode as InstallationMode
 import Cachix.Client.URI (defaultCachixURI)
 import qualified Cachix.Deploy.OptionsParser as DeployOptions
 import Options.Applicative
-import Protolude hiding (option, toS)
+import Protolude hiding (toS)
 import Protolude.Conv
 import URI.ByteString
   ( Absolute,
@@ -63,6 +63,7 @@ type BinaryCacheName = Text
 
 data CachixCommand
   = AuthToken (Maybe Text)
+  | Config Config.Command
   | GenerateKeypair BinaryCacheName
   | Push PushArguments
   | WatchStore PushOptions Text
@@ -88,6 +89,7 @@ parserCachixCommand :: Parser CachixCommand
 parserCachixCommand =
   subparser $
     command "authtoken" (infoH authtoken (progDesc "Configure authentication token for communication to HTTP API"))
+      <> command "config" (Config <$> Config.parser)
       <> command "generate-keypair" (infoH generateKeypair (progDesc "Generate signing key pair for a binary cache"))
       <> command "push" (infoH push (progDesc "Upload Nix store paths to a binary cache"))
       <> command "watch-exec" (infoH watchExec (progDesc "Run a command while it's running watch /nix/store for newly added store paths and upload them to a binary cache"))

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -21,13 +21,13 @@ import qualified URI.ByteString as URI
 
 data Flags = Flags
   { configPath :: Config.ConfigPath,
-    host :: Maybe (URI.URIRef URI.Absolute),
+    hostname :: Maybe (URI.URIRef URI.Absolute),
     verbose :: Bool
   }
 
 flagParser :: Config.ConfigPath -> Parser Flags
 flagParser defaultConfigPath = do
-  host <-
+  hostname <-
     optional $
       option
         uriOption
@@ -59,7 +59,7 @@ flagParser defaultConfigPath = do
           help "Verbose mode"
         ]
 
-  pure Flags {host, configPath, verbose}
+  pure Flags {hostname, configPath, verbose}
   where
     defaultHostname = toS (URI.serializeURIRef' URI.defaultCachixURI)
 

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -281,7 +281,7 @@ getMissingPathsForClosure pushParams inputPaths = do
 
 -- | Find auth token or signing key in the 'Config' or environment variable
 findPushSecret ::
-  Maybe Config.Config ->
+  Config.Config ->
   -- | Cache name
   Text ->
   -- | Secret key or exception
@@ -289,9 +289,7 @@ findPushSecret ::
 findPushSecret config name = do
   maybeSigningKeyEnv <- toS <<$>> lookupEnv "CACHIX_SIGNING_KEY"
   maybeAuthToken <- Config.getAuthTokenMaybe config
-  let maybeSigningKeyConfig = case config of
-        Nothing -> Nothing
-        Just cfg -> Config.secretKey <$> head (getBinaryCache cfg)
+  let maybeSigningKeyConfig = Config.secretKey <$> head (getBinaryCache config)
   case maybeSigningKeyEnv <|> maybeSigningKeyConfig of
     Just signingKey -> escalateAs FatalError $ PushSigningKey (fromMaybe (Token "") maybeAuthToken) <$> parseSigningKeyLenient signingKey
     Nothing -> case maybeAuthToken of

--- a/cachix/src/Cachix/Deploy/ActivateCommand.hs
+++ b/cachix/src/Cachix/Deploy/ActivateCommand.hs
@@ -4,8 +4,8 @@ module Cachix.Deploy.ActivateCommand where
 
 import qualified Cachix.API.Deploy as API
 import Cachix.API.Error (escalate)
+import qualified Cachix.Client.Config as Config
 import qualified Cachix.Client.Env as Env
-import qualified Cachix.Client.OptionsParser as CachixOptions
 import Cachix.Client.Servant (deployClient)
 import qualified Cachix.Deploy.OptionsParser as DeployOptions
 import qualified Cachix.Types.DeployResponse as DeployResponse
@@ -18,7 +18,7 @@ import Servant.Client.Streaming (runClientM)
 import Servant.Conduit ()
 import System.Environment (getEnv)
 
-run :: CachixOptions.CachixOptions -> DeployOptions.ActivateOptions -> IO ()
+run :: Config.CachixOptions -> DeployOptions.ActivateOptions -> IO ()
 run cachixOptions DeployOptions.ActivateOptions {DeployOptions.payloadPath} = do
   agentToken <- getEnv "CACHIX_ACTIVATE_TOKEN"
   clientEnv <- Env.createClientEnv cachixOptions

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -3,7 +3,7 @@
 module Cachix.Deploy.Agent where
 
 import qualified Cachix.API.WebSocketSubprotocol as WSS
-import qualified Cachix.Client.OptionsParser as CachixOptions
+import qualified Cachix.Client.Config as Config
 import Cachix.Client.URI (getBaseUrl)
 import qualified Cachix.Deploy.OptionsParser as AgentOptions
 import Cachix.Deploy.StdinProcess (readProcess)
@@ -16,11 +16,11 @@ import Protolude hiding (toS)
 import Protolude.Conv
 import qualified Servant.Client as Servant
 
-run :: CachixOptions.CachixOptions -> AgentOptions.AgentOptions -> IO ()
+run :: Config.CachixOptions -> AgentOptions.AgentOptions -> IO ()
 run cachixOptions agentOpts =
   CachixWebsocket.runForever options handleMessage
   where
-    host = toS $ Servant.baseUrlHost $ getBaseUrl $ CachixOptions.host cachixOptions
+    host = toS $ Servant.baseUrlHost $ getBaseUrl $ Config.host cachixOptions
     name = AgentOptions.name agentOpts
     profile = fromMaybe "system" (AgentOptions.profile agentOpts)
     options =
@@ -29,7 +29,7 @@ run cachixOptions agentOpts =
           CachixWebsocket.name = name,
           CachixWebsocket.path = "/ws",
           CachixWebsocket.profile = profile,
-          CachixWebsocket.isVerbose = CachixOptions.verbose cachixOptions
+          CachixWebsocket.isVerbose = Config.verbose cachixOptions
         }
     handleMessage :: ByteString -> (K.KatipContextT IO () -> IO ()) -> WS.Connection -> CachixWebsocket.AgentState -> ByteString -> K.KatipContextT IO ()
     handleMessage payload _ _ agentState _ =
@@ -51,6 +51,6 @@ run cachixOptions agentOpts =
                           name = name,
                           path = "/ws-deployment",
                           profile = profile,
-                          isVerbose = CachixOptions.verbose cachixOptions
+                          isVerbose = Config.verbose cachixOptions
                         }
                   }


### PR DESCRIPTION
You can now configure a persistent hostname with `cachix config set hostname`. 

A few questions to resolve:

- [x] `host` vs `hostname`
`hostname` seems to be the standard. We could allow providing `--hostname` (in addition to the current `--host`)
- [x] `config set hostname` vs `config hostname`
Would we want to have other subcommands in the future? `get` or `list`?

Resolves #439.