### PR TITLE
Add a daemon mode to push store paths asynchronously

### DIFF
--- a/cachix-api/src/Cachix/Types/BinaryCache.hs
+++ b/cachix-api/src/Cachix/Types/BinaryCache.hs
@@ -6,6 +6,8 @@ import Data.Swagger (ToParamSchema (..), ToSchema)
 import Protolude
 import Servant.API
 
+type BinaryCacheName = Text
+
 data BinaryCache = BinaryCache
   { name :: Text,
     uri :: Text,

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -121,7 +121,6 @@ library
     , directory
     , ed25519
     , either
-    , exceptions
     , extra
     , filepath
     , fsnotify                >=0.4.1
@@ -161,7 +160,6 @@ library
     , text
     , time
     , unix
-    , unliftio-core
     , unordered-containers
     , uri-bytestring
     , uuid

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -67,8 +67,8 @@ library
     Cachix.Client.Config
     Cachix.Client.Config.Orphans
     Cachix.Client.Daemon
+    Cachix.Client.Daemon.Client
     Cachix.Client.Daemon.Listen
-    Cachix.Client.Daemon.Push
     Cachix.Client.Daemon.Types
     Cachix.Client.Env
     Cachix.Client.Exception

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -66,6 +66,10 @@ library
     Cachix.Client.Commands
     Cachix.Client.Config
     Cachix.Client.Config.Orphans
+    Cachix.Client.Daemon
+    Cachix.Client.Daemon.Listen
+    Cachix.Client.Daemon.Push
+    Cachix.Client.Daemon.Types
     Cachix.Client.Env
     Cachix.Client.Exception
     Cachix.Client.HumanSize
@@ -117,6 +121,7 @@ library
     , directory
     , ed25519
     , either
+    , exceptions
     , extra
     , filepath
     , fsnotify                >=0.4.1
@@ -127,12 +132,14 @@ library
     , http-client-tls
     , http-conduit
     , http-types
+    , immortal
     , katip
     , lukko
     , lzma-conduit
     , megaparsec              >=7.0.0
     , memory
     , netrc
+    , network
     , optparse-applicative
     , pretty-terminal
     , prettyprinter
@@ -154,6 +161,7 @@ library
     , text
     , time
     , unix
+    , unliftio-core
     , unordered-containers
     , uri-bytestring
     , uuid

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -5,8 +5,9 @@ where
 
 import Cachix.Client.Commands as Commands
 import qualified Cachix.Client.Config as Config
+import qualified Cachix.Client.Daemon as Daemon
 import Cachix.Client.Env (cachixoptions, mkEnv)
-import Cachix.Client.OptionsParser (CachixCommand (..), getOpts)
+import Cachix.Client.OptionsParser (CachixCommand (..), DaemonCommand (..), getOpts)
 import Cachix.Client.Version (cachixVersion)
 import Cachix.Deploy.ActivateCommand as ActivateCommand
 import qualified Cachix.Deploy.Agent as AgentCommand
@@ -22,6 +23,8 @@ main = displayConsoleRegions $ do
   case command of
     AuthToken token -> Commands.authtoken env token
     Config configCommand -> Config.run cachixOptions configCommand
+    Daemon (DaemonRun pushOptions daemonOptions) -> Daemon.run env pushOptions daemonOptions
+    Daemon (DaemonPushPaths cacheName storePaths) -> Daemon.push env cacheName storePaths
     GenerateKeypair name -> Commands.generateKeypair env name
     Push pushArgs -> Commands.push env pushArgs
     Pin pingArgs -> Commands.pin env pingArgs
@@ -30,7 +33,5 @@ main = displayConsoleRegions $ do
     Use name useOptions -> Commands.use env name useOptions
     Remove name -> Commands.remove env name
     Version -> putText cachixVersion
-    DeployCommand deployCommand ->
-      case deployCommand of
-        DeployOptions.Agent opts -> AgentCommand.run cachixOptions opts
-        DeployOptions.Activate opts -> ActivateCommand.run env opts
+    DeployCommand (DeployOptions.Agent opts) -> AgentCommand.run cachixOptions opts
+    DeployCommand (DeployOptions.Activate opts) -> ActivateCommand.run env opts

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -23,8 +23,8 @@ main = displayConsoleRegions $ do
   case command of
     AuthToken token -> Commands.authtoken env token
     Config configCommand -> Config.run cachixOptions configCommand
-    Daemon (DaemonRun pushOptions daemonOptions) -> Daemon.run env pushOptions daemonOptions
-    Daemon (DaemonPushPaths cacheName storePaths) -> Daemon.push env cacheName storePaths
+    Daemon (DaemonRun daemonOptions pushOptions) -> Daemon.run env daemonOptions pushOptions
+    Daemon (DaemonPushPaths daemonOptions cacheName storePaths) -> Daemon.push env daemonOptions cacheName storePaths
     GenerateKeypair name -> Commands.generateKeypair env name
     Push pushArgs -> Commands.push env pushArgs
     Pin pingArgs -> Commands.pin env pingArgs

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -24,6 +24,7 @@ main = displayConsoleRegions $ do
     AuthToken token -> Commands.authtoken env token
     Config configCommand -> Config.run cachixOptions configCommand
     Daemon (DaemonRun daemonOptions pushOptions) -> Daemon.run env daemonOptions pushOptions
+    Daemon (DaemonStop daemonOptions) -> Daemon.stop env daemonOptions
     Daemon (DaemonPushPaths daemonOptions cacheName storePaths) -> Daemon.push env daemonOptions cacheName storePaths
     GenerateKeypair name -> Commands.generateKeypair env name
     Push pushArgs -> Commands.push env pushArgs

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -309,7 +309,7 @@ pushStrategy store authToken opts name compressionMethod storePath =
             return $ liftIO . tickN progressBar . BS.length
           else do
             -- we append newline instead of putStrLn due to https://github.com/haskell/text/issues/242
-            putStr $ retryText retryStatus <> "Pushing " <> path <> " (" <> toS hSize <> ")\n"
+            putErrText $ retryText retryStatus <> "Pushing " <> path <> " (" <> toS hSize <> ")\n"
             return $ const pass
 
       Conduit.awaitForever $ \chunk -> do

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -309,7 +309,7 @@ pushStrategy store authToken opts name compressionMethod storePath =
             return $ liftIO . tickN progressBar . BS.length
           else do
             -- we append newline instead of putStrLn due to https://github.com/haskell/text/issues/242
-            putErrText $ retryText retryStatus <> "Pushing " <> path <> " (" <> toS hSize <> ")\n"
+            appendErrText $ retryText retryStatus <> "Pushing " <> path <> " (" <> toS hSize <> ")\n"
             return $ const pass
 
       Conduit.awaitForever $ \chunk -> do
@@ -344,3 +344,9 @@ withPushParams env pushOpts name m = do
           pushParamsStrategy = pushStrategy store authToken pushOpts name compressionMethod,
           pushParamsStore = store
         }
