### PR TITLE
Add a bootstrap mode to help initially deploy agents

### DIFF
--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -31,6 +31,9 @@ import Protolude hiding (toS)
 import Protolude.Conv
 import System.IO (BufferMode (..), hSetBuffering)
 
+lockFilename :: Text -> FilePath
+lockFilename profileName = "deployment-" <> toS profileName
+
 -- | Activate the new deployment.
 --
 -- If the target profile is already locked by another deployment, exit
@@ -74,7 +77,7 @@ main = do
           }
 
   Log.withLog logOptions $ \withLog ->
-    void . Lock.withTryLock profileName $ do
+    void . Lock.withTryLock (lockFilename profileName) $ do
       -- Open a connection to logging stream
       (logQueue, loggingThread) <- runLogStream withLog logWebsocketOptions
 

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -30,7 +30,7 @@ import Protolude.Conv
 import System.IO (BufferMode (..), hSetBuffering)
 
 lockFilename :: Text -> FilePath
-lockFilename profileName = "deployment-" <> toS profileName
+lockFilename agentName = "deployment-" <> toS agentName
 
 -- | Activate the new deployment.
 --
@@ -45,7 +45,6 @@ main = do
   deployment@Deployment
     { agentName,
       agentToken,
-      profileName,
       host,
       logOptions,
       deploymentDetails
@@ -75,7 +74,7 @@ main = do
           }
 
   Log.withLog logOptions $ \withLog ->
