### PR TITLE
Fix a bunch of WebSocket-related Cachix Deploy issues

### DIFF
--- a/cachix/src/Cachix/Deploy/Websocket.hs
+++ b/cachix/src/Cachix/Deploy/Websocket.hs
@@ -92,16 +92,12 @@ read :: Receive rx -> IO (Maybe (Message rx))
 read = atomically . TMChan.readTMChan
 
 -- | Read incoming data messages, ignoring everything else.
---
--- Stops reading when either a close request is received or the channel is
--- closed.
 readDataMessages :: Receive rx -> (rx -> IO ()) -> IO ()
 readDataMessages channel action = loop
   where
     loop =
       read channel >>= \case
         Just (DataMessage message) -> action message *> loop
-        Just (ControlMessage (WS.Close _ _)) -> pure ()
         Just (ControlMessage _) -> loop
         Nothing -> pure ()
 


### PR DESCRIPTION
The agent shouldn't exit after this + https://github.com/NixOS/nixpkgs/pull/207960 is the fallback in case it does.

* Simplify how we block when waiting for the websocket initial connection. This also addresses an issue where the agent might have trouble re-connecting to the service.
* Ignore close requests when handling data messages in the agent. The websocket thread deals with these on its own and will restart if necessary.
* Prevent the agent from irreversibly shutting down the socket after receiving a close request. Most close requests are recoverable and should trigger re-connection.