### PR TITLE
deploy: use the high-level activate script

### DIFF
--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -145,8 +145,7 @@ getActivationScript profile storePath = do
        in ( profilePath,
             [ ("mkdir", ["-p", "-m", "0755", "/nix/var/nix/profiles/system-profiles"]),
               setNewProfile profilePath,
-              (toS storePath </> "activate-user", []),
-              (toS storePath </> "activate", [])
+              (toS storePath </> "sw/bin/darwin-rebuild", ["activate"])
             ]
           )
     (_, _, True) ->


### PR DESCRIPTION
As warned on matrix, the low-level scripts are about to change.