-    void . Lock.withTryLock (lockFilename profileName) $ do
+    void . Lock.withTryLock (lockFilename agentName) $ do
       -- Open a connection to logging stream
       (logQueue, loggingThread) <- runLogStream withLog logWebsocketOptions
 

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Main
   ( main,

--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -89,8 +89,8 @@ main = do
         `finally` do
           withLog $ K.logLocM K.DebugS "Cleaning up websocket connections"
           atomically $ TMQueue.closeTMQueue logQueue
-          serviceThread <- shutdownService
-          Async.waitBoth serviceThread loggingThread
+          shutdownService
+          Async.wait loggingThread
 
 -- | Run the deployment commands
 deploy ::

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -68,6 +68,7 @@ library
     Cachix.Deploy.Activate
     Cachix.Deploy.ActivateCommand
     Cachix.Deploy.Agent
+    Cachix.Deploy.Deployment
     Cachix.Deploy.Lock
     Cachix.Deploy.Log
     Cachix.Deploy.OptionsParser

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -28,6 +28,8 @@ common defaults
     LambdaCase
     NamedFieldPuns
     OverloadedStrings
+    RecordWildCards
+    ScopedTypeVariables
 
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Cachix.Deploy.Agent where
 
@@ -9,24 +10,30 @@ import Cachix.Client.URI (URI)
 import qualified Cachix.Client.URI as URI
 import Cachix.Client.Version (versionNumber)
 import qualified Cachix.Deploy.Deployment as Deployment
+import qualified Cachix.Deploy.Lock as Lock
 import qualified Cachix.Deploy.Log as Log
-import qualified Cachix.Deploy.OptionsParser as AgentOptions
+import qualified Cachix.Deploy.OptionsParser as CLI
 import qualified Cachix.Deploy.StdinProcess as StdinProcess
 import qualified Cachix.Deploy.Websocket as WebSocket
 import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.Extra (once)
 import qualified Control.Concurrent.MVar as MVar
-import Control.Exception.Safe (handleAny, onException)
+import Control.Exception.Safe (handleAny, onException, throwString)
+import qualified Control.Exception.Safe as Safe
+import qualified Control.Retry as Retry
 import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.String (String)
+import qualified Data.Text as Text
 import qualified Katip as K
 import Paths_cachix (getBinDir)
-import Protolude hiding (onException, toS)
+import Protolude hiding (onException, toS, (<.>))
 import Protolude.Conv
 import qualified System.Directory as Directory
 import System.Environment (getEnv, lookupEnv)
+import System.FilePath ((<.>), (</>))
 import qualified System.Posix.Files as Posix.Files
+import qualified System.Posix.Process as Posix
 import qualified System.Posix.Signals as Signals
 import qualified System.Posix.Types as Posix
 import qualified System.Posix.User as Posix.User
@@ -40,6 +47,7 @@ data Agent = Agent
     profileName :: Text,
     agentState :: IORef (Maybe WSS.AgentInformation),
     pid :: Posix.CPid,
+    bootstrap :: Bool,
     host :: URI,
     logOptions :: Log.Options,
     withLog :: Log.WithLog,
@@ -49,58 +57,60 @@ data Agent = Agent
 agentIdentifier :: Text -> Text
 agentIdentifier agentName = agentName <> " " <> toS versionNumber
 
-run :: Config.CachixOptions -> AgentOptions.AgentOptions -> IO ()
-run cachixOptions agentOpts =
+run :: Config.CachixOptions -> CLI.AgentOptions -> IO ()
+run cachixOptions agentOptions =
   Log.withLog logOptions $ \withLog ->
-    handleAny (logAndExitWithFailure withLog) $ do
-      checkUserOwnsHome
+    handleAny (logAndExitWithFailure withLog) $
+      withLockedProfile agentOptions profileName $ do
+        checkUserOwnsHome
 
-      -- TODO: show a more helpful error if the token is missing
-      -- TODO: show a more helpful error when the token isn't valid
-      agentToken <- toS <$> getEnv "CACHIX_AGENT_TOKEN"
-      agentState <- newIORef Nothing
+        -- TODO: show a more helpful error if the token is missing
+        -- TODO: show a more helpful error when the token isn't valid
+        agentToken <- toS <$> getEnv "CACHIX_AGENT_TOKEN"
+        agentState <- newIORef Nothing
 
-      pid <- Process.getCurrentPid
+        pid <- Posix.getProcessID
 
-      let port = fromMaybe (URI.Port 80) $ (URI.getPortFor . URI.getScheme) host
-      let websocketOptions =
-            WebSocket.Options
-              { WebSocket.host = basename,
-                WebSocket.port = port,
-                WebSocket.path = "/ws",
-                WebSocket.useSSL = URI.requiresSSL (URI.getScheme host),
-                WebSocket.headers = WebSocket.createHeaders agentName agentToken,
-                WebSocket.identifier = agentIdentifier agentName
-              }
+        let port = fromMaybe (URI.Port 80) $ (URI.getPortFor . URI.getScheme) host
+        let websocketOptions =
+              WebSocket.Options
+                { WebSocket.host = basename,
+                  WebSocket.port = port,
+                  WebSocket.path = "/ws",
+                  WebSocket.useSSL = URI.requiresSSL (URI.getScheme host),
+                  WebSocket.headers = WebSocket.createHeaders agentName agentToken,
+                  WebSocket.identifier = agentIdentifier agentName
+                }
 
-      websocket <- WebSocket.new withLog websocketOptions
-      channel <- WebSocket.receive websocket
-      shutdownWebsocket <- connectToService websocket
+        websocket <- WebSocket.new withLog websocketOptions
+        channel <- WebSocket.receive websocket
+        shutdownWebsocket <- connectToService websocket
 
-      let signalSet = Signals.CatchOnce (shutdownWebsocket >>= Async.wait)
-      void $ Signals.installHandler Signals.sigINT signalSet Nothing
-      void $ Signals.installHandler Signals.sigTERM signalSet Nothing
+        let signalSet = Signals.CatchOnce (shutdownWebsocket >>= Async.wait)
+        void $ Signals.installHandler Signals.sigINT signalSet Nothing
+        void $ Signals.installHandler Signals.sigTERM signalSet Nothing
 
-      let agent =
-            Agent
-              { name = agentName,
-                token = agentToken,
-                profileName = profileName,
-                agentState = agentState,
-                pid = pid,
-                host = host,
-                logOptions = logOptions,
-                withLog = withLog,
-                websocket = websocket
-              }
+        let agent =
+              Agent
+                { name = agentName,
+                  token = agentToken,
+                  profileName = profileName,
+                  agentState = agentState,
+                  pid = pid,
+                  bootstrap = CLI.bootstrap agentOptions,
+                  host = host,
+                  logOptions = logOptions,
+                  withLog = withLog,
+                  websocket = websocket
+                }
 
-      WebSocket.readDataMessages channel $ \message ->
-        handleCommand agent (WSS.command message)
+        WebSocket.readDataMessages channel $ \message ->
+          handleCommand agent (WSS.command message)
   where
     host = Config.host cachixOptions
     basename = URI.getHostname host
-    agentName = AgentOptions.name agentOpts
-    profileName = fromMaybe "system" (AgentOptions.profile agentOpts)
+    agentName = CLI.name agentOptions
+    profileName = fromMaybe "system" (CLI.profile agentOptions)
 
     logAndExitWithFailure withLog e = do
       void $ withLog $ K.logLocM K.ErrorS $ K.ls (displayException e)
@@ -118,13 +128,25 @@ run cachixOptions agentOpts =
           environment = "production"
         }
 