+
+-- | Put text to stderr without a new line.
+--
+-- This is safe to use when printing from multiple threads, unlike hPutStrLn which may fail to insert the newline at the right place.
+appendErrText :: (MonadIO m) => Text -> m ()
+appendErrText = hPutStr stderr

--- a/cachix/src/Cachix/Client/Commands.hs
+++ b/cachix/src/Cachix/Client/Commands.hs
@@ -11,6 +11,7 @@ module Cachix.Client.Commands
     use,
     remove,
     pin,
+    withPushParams,
   )
 where
 

--- a/cachix/src/Cachix/Client/Config/Orphans.hs
+++ b/cachix/src/Cachix/Client/Config/Orphans.hs
@@ -2,6 +2,7 @@
 
 module Cachix.Client.Config.Orphans where
 
+import qualified Data.Aeson as Aeson
 import qualified Dhall
 import qualified Dhall.Core
 import Protolude hiding (toS)
@@ -20,3 +21,9 @@ instance Dhall.ToDhall Token where
       { Dhall.embed = Dhall.Core.TextLit . Dhall.Core.Chunks [] . toS . getToken,
         Dhall.declared = Dhall.Core.Text
       }
+
+instance Aeson.FromJSON Token where
+  parseJSON = Aeson.withText "Token" $ pure . Token . toS
+
+instance Aeson.ToJSON Token where
+  toJSON = Aeson.String . toS . getToken

--- a/cachix/src/Cachix/Client/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon.hs
@@ -44,10 +44,13 @@ runWithSocket env pushOptions socketPath = do
       Socket.listen sock Socket.maxListenQueue
 
       putText =<< readyMessage socketPath
