### PR TITLE
Open new store connection for each push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,5 @@ jobs:
     - run:  nix build -L '.#ci' '.#cachix' --show-trace
     # make sure it's all uploaded to cachix
     - run: echo > /tmp/store-path-pre-build
+    # test watch-exec
+    - run: cachix watch-exec cachix -- nix-build genpaths.nix --substituters 'https://cache.nixos.org'

--- a/cachix/src/Cachix/Client/PushQueue.hs
+++ b/cachix/src/Cachix/Client/PushQueue.hs
@@ -44,7 +44,7 @@ worker pushParams workerState = forever $ do
   bracket_ (inProgressModify (+ 1)) (inProgressModify (\x -> x - 1)) $
     retryAll $
       \retrystatus -> do
-        Push.uploadStorePath pushParams storePath retrystatus
+        Push.uploadStorePath Nothing pushParams storePath retrystatus
   where
     inProgressModify f =
       atomically $ modifyTVar' (inProgress workerState) f
@@ -96,7 +96,7 @@ queryLoop workerState pushqueue pushParams = do
       if isEmpty
         then return S.empty
         else return $ alreadyQueued workerState
-    missingStorePaths <- Push.getMissingPathsForClosure pushParams storePaths
+    missingStorePaths <- Push.getMissingPathsForClosure Nothing pushParams storePaths
     let missingStorePathsSet = S.fromList missingStorePaths
         uncachedMissingStorePaths = S.difference missingStorePathsSet alreadyQueuedSet
     atomically $ for_ uncachedMissingStorePaths $ TBQueue.writeTBQueue pushqueue

--- a/cachix/src/Cachix/Client/WatchStore.hs
+++ b/cachix/src/Cachix/Client/WatchStore.hs
@@ -11,13 +11,13 @@ import Protolude
 import System.FSNotify
 import qualified System.Systemd.Daemon as Systemd
 
-startWorkers :: Store.Store -> Int -> PushParams IO () -> IO ()
-startWorkers store numWorkers pushParams = do
+startWorkers :: Int -> PushParams IO () -> IO ()
+startWorkers numWorkers pushParams = do
   void Systemd.notifyReady
-  withManager $ \mgr -> PushQueue.startWorkers numWorkers (producer store mgr) pushParams
+  withManager $ \mgr -> PushQueue.startWorkers numWorkers (producer mgr) pushParams
 
-producer :: Store.Store -> WatchManager -> PushQueue.Queue -> IO (IO ())
-producer _ mgr queue = do
+producer :: WatchManager -> PushQueue.Queue -> IO (IO ())
+producer mgr queue = do
   putTextError "Watching /nix/store for new store paths ..."
   watchDir mgr "/nix/store" filterOnlyStorePaths (queueStorePathAction queue)
 

--- a/genpaths.nix
+++ b/genpaths.nix
@@ -1,0 +1,16 @@
+# Realizes <num>> of derivations with size of <size>MB
+# Useful for upload debugging 
+{ size ? 1 # MB
+, num ? 10 # count 
+, currentTime ? builtins.currentTime
+}:
+
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz") {});
+
+let
+  drv = i: runCommand "${toString currentTime}-${toString i}" {} ''
+    dd if=/dev/random of=$out bs=1MB count=${toString size}
+  '';
+in writeText "empty-${toString num}-${toString size}MB" ''
+  ${lib.concatMapStringsSep "" drv (lib.range 1 num)}
+''


### PR DESCRIPTION
This commit introduces a change to open a new connection to the store for each push operation. Previously, a single connection was opened at the beginning of a Cachix invocation, leading to issues when reading the SQLite database in immutable mode.

For instance, long-running commands like watch-* would not recognize new valid paths, as the database would not contain the new entries.

To address this issue, we now open a new database connection whenever the push logic is invoked.