### PR TITLE
Add initial support for Home Manager

### DIFF
--- a/cachix/src/Cachix/Client/PushQueue.hs
+++ b/cachix/src/Cachix/Client/PushQueue.hs
@@ -127,7 +127,7 @@ exitOnceQueueIsEmpty stopProducerCallback pushWorker queryWorker queryWorkerStat
           cancelWith pushWorker StopWorker
         else do
           -- extend shutdown for another 90s
-          void $ Systemd.notify False $ "EXTEND_TIMEOUT_USEC=" <> show (90 * 1000 * 1000)
+          void $ Systemd.notify False $ "EXTEND_TIMEOUT_USEC=" <> show (90 * 1000 * 1000 :: Int)
           putTextError $ "Waiting to finish: " <> show inprogress <> " pushing, " <> show queueLength <> " in queue"
           threadDelay (1000 * 1000)
           go

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -117,9 +117,10 @@ type Command = (String, [String])
 
 getActivationScript :: Text -> FilePath -> IO (FilePath, [Command])
 getActivationScript profile storePath = do
-  isNixOS <- Directory.doesPathExist $ toS storePath </> "nixos-version"
-  isNixDarwin <- Directory.doesPathExist $ toS storePath </> "darwin-version"
-  isHomeManager <- Directory.doesPathExist $ toS storePath </> "hm-version"
+  let checkPath p = Directory.doesPathExist $ toS storePath </> p
+  isNixOS <- checkPath "nixos-version"
+  isNixDarwin <- checkPath "darwin-version"
+  isHomeManager <- checkPath "hm-version"
   user <- InstallationMode.getUser
   let systemProfileDir = "/nix/var/nix/profiles"
   let perUserProfileDir = systemProfileDir </> "per-user" </> toS user

--- a/cachix/src/Cachix/Deploy/OptionsParser.hs
+++ b/cachix/src/Cachix/Deploy/OptionsParser.hs
@@ -47,7 +47,7 @@ parserAgentOptions =
     <*> optional
       ( strArgument
           ( metavar "NIX-PROFILE"
-              <> help "Nix profile to manage. Defaults to 'system' on NixOS and 'system-profiles/system' (nix-darwin) on macOS."
+              <> help "Nix profile to manage. Defaults to 'system' on NixOS, 'system-profiles/system' (nix-darwin) on macOS, and 'home-manager' for Home Manager."
           )
       )
 


### PR DESCRIPTION
This makes it possible to deploy standalone Home Manager configurations. Should work for any GNU/Linux distro on which Home Manager works.

Note, not fit for merge yet:

- [x] Test on a few GNU/Linux distros.
    - [x] Debian
    - [x] Ubuntu
    - [x] Fedora
- [x] Try out rollbacks.
- [x] Verify that NixOS deploys still work. Note, I don't have access to any macOS system so cannot verify nix-darwin deploys, but I imagine if NixOS still works then nix-darwin should as well?
- [x] Record brief demo screencast. See [Cachix demo on Ubuntu](https://walnut.rycee.net/cachix-demo.webm); sorry about the length and oddities in a few places.

Fixes #422