### PR TITLE
[#205] Add zstd compression to the binary cache

### DIFF
--- a/cachix-api/src/Cachix/Types/BinaryCache.hs
+++ b/cachix-api/src/Cachix/Types/BinaryCache.hs
@@ -11,6 +11,10 @@ data BinaryCache = BinaryCache
     isPublic :: Bool,
     publicSigningKeys :: [Text],
     githubUsername :: Text,
-    permission :: Permission
+    permission :: Permission,
+    compression :: CompressionMode
   }
+  deriving (Show, Generic, FromJSON, ToJSON, ToSchema, NFData)
+
+data CompressionMode = XZ | ZSTD
   deriving (Show, Generic, FromJSON, ToJSON, ToSchema, NFData)

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -89,6 +89,7 @@ library
     , concurrent-extra
     , conduit                 >=1.3.0
     , conduit-extra
+    , conduit-zstd
     , containers
     , cookie
     , cryptonite


### PR DESCRIPTION
Problem: xz don't have sufficient transfer speed of binary cache

Solution: add zstd as another compression option to the push strategy

Fixes #205 