### PR TITLE
Unblock interrupt signals on darwin

### DIFF
--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -37,6 +37,7 @@ import Cachix.Client.Servant
 import qualified Cachix.Client.WatchStore as WatchStore
 import qualified Cachix.Types.BinaryCache as BinaryCache
 import qualified Cachix.Types.SigningKeyCreate as SigningKeyCreate
+import qualified Control.Concurrent.Async as Async
 import Control.Exception.Safe (throwM)
 import Control.Retry (RetryStatus (rsIterNumber))
 import Crypto.Sign.Ed25519 (PublicKey (PublicKey), createKeypair)
@@ -55,7 +56,6 @@ import Servant.Client.Streaming
 import Servant.Conduit ()
 import System.Directory (doesFileExist)
 import System.IO (hIsTerminalDevice)
-import qualified System.Posix.Signals as Signals
 import qualified System.Process
 
 -- TODO: check that token actually authenticates!
@@ -186,19 +186,29 @@ watchExec env pushOpts name cmd args = withPushParams env pushOpts name $ \pushP
   stdoutOriginal <- hDuplicate stdout
   let process =
         (System.Process.proc (toS cmd) (toS <$> args))
-          { System.Process.std_out = System.Process.UseHandle stdoutOriginal,
-            -- Interrupt the command first
-            System.Process.delegate_ctlc = True
+          { System.Process.std_out = System.Process.UseHandle stdoutOriginal
           }
       watch = do
         hDuplicateTo stderr stdout -- redirect all stdout to stderr
         WatchStore.startWorkers (pushParamsStore pushParams) (numJobs pushOpts) pushParams
-  (_, exitCode) <- concurrently watch $ do
-    (_, _, _, processHandle) <- System.Process.createProcess process
-    exitCode <- System.Process.waitForProcess processHandle
-    Signals.raiseSignal Signals.sigINT
-    return exitCode
-  exitWith exitCode
+
+  Async.withAsync watch $ \watchThread ->
+    bracketOnError
+      (getProcessHandle <$> System.Process.createProcess process)
+      ( \processHandle -> do
+          -- Terminate the process
+          uninterruptibleMask_ (System.Process.terminateProcess processHandle)
+          -- Wait for the process to clean up and exit
+          _ <- System.Process.waitForProcess processHandle
+          -- Stop watching the store and wait for all paths to be pushed
+          Async.cancel watchThread
+      )
+      $ \processHandle -> do
+        exitCode <- System.Process.waitForProcess processHandle
+        Async.cancel watchThread
+        exitWith exitCode
+  where
+    getProcessHandle (_, _, _, processHandle) = processHandle
 
 retryText :: RetryStatus -> Text
 retryText retrystatus =

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -184,7 +184,12 @@ watchStore env opts name = do
 watchExec :: Env -> PushOptions -> Text -> Text -> [Text] -> IO ()
 watchExec env pushOpts name cmd args = withPushParams env pushOpts name $ \pushParams -> do
   stdoutOriginal <- hDuplicate stdout
-  let process = (System.Process.proc (toS cmd) (toS <$> args)) {System.Process.std_out = System.Process.UseHandle stdoutOriginal}
+  let process =
+        (System.Process.proc (toS cmd) (toS <$> args))
+          { System.Process.std_out = System.Process.UseHandle stdoutOriginal,
+            -- Interrupt the command first
+            System.Process.delegate_ctlc = True
+          }
       watch = do
         hDuplicateTo stderr stdout -- redirect all stdout to stderr
         WatchStore.startWorkers (pushParamsStore pushParams) (numJobs pushOpts) pushParams

--- a/cachix/src/Cachix/Client/Env.hs
+++ b/cachix/src/Cachix/Client/Env.hs
@@ -12,7 +12,7 @@ import qualified Cachix.Client.OptionsParser as Options
 import Cachix.Client.URI (getBaseUrl)
 import Cachix.Client.Version (cachixVersion)
 import qualified Hercules.CNix as CNix
-import Hercules.CNix.Store (Store, openStore)
+import qualified Hercules.CNix.Util as CNix.Util
 import Network.HTTP.Client
   ( ManagerSettings,
     managerModifyRequest,
@@ -25,6 +25,7 @@ import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Client.Streaming (ClientEnv, mkClientEnv)
 import System.Directory (canonicalizePath)
+import System.Posix.Signals (getSignalMask, setSignalMask)
 
 data Env = Env
   { cachixoptions :: Config.CachixOptions,
@@ -34,7 +35,17 @@ data Env = Env
 
 mkEnv :: Options.Flags -> IO Env
 mkEnv flags = do
+  signalset <- getSignalMask
+  -- Initialize the Nix library
   CNix.init
+
+  -- darwin: restore the signal mask modified by Nix
+  -- https://github.com/cachix/cachix/issues/501
+  setSignalMask signalset
+
+  -- Interrupt Nix before throwing UserInterrupt
+  CNix.Util.installDefaultSigINTHandler
+
   -- make sure path to the config is passed as absolute to dhall logic
   canonicalConfigPath <- canonicalizePath (Options.configPath flags)
   cfg <- Config.getConfig canonicalConfigPath


### PR DESCRIPTION
- Restore signal handling on darwin after initializing the Nix library. Resolves #501.

- Replace the `watch-store/watch-exec` signal handler with regular error handling. This way we
  don't interfere with the CNix interrupt handler.

- Terminate the subprocess started by watch-exec on exceptions. Resolves #358.