### PR TITLE
Upgrade dependencies

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -137,7 +137,10 @@ library
     , websockets
     , wuss
 
-  pkgconfig-depends: nix-store ==2.0 || >2.0, nix-main ==2.0 || >2.0
+  -- These versions should match those supported by hercules-ci-cnix-store
+  pkgconfig-depends:
+    nix-main (==2.4 || >2.4) && <2.11,
+    nix-store (==2.4 || >2.4) && <2.11
 
 executable cachix
   import:             defaults

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,17 @@
 { system ? builtins.currentSystem
 , pkgs ? import ./nix { inherit system; }
-,
 }:
 let
+  # Match the GHC version to the one chosen by Stack.
+  # TODO: Choose between stack and cabal. Don't use both!
+  haskellPackages = pkgs.haskell.packages.ghc924;
 
-  cachix-api = pkgs.haskellPackages.callCabal2nix "cachix-api" (pkgs.gitignoreSource ./cachix-api) {};
-  cachix = pkgs.haskellPackages.callCabal2nix "cachix" (pkgs.gitignoreSource ./cachix) {
+  cachix-api = haskellPackages.callCabal2nix "cachix-api" (pkgs.gitignoreSource ./cachix-api) {};
+
+  cachix = haskellPackages.callCabal2nix "cachix" (pkgs.gitignoreSource ./cachix) {
     inherit cachix-api;
-    # note: this has to be in sync with what hercules-ci-cnix-store was compiled with
-    nix = pkgs.nixVersions.nix_2_7;
+    # Make sure that the nix version here is within the range supported by hercules-ci-cnix-store
+    nix = pkgs.nixVersions.nix_2_9;
   };
-
 in
 pkgs.haskell.lib.justStaticExecutables cachix

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "nixos-unstable",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cbcd62ada85e015e8117bd7e901bf40b6c767bc",
-        "sha256": "1y9dajnn8agbbav3qc9q6cmah8g447dqzz19411ynwcnh9zij0cv",
+        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+        "sha256": "1wf0vgzfkpa1famz1fxx2758nm13k7dhkz1z8f4bgasmc2bxfckc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9cbcd62ada85e015e8117bd7e901bf40b6c767bc.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d6490a0bd9dfb298fcd8382d3363b86870dc7340.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "4e7e464ae8e897d487fc412b50560f9f5f744353"
     },

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -6,25 +6,53 @@ let
   # The fetchers. fetch_<type> fetches specs of type <type>.
   #
 
-  fetch_file = pkgs: spec:
-    if spec.builtin or true then
-      builtins_fetchurl { inherit (spec) url sha256; }
-    else
-      pkgs.fetchurl { inherit (spec) url sha256; };
+  fetch_file = pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+      if spec.builtin or true then
+        builtins_fetchurl { inherit (spec) url sha256; name = name'; }
+      else
+        pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
 
   fetch_tarball = pkgs: name: spec:
     let
-      ok = str: ! builtins.isNull (builtins.match "[a-zA-Z0-9+-._?=]" str);
-      # sanitize the name, though nix will still fail if name starts with period
-      name' = stringAsChars (x: if ! ok x then "-" else x) "${name}-src";
+      name' = sanitizeName name + "-src";
     in
       if spec.builtin or true then
         builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
       else
         pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
-  fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  fetch_git = name: spec:
+    let
+      ref =
+        if spec ? ref then spec.ref else
+          if spec ? branch then "refs/heads/${spec.branch}" else
+            if spec ? tag then "refs/tags/${spec.tag}" else
+              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
+    in
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 
@@ -40,11 +68,21 @@ let
   # Various helpers
   #
 
+  # https://github.com/NixOS/nixpkgs/pull/83241/files#diff-c6f540a4f3bfa4b0e8b6bafd4cd54e8bR695
+  sanitizeName = name:
+    (
+      concatMapStrings (s: if builtins.isList s then "-" else s)
+        (
+          builtins.split "[^[:alnum:]+._?=-]+"
+            ((x: builtins.elemAt (builtins.match "\\.*(.*)" x) 0) name)
+        )
+    );
+
   # The set of packages used when specs are fetched using non-builtins.
-  mkPkgs = sources:
+  mkPkgs = sources: system:
     let
       sourcesNixpkgs =
-        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {};
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) { inherit system; };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
@@ -64,9 +102,9 @@ let
 
     if ! builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file pkgs spec
+    else if spec.type == "file" then fetch_file pkgs name spec
     else if spec.type == "tarball" then fetch_tarball pkgs name spec
-    else if spec.type == "git" then fetch_git spec
+    else if spec.type == "git" then fetch_git name spec
     else if spec.type == "local" then fetch_local spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
     else if spec.type == "builtin-url" then fetch_builtin-url name
@@ -80,7 +118,10 @@ let
       saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
       ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
     in
-      if ersatz == "" then drv else ersatz;
+      if ersatz == "" then drv else
+        # this turns the string into an actual Nix path (for both absolute and
+        # relative paths)
+        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 
@@ -98,25 +139,29 @@ let
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
   stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
+  concatMapStrings = f: list: concatStrings (map f list);
   concatStrings = builtins.concatStringsSep "";
 
+  # https://github.com/NixOS/nixpkgs/blob/8a9f58a375c401b96da862d969f66429def1d118/lib/attrsets.nix#L331
+  optionalAttrs = cond: as: if cond then as else {};
+
   # fetchTarball version that is compatible between all the versions of Nix
-  builtins_fetchTarball = { url, name, sha256 }@attrs:
+  builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
       if lessThan nixVersion "1.12" then
-        fetchTarball { inherit name url; }
+        fetchTarball ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
-  builtins_fetchurl = { url, sha256 }@attrs:
+  builtins_fetchurl = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
       if lessThan nixVersion "1.12" then
-        fetchurl { inherit url; }
+        fetchurl ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchurl attrs;
 
@@ -135,7 +180,8 @@ let
   mkConfig =
     { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
     , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
-    , pkgs ? mkPkgs sources
+    , system ? builtins.currentSystem
+    , pkgs ? mkPkgs sources system
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -9,10 +9,13 @@ pkgs.haskell.lib.buildStackProject {
 
   ghc = pkgs.haskell.compiler."${ghcVersion}";
 
+  NIX_PATH = "nixpkgs=${pkgs.path}";
+
   buildInputs = [
     pkgs.lzma
     pkgs.zlib
-    pkgs.nix
+    # TODO: match this to version in default.nix
+    pkgs.nixVersions.nix_2_9
     pkgs.boost
   ];
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,12 @@
-resolver: nightly-2022-06-20
+resolver: nightly-2022-09-22
 packages:
-- cachix-api
 - cachix
+- cachix-api
 extra-deps:
-- hercules-ci-cnix-store-0.3.3.0
-- netrc-0.2.0.0
+- hercules-ci-cnix-store-0.3.3.1
 - nix-narinfo-0.1.0.1
-- protolude-0.3.2
-- servant-auth-swagger-0.2.10.1
 - cabal-pkg-config-version-hook-0.1.0.0
-# https://github.com/haskell-hvr/netrc/issues/5
-allow-newer: true
+allow-newer: false
 nix:
-  packages: []
+  enable: true
   shell-file: ./nix/stack-shell.nix


### PR DESCRIPTION
* Bump nixpkgs
* Upgrade to GHC 9.2.4
* Match the GHC version in CI to the one in development
* Match the Nix version in CI to the one in development (for hercules-ci-cnix-store)

This should help us have more or less the same dependencies between CI and development. I would strongly consider bidding farewell to stack in the future 🙃 