### PR TITLE
Re-enable optimizations for servant routes

### DIFF
--- a/cachix/src/Cachix/Client/Servant.hs
+++ b/cachix/src/Cachix/Client/Servant.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# OPTIONS_GHC -O0 #-}
-
--- TODO https://github.com/haskell-servant/servant/issues/986
 
 module Cachix.Client.Servant
   ( isErr,


### PR DESCRIPTION
This workaround is no longer needed.