### PR TITLE
activate: allow filtering what agent to deploy

### DIFF
--- a/cachix/src/Cachix/Deploy/OptionsParser.hs
+++ b/cachix/src/Cachix/Deploy/OptionsParser.hs
@@ -32,7 +32,8 @@ data AgentOptions = AgentOptions
   deriving (Show)
 
 data ActivateOptions = ActivateOptions
-  { payloadPath :: FilePath
+  { payloadPath :: FilePath,
+    agents :: [Text]
   }
   deriving (Show)
 
@@ -56,4 +57,12 @@ parserActivateOptions =
     <$> strArgument
       ( metavar "DEPLOY-SPEC.JSON"
           <> help "https://docs.cachix.org/deploy/reference.html#deploy-json"
+      )
+    <*> many
+      ( strOption
+          ( long "agent"
+              <> short 'a'
+              <> metavar "AGENT-NAME"
+              <> help "Deploy only specific agent(s)."
+          )
       )


### PR DESCRIPTION
Fixes #408 

cc @lovesegfault

Allows one to deploy only a specific agent(s) via `cachix deploy activate --agent name spec.json`.