-registerAgent :: Agent -> WSS.AgentInformation -> K.KatipContextT IO ()
-registerAgent Agent {agentState} agentInformation = do
-  K.logLocM K.InfoS "Agent registered."
-  liftIO $ atomicWriteIORef agentState (Just agentInformation)
+lockFilename :: Text -> FilePath
+lockFilename profileName = "agent-" <> toS profileName
+
+-- | Acquire a lock on the profile for this agent. Skip this step if we're bootstrapping the agent.
+withLockedProfile :: CLI.AgentOptions -> Text -> IO () -> IO ()
+withLockedProfile CLI.AgentOptions {bootstrap = True} _ action = action
+withLockedProfile _ profileName action = do
+  lock <- Lock.withTryLock (lockFilename profileName) action
+  case lock of
+    Nothing -> throwIO (ProfileLocked profileName)
+    _ -> pure ()
+
+registerAgent :: Agent -> WSS.AgentInformation -> IO ()
+registerAgent Agent {agentState, withLog} agentInformation = do
+  withLog $ K.logLocM K.InfoS "Agent registered."
+  atomicWriteIORef agentState (Just agentInformation)
 
 launchDeployment :: Agent -> WSS.DeploymentDetails -> IO ()
-launchDeployment Agent {agentState, name, token, profileName, host, logOptions} deploymentDetails = do
+launchDeployment agent@Agent {..} deploymentDetails = do
   agentRegistered <- readIORef agentState
 
   case agentRegistered of
@@ -133,22 +155,55 @@ launchDeployment Agent {agentState, name, token, profileName, host, logOptions} 
     Nothing -> pure ()
     Just agentInformation -> do
       binDir <- toS <$> getBinDir
