### PR TITLE
Push: print what we're going to do when pushing

### DIFF
--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -301,8 +301,7 @@ pushStrategy store authToken opts name compressionMethod storePath =
             return $ liftIO . tickN progressBar . BS.length
           else do
             -- we append newline instead of putStrLn due to https://github.com/haskell/text/issues/242
-            let compression = T.toLower (show compressionMethod)
-            putStr $ retryText retryStatus <> "compressing using " <> compression <> " and pushing " <> path <> " (" <> toS hSize <> ")\n"
+            putStr $ retryText retryStatus <> "Pushing " <> path <> " (" <> toS hSize <> ")\n"
             return $ const pass
 
       Conduit.awaitForever $ \chunk -> do
@@ -328,6 +327,12 @@ withPushParams env pushOpts name m = do
         { pushParamsName = name,
           pushParamsSecret = pushSecret,
           pushParamsClientEnv = clientenv env,
+          pushOnClosureAttempt = \full missing -> do
+            unless (null missing) $ do
+              let numMissing = length missing
+                  numCached = length full - numMissing
+              putTextError $ "Pushing " <> show numMissing <> " paths (" <> show numCached <> " are already present) using " <> T.toLower (show compressionMethod) <> " to cache " <> name <> " ⏳\n"
+            return missing,
           pushParamsStrategy = pushStrategy store authToken pushOpts name compressionMethod,
           pushParamsStore = store
         }

--- a/cachix/src/Cachix/Client/PushQueue.hs
+++ b/cachix/src/Cachix/Client/PushQueue.hs
@@ -99,7 +99,7 @@ queryLoop workerState pushqueue pushParams = do
       if isEmpty
         then return S.empty
         else return $ alreadyQueued workerState
-    missingStorePaths <- Push.getMissingPathsForClosure pushParams storePaths
+    (missingStorePaths, _) <- Push.getMissingPathsForClosure pushParams storePaths
     let missingStorePathsSet = S.fromList missingStorePaths
         uncachedMissingStorePaths = S.difference missingStorePathsSet alreadyQueuedSet
     atomically $ for_ uncachedMissingStorePaths $ TBQueue.writeTBQueue pushqueue


### PR DESCRIPTION
Fixes #261 

```
Pushing 6 paths (2 are already present) using zstd to test cache ⏳

✓ /nix/store/mqhwv2b7mf6p165yrr0qp1vwknz86l8b-1687697576-5 (976.67 KiB)
✓ /nix/store/f7sdpi935zbhjq5pacdsnv8g802a6v4v-1687697576-3 (976.67 KiB)
✓ /nix/store/d05a6mlmkcfzwylkcz9d43rqri6sbpcw-1687697576-1 (976.67 KiB)
✓ /nix/store/i1mv9jb7vkkmpyagjyxz96lailbdzb81-1687697576-4 (976.67 KiB)
✓ /nix/store/9kfsxdhmpy6s6hwa5n7lqyzbnplmkzlj-empty-5-1MB (400.00 B)
✓ /nix/store/f583lm07zalryyc5a82y5a96xpnci6y7-1687697576-2 (976.67 KiB)

All done.
```