### PR TITLE
Propagate errors between websocket threads

### DIFF
--- a/cachix/src/Cachix/Deploy/WebsocketPong.hs
+++ b/cachix/src/Cachix/Deploy/WebsocketPong.hs
@@ -25,7 +25,7 @@ newState = do
 pingHandler :: LastPongState -> ThreadId -> Int -> IO ()
 pingHandler pong threadID maxLastPing = do
   last <- secondsSinceLastPong pong
-  when (last > maxLastPing) $ do
+  when (last > maxLastPing) $
     throwTo threadID WebsocketPongTimeout
 
 secondsSinceLastPong :: LastPongState -> IO Int


### PR DESCRIPTION
Resolves #453.

Here's a breakdown of the mistake I made:

Supposed the thread processing incoming JSON messages encounters a network exception and exits. I had thought that the other threads would then be cancelled and we'd reconnect. In reality, the other threads would continue running and we would rely on either ping timeout or deadlock detection to get us out of the loop. Not good!

The lesson here is that you have to `wait` for your threads. That's the error propagation mechanism between threads.

Related to this: https://github.com/simonmar/async/issues/128