-      StdinProcess.spawnProcess (binDir <> "/.cachix-deployment") [] $
-        toS . Aeson.encode $
-          Deployment.Deployment
-            { Deployment.agentName = name,
-              Deployment.agentToken = token,
-              Deployment.profileName = profileName,
-              Deployment.host = host,
-              Deployment.deploymentDetails = deploymentDetails,
-              Deployment.agentInformation = agentInformation,
-              Deployment.logOptions = logOptions
-            }
+      exitCode <-
+        StdinProcess.spawnProcess (binDir <> "/.cachix-deployment") [] $
+          toS . Aeson.encode $
+            Deployment.Deployment
+              { Deployment.agentName = name,
+                Deployment.agentToken = token,
+                Deployment.profileName = profileName,
+                Deployment.host = host,
+                Deployment.deploymentDetails = deploymentDetails,
+                Deployment.agentInformation = agentInformation,
+                Deployment.logOptions = logOptions
+              }
+
+      case exitCode of
+        ExitSuccess
+          | bootstrap ->
+            verifyBootstrapSuccess agent
+        _ -> pure ()
+
+verifyBootstrapSuccess :: Agent -> IO ()
+verifyBootstrapSuccess Agent {profileName, withLog} = do
+  withLog $ K.logLocM K.InfoS $ K.ls $ unwords ["Waiting for another agent to take over", profileName, "..."]
+
+  lockDirectory <- Lock.getLockDirectory
+  eProcessName <-
+    Safe.tryIO $
+      Retry.recoverAll
+        (Retry.limitRetries 30 <> Retry.constantDelay 1000)
+        (const $ getProcessName lockDirectory)
+
+  case eProcessName of
+    Right (pid, "cachix") -> do
+      withLog $ K.logLocM K.InfoS $ K.ls $ unwords ["Found an active agent for", profileName, "with PID", show pid]
+      exitSuccess
+    _ -> pure ()
+  where
+    getProcessName :: FilePath -> IO (Posix.CPid, Text)
+    getProcessName lockDirectory = do
+      mpid <- readMaybe <$> readFile (lockDirectory </> lockFilename profileName <.> "pid")
+      case mpid of
+        Nothing -> throwString "No PID"
+        Just pid -> do
+          processName <- Process.readProcess "ps" ["--quick-pid", show pid, "-o", "comm", "--no-headers"] []
+          pure (pid, Text.strip $ toS processName)
 
 handleCommand :: Agent -> WSS.BackendCommand -> IO ()
-handleCommand agent@Agent {withLog} command =
+handleCommand agent command =
   case command of
-    WSS.AgentRegistered agentInformation -> withLog $ registerAgent agent agentInformation
+    WSS.AgentRegistered agentInformation -> registerAgent agent agentInformation
     WSS.Deployment deploymentDetails -> launchDeployment agent deploymentDetails
 
 -- | Asynchronously open and maintain a websocket connection to the backend for
@@ -187,7 +242,9 @@ checkUserOwnsHome = do
         }
 
 data Error
-  = -- | No home directory.
+  = -- | The target profile is already locked by another agent.
+    ProfileLocked Text
+  | -- | No home directory.
     NoHomeFound
   | -- | Safeguard against creating root-owned files in user directories.
     -- This is an issue on macOS, where, by default, sudo does not reset $HOME.
@@ -199,11 +256,13 @@ data Error
   deriving (Show)
 
 instance Exception Error where
-  displayException NoHomeFound = "Could not find the user’s home directory. Make sure to set the $HOME variable."
-  displayException UserDoesNotOwnHome {userName = userName, sudoUser = sudoUser, home = home} =
-    if isJust sudoUser
-      then toS $ unlines [warningMessage, suggestSudoFlagH]
-      else toS warningMessage
-    where
-      warningMessage = "The current user (" <> toS userName <> ") does not own the home directory (" <> toS home <> ")"
-      suggestSudoFlagH = "Try running the agent with `sudo -H`."
+  displayException = \case
+    ProfileLocked profileName -> toS $ unwords ["The profile", "\"" <> profileName <> "\"", "is already being managed by another Cachix Agent"]
+    NoHomeFound -> "Could not find the user’s home directory. Make sure to set the $HOME variable."
+    UserDoesNotOwnHome {userName = userName, sudoUser = sudoUser, home = home} ->
+      if isJust sudoUser
+        then toS $ unlines [warningMessage, suggestSudoFlagH]
+        else toS warningMessage
+      where
+        warningMessage = "The current user (" <> toS userName <> ") does not own the home directory (" <> toS home <> ")"
+        suggestSudoFlagH = "Try running the agent with `sudo -H`."

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Cachix.Deploy.Agent where
 

