### PR TITLE
flake.nix: Expose haskell packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,22 +22,27 @@
     forAllSystems = f: builtins.listToAttrs (map (name: { inherit name; value = f name; }) systems);
 
     # Try to use the same Nix version as cnix-store, if available.
-    getNix = pkgs:
-      pkgs.haskellPackages.hercules-ci-cnix-store.passthru.nixPackage
+    getNix = { pkgs, haskellPackages ? pkgs.haskellPackages }:
+      haskellPackages.hercules-ci-cnix-store.nixPackage
         or pkgs.nixVersions.nix_2_9;
+
+    customHaskellPackages = { pkgs, haskellPackages }: rec {
+      cachix-api = haskellPackages.callCabal2nix "cachix-api" ./cachix-api {};
+      cachix = haskellPackages.callCabal2nix "cachix" ./cachix {
+        inherit cachix-api;
+        fsnotify = haskellPackages.fsnotify_0_4_1_0;
+        hnix-store-core = haskellPackages.callCabal2nix "hnix-store-core" "${hnix-store-core}/hnix-store-core" {};
+        nix = getNix { inherit pkgs haskellPackages; };
+      };
+    };
+
   in
     {
       packages = forAllSystems (system: 
         let
           pkgs = import nixpkgs { inherit system; };
-
-          cachix-api = pkgs.haskellPackages.callCabal2nix "cachix-api" ./cachix-api {};
-          cachix = pkgs.haskellPackages.callCabal2nix "cachix" ./cachix {
-            inherit cachix-api;
-            fsnotify = pkgs.haskellPackages.fsnotify_0_4_1_0;
-            hnix-store-core = pkgs.haskellPackages.callCabal2nix "hnix-store-core" "${hnix-store-core}/hnix-store-core" {};
-            nix = getNix pkgs;
-          };
+          inherit (customHaskellPackages { inherit pkgs; inherit (pkgs) haskellPackages; })
+            cachix;
         in
         {
           cachix = pkgs.haskell.lib.justStaticExecutables cachix;
@@ -60,7 +65,7 @@
               pkgs.libsodium
               # sync with stack.yaml LTS
               pkgs.haskell.compiler.ghc925
-              (getNix pkgs)
+              (getNix { inherit pkgs; })
             ];
 
             pre-commit.hooks = {
@@ -73,5 +78,11 @@
         }];
         }
       );
+
+      lib = {
+        # Let downstream haskell packages such as hercules-ci-agent use the
+        # overrides we declare in their CI.
+        inherit customHaskellPackages;
+      };
     };
 }


### PR DESCRIPTION
Let downstream haskell packages use the overrides declared in `flake.nix`.

I will use this to set up a CI build for hercules-ci-agent with the latest cachix, so that compatibility issues like https://github.com/NixOS/nixpkgs/pull/219849#issuecomment-1456462191 can be resolved sooner, not blocking your releases.