-      Daemon.listen queue sock
+      clientStopConn <- Daemon.listen queue sock
 
       -- Gracefully shutdown the worker before closing the socket
+      -- TODO: consider shutdown from Network.Socket
       shutdownWorker
+
+      Socket.gracefulClose clientStopConn 5000
   where
     startWorker queue = do
       worker <- Immortal.create $ \thread ->

--- a/cachix/src/Cachix/Client/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Cachix.Client.Daemon
+  ( run,
+    runWithSocket,
+    push,
+  )
+where
+
+import Cachix.Client.CNix (filterInvalidStorePath)
+import qualified Cachix.Client.Commands as Commands
+import Cachix.Client.Config.Orphans ()
+import Cachix.Client.Daemon.Listen as Daemon
+import Cachix.Client.Daemon.Push (push)
+import Cachix.Client.Daemon.Types
+import Cachix.Client.Env as Env
+import Cachix.Client.OptionsParser as Options
+import Cachix.Client.Push
+import Control.Concurrent.STM.TBMQueue
+import qualified Control.Immortal as Immortal
+import Data.String.Here (i)
+import qualified Data.Text as T
+import qualified Hercules.CNix.Store as Store
+import qualified Network.Socket as Socket
+import Protolude
+import System.Directory (removeFile)
+import System.IO.Error (isDoesNotExistError)
+
+run :: Env -> PushOptions -> DaemonOptions -> IO ()
+run env pushOptions daemonOptions = do
+  socketPath <- maybe getSocketPath pure (daemonSocketPath daemonOptions)
+  runWithSocket env pushOptions socketPath
+
+runWithSocket :: Env -> PushOptions -> FilePath -> IO ()
+runWithSocket env pushOptions socketPath =
+  bracket (open socketPath) Socket.close $ \sock -> do
+    Socket.listen sock Socket.maxListenQueue
+
+    -- Create a queue of push requests for the workers to process
+    queue <- newTBMQueueIO 1000
+    bracket (startWorkers queue) (shutdownWorkers queue) $ \_ -> do
+      putText $ readyMessage socketPath
+      Daemon.listen queue sock
+  where
+    startWorkers queue =
+      replicateM 1 $ do
+        Immortal.create $ \thread ->
+          Immortal.onUnexpectedFinish thread logException $
+            runWorker env pushOptions queue
+
+    shutdownWorkers queue workers = do
+      atomically $ closeTBMQueue queue
+      mapM_ Immortal.mortalize workers
+      mapM_ Immortal.wait workers
+
+    logException e =
+      putErrText $ "Exception in daemon worker thread: " <> show e
+
+    -- TODO: lock the socket
+    open socketFilePath = do
+      deleteSocketFileIfExists socketFilePath
+      sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
+      Socket.bind sock $ Socket.SockAddrUnix socketFilePath
+      -- setFileMode socketFilePath socketFileMode
+      return sock
+
+    deleteSocketFileIfExists path =
+      removeFile path `catch` handleDoesNotExist
+
+    handleDoesNotExist e
+      | isDoesNotExistError e = return ()
+      | otherwise = throwIO e
+
+runWorker :: Env -> PushOptions -> TBMQueue QueuedPushRequest -> IO ()
+runWorker env pushOptions queue =
+  atomically (readTBMQueue queue) >>= \case
+    Nothing -> return ()
+    Just msg -> handleRequest env pushOptions msg
+
+handleRequest :: Env -> PushOptions -> QueuedPushRequest -> IO ()
+handleRequest env pushOptions (QueuedPushRequest {..}) = do
+  putText $ "Pushing " <> show (length $ storePaths pushRequest) <> " store paths"
+
+  Commands.withPushParams env pushOptions (binaryCacheName pushRequest) $ \pushParams -> do
+    normalized <-
+      for (storePaths pushRequest) $ \fp -> do
+        storePath <- Store.followLinksToStorePath (pushParamsStore pushParams) (encodeUtf8 $ T.pack fp)
+        filterInvalidStorePath (pushParamsStore pushParams) storePath
+    void $
+      pushClosure
+        (mapConcurrentlyBounded (numJobs pushOptions))
+        pushParams
+        (catMaybes normalized)
+
+readyMessage :: FilePath -> Text
+readyMessage socketPath =
+  [i|
+Cachix Daemon is ready to push store paths.
+Listening on socket: ${socketPath}
+  |]