--- a/cachix/src/Cachix/Deploy/Deployment.hs
+++ b/cachix/src/Cachix/Deploy/Deployment.hs
@@ -1,0 +1,21 @@
+module Cachix.Deploy.Deployment where
+
+import qualified Cachix.API.WebSocketSubprotocol as WSS
+import Cachix.Client.URI as Cachix
+import qualified Cachix.Deploy.Log as Log
+import qualified Data.Aeson as Aeson
+import Protolude
+
+-- | Everything required for the standalone deployment binary to complete a
+-- deployment.
+data Deployment = Deployment
+  { agentName :: Text,
+    agentToken :: Text,
+    profileName :: Text,
+    agentInformation :: WSS.AgentInformation,
+    deploymentDetails :: WSS.DeploymentDetails,
+    host :: Cachix.URI,
+    logOptions :: Log.Options
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass (Aeson.ToJSON, Aeson.FromJSON)

--- a/cachix/src/Cachix/Deploy/Lock.hs
+++ b/cachix/src/Cachix/Deploy/Lock.hs
@@ -1,6 +1,7 @@
 module Cachix.Deploy.Lock
   ( defaultLockDirectory,
     getLockDirectory,
+    readPidFile,
     withTryLock,
   )
 where
@@ -11,6 +12,12 @@ import qualified System.Directory as Directory
 import System.FilePath ((<.>), (</>))
 import System.Posix (getProcessID)
 import System.Posix.Types (CPid (..))
+
+lockExtension :: FilePath
+lockExtension = "lock"
+
+pidExtension :: FilePath
+pidExtension = "pid"
 
 defaultLockDirectory :: FilePath
 defaultLockDirectory = "cachix" </> "deploy" </> "locks"
@@ -29,6 +36,12 @@ getLockDirectory = do
 
   pure lockDirectory
 
+readPidFile :: FilePath -> IO (Maybe CPid)
+readPidFile pidFilename = do
+  lockDirectory <- getLockDirectory
+  pidContents <- readFile (lockDirectory </> pidFilename <.> pidExtension)
+  pure (readMaybe pidContents)
+
 -- | Run an IO action with an acquired profile lock. Returns immediately if the profile is already locked.
 --
 -- Lock files are not deleted after use.
@@ -38,8 +51,8 @@ withTryLock :: FilePath -> IO a -> IO (Maybe a)
 withTryLock lockFilename action = do
   lockDirectory <- getLockDirectory
 
-  let lockFile = lockDirectory </> lockFilename <.> "lock"
-  let pidFile = lockDirectory </> lockFilename <.> "pid"
+  let lockFile = lockDirectory </> lockFilename <.> lockExtension
+  let pidFile = lockDirectory </> lockFilename <.> pidExtension
 
   bracket
     (Lock.fdOpen lockFile)

--- a/cachix/src/Cachix/Deploy/Log.hs
+++ b/cachix/src/Cachix/Deploy/Log.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Cachix.Deploy.Log where
 

--- a/cachix/src/Cachix/Deploy/OptionsParser.hs
+++ b/cachix/src/Cachix/Deploy/OptionsParser.hs
@@ -27,7 +27,8 @@ parser =
 
 data AgentOptions = AgentOptions
   { name :: Text,
-    profile :: Maybe Text
+    profile :: Maybe Text,
+    bootstrap :: Bool
   }
   deriving (Show)
 
@@ -50,6 +51,7 @@ parserAgentOptions =
               <> help "Nix profile to manage. Defaults to 'system' on NixOS, 'system-profiles/system' (nix-darwin) on macOS, and 'home-manager' for Home Manager."
           )
       )
+    <*> switch (long "bootstrap" <> help "Exit once the system agent takes over.")
 
 parserActivateOptions :: Parser ActivateOptions
 parserActivateOptions =

--- a/cachix/src/Cachix/Deploy/StdinProcess.hs
+++ b/cachix/src/Cachix/Deploy/StdinProcess.hs
@@ -6,9 +6,9 @@ import System.Process
 import Prelude (String)
 
 -- | Spawn a process with only stdin as an input
