### PR TITLE
Fix `watch-exec` and `watch-store` cleanup

### DIFF
--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -202,7 +202,10 @@ watchExec env pushOpts name cmd args = withPushParams env pushOpts name $ \pushP
         hDuplicateTo stderr stdout -- redirect all stdout to stderr
         WatchStore.startWorkers (pushParamsStore pushParams) (numJobs pushOpts) pushParams
 
-  Async.withAsync watch $ \_ -> do
+  Async.withAsync watch $ \watchThread -> do
+    -- Throw any errors encountered by the workers
+    Async.link watchThread
+
     exitCode <-
       bracketOnError
         (getProcessHandle <$> System.Process.createProcess process)


### PR DESCRIPTION
Revert back to using signals to trigger graceful shutdown when using `watch-exec` or `watch-store`.  Async immediately cancels all awaited threads, making it a chore to implement any cleanup that requires the threads to keep running during cleanup.