--- a/cachix/src/Cachix/Client/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon.hs
@@ -25,8 +25,8 @@ import qualified Network.Socket as Socket
 import Protolude
 import System.Posix.Process (getProcessID)
 
-run :: Env -> PushOptions -> DaemonOptions -> IO ()
-run env pushOptions daemonOptions = do
+run :: Env -> DaemonOptions -> PushOptions -> IO ()
+run env daemonOptions pushOptions = do
   socketPath <- maybe getSocketPath pure (daemonSocketPath daemonOptions)
   runWithSocket env pushOptions socketPath
     `finally` putErrText "Daemon shut down."

--- a/cachix/src/Cachix/Client/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon.hs
@@ -70,10 +70,14 @@ logWorkerException (Left err) =
 logWorkerException _ = return ()
 
 runWorker :: Env -> PushOptions -> TBMQueue QueuedPushRequest -> IO ()
-runWorker env pushOptions queue =
-  atomically (readTBMQueue queue) >>= \case
-    Nothing -> return ()
-    Just msg -> handleRequest env pushOptions msg
+runWorker env pushOptions queue = loop
+  where
+    loop =
+      atomically (readTBMQueue queue) >>= \case
+        Nothing -> return ()
+        Just msg -> do
+          handleRequest env pushOptions msg
+          loop
 
 handleRequest :: Env -> PushOptions -> QueuedPushRequest -> IO ()
 handleRequest env pushOptions (QueuedPushRequest {..}) = do

--- a/cachix/src/Cachix/Client/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon.hs
@@ -38,9 +38,9 @@ runWithSocket env pushOptions socketPath = do
   -- Create a queue of push requests for the workers to process
   queue <- newTBMQueueIO 1000
 
-  bracket (startWorker queue) identity $ \shutdownWorker -> do
+  bracketOnError (startWorker queue) identity $ \shutdownWorker -> do
     -- TODO: retry the connection on socket errors
-    bracket (Daemon.openSocket socketPath) Socket.close $ \sock -> do
+    bracketOnError (Daemon.openSocket socketPath) Socket.close $ \sock -> do
       Socket.listen sock Socket.maxListenQueue
 
       putText =<< readyMessage socketPath

--- a/cachix/src/Cachix/Client/Daemon/Client.hs
+++ b/cachix/src/Cachix/Client/Daemon/Client.hs
@@ -14,7 +14,7 @@ import qualified System.Posix.IO as Posix
 
 -- | Queue up push requests with the daemon
 --
--- TODO: wait for the daemon to response that it has received the request
+-- TODO: wait for the daemon to respond that it has received the request
 push :: Env -> DaemonOptions -> BinaryCacheName -> [FilePath] -> IO ()
 push Env {config, cachixoptions} daemonOptions cacheName storePaths = do
   sock <- connectToDaemon (daemonSocketPath daemonOptions)
@@ -24,6 +24,7 @@ push Env {config, cachixoptions} daemonOptions cacheName storePaths = do
       ClientPushRequest $
         PushRequest (Config.authToken config) cacheName (Config.host cachixoptions) storePaths
 
+-- | Tell the daemon to stop and wait for it gracefully exit
 stop :: Env -> DaemonOptions -> IO ()
 stop _env daemonOptions = do
   sock <- connectToDaemon (daemonSocketPath daemonOptions)

--- a/cachix/src/Cachix/Client/Daemon/Listen.hs
+++ b/cachix/src/Cachix/Client/Daemon/Listen.hs
@@ -33,6 +33,9 @@ instance Exception ListenError where
     SocketError err -> "Failed to read from the daemon socket: " <> show err
     DecodingError err -> "Failed to decode request: " <> toS err
 
+-- | The main daemon server loop.
+--
+-- The daemon listens for incoming push requests on the provided socket and queues them up for the worker thread.
 listen :: TBMQueue QueuedPushRequest -> Socket.Socket -> IO Socket.Socket
 listen queue sock = loop
   where
@@ -52,6 +55,7 @@ listen queue sock = loop
           loop
         Left err -> throwIO err
 
+-- | Try to read and decode a push request.
 readPushRequest :: Socket.Socket -> ExceptT ListenError IO (ClientMessage, Socket.Socket)
 readPushRequest sock = do
   (bs, clientConn) <- readFromSocket `mapSyncException` SocketError