-spawnProcess :: FilePath -> [String] -> String -> IO ()
+spawnProcess :: FilePath -> [String] -> String -> IO ExitCode
 spawnProcess cmd args input = do
-  (Just stdin, _, _, _) <-
+  (Just stdin, _, _, pHandle) <-
     createProcess
       (proc cmd args)
         { std_in = CreatePipe,
@@ -17,5 +17,8 @@ spawnProcess cmd args input = do
           -- Same, but with posix api
           new_session = True
         }
+
   hPutStr stdin input
   hClose stdin
+
+  waitForProcess pHandle

--- a/cachix/src/Cachix/Deploy/StdinProcess.hs
+++ b/cachix/src/Cachix/Deploy/StdinProcess.hs
@@ -5,9 +5,9 @@ import System.IO (hClose)
 import System.Process
 import Prelude (String)
 
--- | Spawn a process with only stdin as an input
-spawnProcess :: FilePath -> [String] -> String -> IO ExitCode
-spawnProcess cmd args input = do
+-- | Run a process with only stdin as an input
+readProcess :: FilePath -> [String] -> String -> IO ExitCode
+readProcess cmd args input = do
   (Just stdin, _, _, pHandle) <-
     createProcess
       (proc cmd args)

--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -102,7 +102,7 @@ readDataMessages channel action = loop
       read channel >>= \case
         Just (DataMessage message) -> action message *> loop
         Just (ControlMessage (WS.Close _ _)) -> pure ()
-        Just _ -> loop
+        Just (ControlMessage _) -> loop
         Nothing -> pure ()
 
 -- | Close the outgoing queue.


### PR DESCRIPTION
Resolves #455.

I'll need to thoroughly look over this tomorrow, but I'd love some feedback!

The main additions are:

* The agent now acquires a lock on the profile that it's managing. This uses the same lock design as the deployment binary.
* The agent writes its PID to the same directory as the lock file.
* The new `--bootstrap` mode runs deployments until it detects another Cachix Deploy agent managing the same profile. In this mode,  the agent does not acquire a lock on the profile. We poll the PID file to find the newly spawned agent and double check that the process name is correct. Perhaps we can skip the process name check and just see if the lock file is locked?

#### Sample log output
```
[2022-10-18 02:42:06][agent.agent][Debug][agent-1][PID 875][ThreadId 8][cachix-1.0.1-5LusKggLrbP2kqeM106WV9:Cachix.Deploy.Websocket src/Cachix/Deploy/Websocket.hs:257:13] Received close request from peer (Peer initiated a close request). Closing connection
[2022-10-18 02:42:06][agent.agent][Info][agent-1][PID 868][ThreadId 4][cachix-1.0.1-5LusKggLrbP2kqeM106WV9:Cachix.Deploy.Agent src/Cachix/Deploy/Agent.hs:186:13] Waiting for another agent to take over the system profile...
[2022-10-18 02:42:06][agent.agent][Info][agent-1][PID 868][ThreadId 4][cachix-1.0.1-5LusKggLrbP2kqeM106WV9:Cachix.Deploy.Agent src/Cachix/Deploy/Agent.hs:197:17] Found an active agent for the system profile with PID 1045. Exiting.
```

#### Alternatives

I tried out a few other options before settling on the PID approach.

1. **`pgrep` with regex matching to find the profile in the arguments.** The main downside is that it ties the bootstrapping logic to the CLI design. I'm worried we might change the CLI and forget to update the regex. Also, it's regex 🤮.
2. **`ps`.** We have to extract and re-parse the command line arguments. This is better than `pgrep` because we can reuse our `OptionsParser` and avoid regex, but we still end up tied to the CLI.
3. **Manually reading proc files.** This isn't cross-platform, so it's best to stick with `ps`.