### PR TITLE
Allow creating WebSocket state before connecting

### DIFF
--- a/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
+++ b/cachix-api/src/Cachix/API/WebSocketSubprotocol.hs
@@ -51,14 +51,11 @@ data AgentCommand
   deriving (Show, Eq, Generic, Aeson.FromJSON, Aeson.ToJSON)
 
 parseMessage :: Aeson.FromJSON cmd => ByteString -> Either Text (Message cmd)
-parseMessage body =
-  case Aeson.eitherDecodeStrict' body of
-    Left err -> Left $ toS err
-    Right message -> Right message
+parseMessage = first toS . Aeson.eitherDecodeStrict'
 
 sendMessage :: Aeson.ToJSON cmd => WS.Connection -> Message cmd -> IO ()
 sendMessage connection cmd =
-  WS.sendTextData connection $ Aeson.encode cmd
+  WS.sendTextData connection (Aeson.encode cmd)
 
 -- | Receive and process messages in parallel.
 --

--- a/cachix/src/Cachix/Deploy/Agent.hs
+++ b/cachix/src/Cachix/Deploy/Agent.hs
@@ -73,8 +73,9 @@ run cachixOptions agentOpts =
                 WebSocket.identifier = agentIdentifier agentName
               }
 
-      WebSocket.withConnection withLog websocketOptions $ \websocket -> do
-        channel <- WebSocket.receive websocket
+      websocket <- WebSocket.new withLog websocketOptions
+      channel <- WebSocket.receive websocket
+      WebSocket.runConnection websocket $
         WebSocket.handleJSONMessages @(WSS.Message WSS.AgentCommand) @(WSS.Message WSS.BackendCommand) websocket $
           WebSocket.readDataMessages channel $ \message ->
             handleMessage withLog agentState agentName agentToken message


### PR DESCRIPTION
This is a minor improvement that lets you access the WebSocket record before making the connection. This turns out to be quite useful for setting up the WebSocket in a multi-threaded environment, where you'd want to set up the incoming message listeners before running the socket in a separate thread.