--- a/cachix/src/Cachix/Client/Daemon/Listen.hs
+++ b/cachix/src/Cachix/Client/Daemon/Listen.hs
@@ -1,0 +1,59 @@
+module Cachix.Client.Daemon.Listen
+  ( listen,
+    getSocketPath,
+  )
+where
+
+import Cachix.Client.Config.Orphans ()
+import Cachix.Client.Daemon.Types (QueuedPushRequest (..))
+import Control.Concurrent.STM.TBMQueue
+import Control.Monad.Catch as E
+import qualified Data.Aeson as Aeson
+import qualified Network.Socket as Socket
+import qualified Network.Socket.ByteString as Socket.BS
+import Protolude
+import System.Directory
+  ( XdgDirectory (..),
+    createDirectoryIfMissing,
+    getXdgDirectory,
+  )
+import qualified System.Environment as System
+import System.FilePath ((</>))
+
+listen :: TBMQueue QueuedPushRequest -> Socket.Socket -> IO ()
+listen queue sock =
+  forever $ E.handleAll logException $ do
+    (conn, _peerAddr) <- Socket.accept sock
+    bs <- Socket.BS.recv conn 4096
+
+    -- TODO: ignore empty requests (means that the connection was closed)
+    case Aeson.eitherDecodeStrict bs of
+      Left err -> putErrText $ "Failed to decode push request: " <> show err
+      Right pushRequest -> do
+        -- Socket.BS.sendAll conn "OK"
+        atomically $ writeTBMQueue queue $ QueuedPushRequest pushRequest conn
+  where
+    logException e = putErrText $ "Exception in daemon listen thread: " <> show e
+
+mapSyncException :: (Exception e1, Exception e2, Safe.MonadCatch m) => m a -> (e1 -> e2) -> m a
+mapSyncException a f = a `Safe.catch` (Safe.throwM . f)
+
+getSocketPath :: IO FilePath
+getSocketPath = do
+  socketDir <- getSocketDir
+  return $ socketDir </> "cachix-daemon.sock"
+
+getSocketDir :: IO FilePath
+getSocketDir = do
+  xdgRuntimeDir <- getXdgRuntimeDir
+  let socketDir = xdgRuntimeDir </> "cachix"
+  createDirectoryIfMissing True socketDir
+  return socketDir
+
+-- On systems with systemd: /run/user/$UID
+-- Otherwise, fall back to XDG_CACHE_HOME
+getXdgRuntimeDir :: IO FilePath
+getXdgRuntimeDir = do
+  xdgRuntimeDir <- System.lookupEnv "XDG_RUNTIME_DIR"
+  cacheFallback <- getXdgDirectory XdgCache ""
+  return $ fromMaybe cacheFallback xdgRuntimeDir

--- a/cachix/src/Cachix/Client/Daemon/Push.hs
+++ b/cachix/src/Cachix/Client/Daemon/Push.hs
@@ -1,0 +1,29 @@
+module Cachix.Client.Daemon.Push (push) where
+
+import Cachix.Client.Config as Config
+import Cachix.Client.Daemon.Listen (getSocketPath)
+import Cachix.Client.Daemon.Types (PushRequest (..))
+import Cachix.Client.Env as Env
+import Cachix.Types.BinaryCache (BinaryCacheName)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Network.Socket as Socket
+import qualified Network.Socket.ByteString as Socket.BS
+import qualified Network.Socket.ByteString.Lazy as Socket.LBS
+import Protolude
+
+-- | Queue up push requests with the daemon
+push :: Env -> BinaryCacheName -> [FilePath] -> IO ()
+push Env {config, cachixoptions} cacheName storePaths = do
+  socketPath <- maybe getSocketPath pure Nothing
+  sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
+  Socket.connect sock (Socket.SockAddrUnix socketPath)
+
+  Socket.LBS.sendAll sock (Aeson.encode payload)
+
+  forever $ do
+    response <- Socket.BS.recv sock 4096
+    BS.hPut stderr response
+  where
+    payload =
+      PushRequest (Config.authToken config) cacheName (Config.host cachixoptions) storePaths

--- a/cachix/src/Cachix/Client/Daemon/Push.hs
+++ b/cachix/src/Cachix/Client/Daemon/Push.hs
@@ -4,6 +4,7 @@ import Cachix.Client.Config as Config
 import Cachix.Client.Daemon.Listen (getSocketPath)
 import Cachix.Client.Daemon.Types (PushRequest (..))
 import Cachix.Client.Env as Env
