### PR TITLE
Remove trailing slashes from BaseUrls

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -216,4 +216,5 @@ test-suite cachix-test
     , hspec
     , protolude
     , servant-auth-client
+    , servant-client-core
     , temporary

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -122,7 +122,7 @@ use env name useOptions = do
       -- TODO: is checking for the existence of the config file the right thing to do here?
       | isErr err status401 && isJust optionalAuthToken -> throwM $ accessDeniedBinaryCache name
       | isErr err status401 -> throwM $ notAuthenticatedBinaryCache name
-      | isErr err status404 -> throwM $ BinaryCacheNotFound $ "Binary cache" <> name <> " does not exist."
+      | isErr err status404 -> throwM $ BinaryCacheNotFound $ "Binary cache " <> name <> " does not exist."
       | otherwise -> throwM err
     Right binaryCache -> do
       () <- escalateAs UnsupportedNixVersion =<< assertNixVersion

--- a/cachix/test/URISpec.hs
+++ b/cachix/test/URISpec.hs
@@ -2,11 +2,13 @@ module URISpec where
 
 import qualified Cachix.Client.URI as URI
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy as BL
 import Data.Either.Extra
 import qualified Dhall
 import qualified Dhall.Core
 import Protolude
+import qualified Servant.Client.Core as Servant
 import Test.Hspec
 
 secureScheme :: ByteString
@@ -77,3 +79,9 @@ spec =
 
     it "converts from Dhall" $
       Dhall.input Dhall.auto ("\"" <> decodeUtf8 secureUri <> "\"") `shouldReturn` parseURI' secureUri
+
+    -- https://github.com/cachix/cachix/issues/462
+    it "converts to a Servant BaseUrl without trailing slashes" $
+      let uriWithTrailingSlash = secureUri <> "/"
+          uri = parseURI' uriWithTrailingSlash
+       in Servant.baseUrlPath (URI.getBaseUrl uri) `shouldBe` ""


### PR DESCRIPTION
Servant doesn't seem to normalize URIs and is very happy to double up slashes when the hostname has a trailing slash.

Resolves #462