### PR TITLE
Set the file system encoding to utf8

### DIFF
--- a/cachix/cachix-deployment/Main.hs
+++ b/cachix/cachix-deployment/Main.hs
@@ -41,6 +41,7 @@ lockFilename agentName = "deployment-" <> toS agentName
 main :: IO ()
 main = do
   setLocaleEncoding utf8
+  setFileSystemEncoding utf8
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
 

--- a/cachix/cachix/Main.hs
+++ b/cachix/cachix/Main.hs
@@ -10,6 +10,7 @@ import System.IO
 main :: IO ()
 main = do
   setLocaleEncoding utf8
+  setFileSystemEncoding utf8
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
   handleExceptions CC.main


### PR DESCRIPTION
Filesystem operations in Haskell respect the system locale, which may or may not be set correctly. A utf8-encoded path on a (supposedly) non-utf8 system will be mangled when read into Haskell.

On unix, we can assume utf8 encoding. A more robust solution would be to update hnix-store-core and cachix to use OsPath, dodging the whole encoding question.

Resolves #571.