+import Cachix.Client.OptionsParser (DaemonOptions (..))
 import Cachix.Types.BinaryCache (BinaryCacheName)
 import qualified Data.Aeson as Aeson
 import qualified Network.Socket as Socket
@@ -13,12 +14,12 @@ import Protolude
 -- | Queue up push requests with the daemon
 --
 -- TODO: wait for the daemon to response that it has received the request
--- TODO: allow customizing the socket path
-push :: Env -> BinaryCacheName -> [FilePath] -> IO ()
-push Env {config, cachixoptions} cacheName storePaths = do
-  socketPath <- maybe getSocketPath pure Nothing
+push :: Env -> DaemonOptions -> BinaryCacheName -> [FilePath] -> IO ()
+push Env {config, cachixoptions} daemonOptions cacheName storePaths = do
+  socketPath <- maybe getSocketPath pure (daemonSocketPath daemonOptions)
   sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
   Socket.connect sock (Socket.SockAddrUnix socketPath)
+
   Socket.LBS.sendAll sock (Aeson.encode payload)
   where
     payload =

--- a/cachix/src/Cachix/Client/Daemon/Push.hs
+++ b/cachix/src/Cachix/Client/Daemon/Push.hs
@@ -6,24 +6,19 @@ import Cachix.Client.Daemon.Types (PushRequest (..))
 import Cachix.Client.Env as Env
 import Cachix.Types.BinaryCache (BinaryCacheName)
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
 import qualified Network.Socket as Socket
-import qualified Network.Socket.ByteString as Socket.BS
 import qualified Network.Socket.ByteString.Lazy as Socket.LBS
 import Protolude
 
 -- | Queue up push requests with the daemon
+--
+-- TODO: wait for the daemon to response that it has received the request
 push :: Env -> BinaryCacheName -> [FilePath] -> IO ()
 push Env {config, cachixoptions} cacheName storePaths = do
   socketPath <- maybe getSocketPath pure Nothing
   sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
   Socket.connect sock (Socket.SockAddrUnix socketPath)
-
   Socket.LBS.sendAll sock (Aeson.encode payload)
-
-  forever $ do
-    response <- Socket.BS.recv sock 4096
-    BS.hPut stderr response
   where
     payload =
       PushRequest (Config.authToken config) cacheName (Config.host cachixoptions) storePaths

--- a/cachix/src/Cachix/Client/Daemon/Push.hs
+++ b/cachix/src/Cachix/Client/Daemon/Push.hs
@@ -13,6 +13,7 @@ import Protolude
 -- | Queue up push requests with the daemon
 --
 -- TODO: wait for the daemon to response that it has received the request
+-- TODO: allow customizing the socket path
 push :: Env -> BinaryCacheName -> [FilePath] -> IO ()
 push Env {config, cachixoptions} cacheName storePaths = do
   socketPath <- maybe getSocketPath pure Nothing

--- a/cachix/src/Cachix/Client/Daemon/Types.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types.hs
@@ -7,6 +7,12 @@ import qualified Network.Socket as Socket
 import Protolude
 import Servant.Auth.Client (Token)
 
