### PR TITLE
Open an incoming message channel early

### DIFF
--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -73,11 +73,11 @@ run cachixOptions agentOpts =
                 WebSocket.identifier = agentIdentifier agentName
               }
 
-      WebSocket.withConnection withLog websocketOptions $ \websocket ->
+      WebSocket.withConnection withLog websocketOptions $ \websocket -> do
+        channel <- WebSocket.receive websocket
         WebSocket.handleJSONMessages @(WSS.Message WSS.AgentCommand) @(WSS.Message WSS.BackendCommand) websocket $
-          WebSocket.receive websocket >>= \channel ->
-            WebSocket.readDataMessages channel $ \message ->
-              handleMessage withLog agentState agentName agentToken message
+          WebSocket.readDataMessages channel $ \message ->
+            handleMessage withLog agentState agentName agentToken message
   where
     host = Config.host cachixOptions
     basename = URI.getHostname host

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -174,6 +174,10 @@ runClientWith Options {host, port, path, headers, useSSL} connectionOptions app 
 
 -- Handle JSON messages
 
+-- | Start processing incoming and outgoing JSON messages.
+--
+-- Make sure to open an incoming channel with [receive] beforehand to avoid
+-- dropping messages.
 handleJSONMessages :: (Aeson.ToJSON tx, Aeson.FromJSON rx) => WebSocket tx rx -> IO () -> IO ()
 handleJSONMessages websocket app =
   Async.withAsync (handleIncomingJSON websocket) $ \incomingThread ->


### PR DESCRIPTION
It's possible to lose messages in between starting the incoming message handler and actually reading them. There are two reasons for this:

1. Broadcast channels eagerly drop messages when no-one is listening to avoid memory leaks.

2. Even if we were to use a regular channel that kept unread messages, the duplicated channel would still only receive future messages.

We can avoid both of these issues by opening the channel early.