+data ClientMessage
+  = ClientPushRequest PushRequest
+  | ClientStop
+  deriving stock (Generic)
+  deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
+
 -- | A request sent to the daemon to push a store path to a binary cache.
 data PushRequest = PushRequest
   { authToken :: Token,

--- a/cachix/src/Cachix/Client/Daemon/Types.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types.hs
@@ -1,0 +1,24 @@
+module Cachix.Client.Daemon.Types where
+
+import Cachix.Client.Config.Orphans ()
+import Cachix.Client.URI
+import qualified Data.Aeson as Aeson
+import qualified Network.Socket as Socket
+import Protolude
+import Servant.Auth.Client (Token)
+
+-- | A request sent to the daemon to push a store path to a binary cache.
+data PushRequest = PushRequest
+  { authToken :: Token,
+    binaryCacheName :: Text,
+    host :: URI,
+    storePaths :: [FilePath]
+  }
+  deriving stock (Generic)
+  deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
+
+data QueuedPushRequest = QueuedPushRequest
+  { pushRequest :: PushRequest,
+    -- | An open socket to the client that sent the push request.
+    clientConnection :: Socket.Socket
+  }

--- a/cachix/src/Cachix/Client/Daemon/Types.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types.hs
@@ -7,25 +7,26 @@ import qualified Network.Socket as Socket
 import Protolude
 import Servant.Auth.Client (Token)
 
+-- | JSON messages that the client can send to the daemon
 data ClientMessage
   = ClientPushRequest PushRequest
   | ClientStop
   deriving stock (Generic)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
--- | A request sent to the daemon to push a store path to a binary cache.
+-- | A request for the daemon to push store paths to a binary cache
 data PushRequest = PushRequest
   { authToken :: Token,
     binaryCacheName :: Text,
-    -- Host is not currently supported
-    host :: URI,
+    host :: URI, -- TODO: host is not currently supported
     storePaths :: [FilePath]
   }
   deriving stock (Generic)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 data QueuedPushRequest = QueuedPushRequest
-  { pushRequest :: PushRequest,
+  { -- | The original push request
+    pushRequest :: PushRequest,
     -- | An open socket to the client that sent the push request.
     clientConnection :: Socket.Socket
   }

--- a/cachix/src/Cachix/Client/Daemon/Types.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types.hs
@@ -11,6 +11,7 @@ import Servant.Auth.Client (Token)
 data PushRequest = PushRequest
   { authToken :: Token,
     binaryCacheName :: Text,
+    -- Host is not currently supported
     host :: URI,
     storePaths :: [FilePath]
   }

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -113,8 +113,8 @@ data PushOptions = PushOptions
   deriving (Show)
 
 data DaemonCommand
-  = DaemonPushPaths BinaryCacheName [FilePath]
-  | DaemonRun PushOptions DaemonOptions
+  = DaemonPushPaths DaemonOptions BinaryCacheName [FilePath]
+  | DaemonRun DaemonOptions PushOptions
   deriving (Show)
 
 data DaemonOptions = DaemonOptions
@@ -204,8 +204,8 @@ commandParser =
       subparser $
         command "push" (infoH daemonPush (progDesc "Push store paths to the daemon"))
           <> command "run" (infoH daemonRun (progDesc "Launch the daemon"))
-    daemonPush = DaemonPushPaths <$> nameArg <*> many (strArgument (metavar "PATHS..."))
-    daemonRun = DaemonRun <$> pushOptions <*> daemonOptions
+    daemonPush = DaemonPushPaths <$> daemonOptions <*> nameArg <*> many (strArgument (metavar "PATHS..."))
+    daemonRun = DaemonRun <$> daemonOptions <*> pushOptions
     daemonOptions = DaemonOptions <$> optional (strOption (long "socket" <> short 's' <> metavar "SOCKET"))
     watchExec = WatchExec <$> pushOptions <*> nameArg <*> strArgument (metavar "CMD") <*> many (strArgument (metavar "-- ARGS"))
     watchStore = WatchStore <$> pushOptions <*> nameArg

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -16,6 +16,7 @@ import qualified Cachix.Client.InstallationMode as InstallationMode
 import Cachix.Client.URI (URI)
 import qualified Cachix.Client.URI as URI
 import qualified Cachix.Deploy.OptionsParser as DeployOptions
+import Cachix.Types.BinaryCache (BinaryCacheName)
 import qualified Cachix.Types.BinaryCache as BinaryCache
 import Cachix.Types.PinCreate (Keep (..))
 import qualified Data.Text as T
@@ -71,8 +72,6 @@ flagParser defaultConfigPath = do
 uriOption :: ReadM URI
 uriOption = eitherReader $ \s ->
   first show $ URI.parseURI (toS s)
-
-type BinaryCacheName = Text
 
 data CachixCommand
   = AuthToken (Maybe Text)

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -128,7 +128,7 @@ commandParser =
   subparser $
     command "authtoken" (infoH authtoken (progDesc "Configure authentication token for communication to HTTP API"))
       <> command "config" (Config <$> Config.parser)
-      <> command "daemon" (infoH (Daemon <$> daemon) (progDesc "Run a daemon that listens for store paths on a unix socket"))
+      <> (hidden <> command "daemon" (infoH (Daemon <$> daemon) (progDesc "Run a daemon that listens push requests over a unix socket")))
       <> command "generate-keypair" (infoH generateKeypair (progDesc "Generate signing key pair for a binary cache"))
       <> command "push" (infoH push (progDesc "Upload Nix store paths to a binary cache"))
       <> command "pin" (infoH pin (progDesc "Pin a store path to prevent it from being garbage collected"))

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -115,6 +115,7 @@ data PushOptions = PushOptions
 data DaemonCommand
   = DaemonPushPaths DaemonOptions BinaryCacheName [FilePath]
   | DaemonRun DaemonOptions PushOptions
+  | DaemonStop DaemonOptions
   deriving (Show)
 
 data DaemonOptions = DaemonOptions
@@ -204,8 +205,10 @@ commandParser =
       subparser $
         command "push" (infoH daemonPush (progDesc "Push store paths to the daemon"))
           <> command "run" (infoH daemonRun (progDesc "Launch the daemon"))
+          <> command "stop" (infoH daemonStop (progDesc "Stop the daemon and wait for any queued paths to be pushed"))
     daemonPush = DaemonPushPaths <$> daemonOptions <*> nameArg <*> many (strArgument (metavar "PATHS..."))
     daemonRun = DaemonRun <$> daemonOptions <*> pushOptions
+    daemonStop = DaemonStop <$> daemonOptions
     daemonOptions = DaemonOptions <$> optional (strOption (long "socket" <> short 's' <> metavar "SOCKET"))
     watchExec = WatchExec <$> pushOptions <*> nameArg <*> strArgument (metavar "CMD") <*> many (strArgument (metavar "-- ARGS"))
     watchStore = WatchStore <$> pushOptions <*> nameArg

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -2,6 +2,8 @@
 
 module Cachix.Client.OptionsParser
   ( CachixCommand (..),
+    DaemonCommand (..),
+    DaemonOptions (..),
     PushArguments (..),
     PushOptions (..),
     PinOptions (..),
@@ -76,6 +78,7 @@ uriOption = eitherReader $ \s ->
 data CachixCommand
   = AuthToken (Maybe Text)
   | Config Config.Command
+  | Daemon DaemonCommand
   | GenerateKeypair BinaryCacheName
   | Push PushArguments
   | Pin PinOptions
@@ -109,11 +112,22 @@ data PushOptions = PushOptions
   }
   deriving (Show)
 
+data DaemonCommand
+  = DaemonPushPaths BinaryCacheName [FilePath]
+  | DaemonRun PushOptions DaemonOptions
+  deriving (Show)
+
+data DaemonOptions = DaemonOptions
+  { daemonSocketPath :: Maybe FilePath
+  }
+  deriving (Show)
+
 commandParser :: Parser CachixCommand
 commandParser =
   subparser $
     command "authtoken" (infoH authtoken (progDesc "Configure authentication token for communication to HTTP API"))
       <> command "config" (Config <$> Config.parser)
+      <> command "daemon" (infoH (Daemon <$> daemon) (progDesc "Run a daemon that listens for store paths on a unix socket"))
       <> command "generate-keypair" (infoH generateKeypair (progDesc "Generate signing key pair for a binary cache"))
       <> command "push" (infoH push (progDesc "Upload Nix store paths to a binary cache"))
       <> command "pin" (infoH pin (progDesc "Pin a store path to prevent it from being garbage collected"))
@@ -186,6 +200,13 @@ commandParser =
         <*> many (strOption (metavar "ARTIFACTS..." <> long "artifact" <> short 'a'))
         <*> keepParser
     pin = Pin <$> pinOptions
+    daemon =
+      subparser $
+        command "push" (infoH daemonPush (progDesc "Push store paths to the daemon"))
+          <> command "run" (infoH daemonRun (progDesc "Launch the daemon"))
+    daemonPush = DaemonPushPaths <$> nameArg <*> many (strArgument (metavar "PATHS..."))
+    daemonRun = DaemonRun <$> pushOptions <*> daemonOptions
+    daemonOptions = DaemonOptions <$> optional (strOption (long "socket" <> short 's' <> metavar "SOCKET"))
     watchExec = WatchExec <$> pushOptions <*> nameArg <*> strArgument (metavar "CMD") <*> many (strArgument (metavar "-- ARGS"))
     watchStore = WatchStore <$> pushOptions <*> nameArg
     pushWatchStore =


### PR DESCRIPTION
A basic daemon with muti-cache support.

Supports the following commands:
* `cachix daemon run` - Launches the daemon.
* `cachix daemon stop` - Stops the daemon and waits for it to finish pushing store paths.
* `cachix daemon push` - Queues store paths.