### PR TITLE
Handle common store path errors

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -132,6 +132,7 @@ library
     , http-conduit
     , http-types
     , immortal
+    , inline-c-cpp
     , katip
     , lukko
     , lzma-conduit
@@ -159,6 +160,7 @@ library
     , temporary
     , text
     , time
+    , transformers
     , unix
     , unordered-containers
     , uri-bytestring

--- a/cachix/cachix/Main.hs
+++ b/cachix/cachix/Main.hs
@@ -1,8 +1,9 @@
 module Main (main) where
 
 import qualified Cachix.Client as CC
+import Cachix.Client.CNix (handleCppExceptions)
 import Cachix.Client.Exception (CachixException)
-import Control.Exception.Safe (displayException, handle)
+import Control.Exception.Safe (Handler (..), catches, displayException)
 import GHC.IO.Encoding
 import System.Exit (exitFailure)
 import System.IO
@@ -15,12 +16,12 @@ main = do
   hSetBuffering stderr LineBuffering
   handleExceptions CC.main
 
-handleExceptions :: IO a -> IO a
-handleExceptions = handle handler
-  where
-    handler :: CachixException -> IO a
-    handler e = do
-      hPutStrLn stderr ""
-      hPutStr stderr (displayException e)
-      hFlush stderr
-      exitFailure
+handleExceptions :: IO () -> IO ()
+handleExceptions f = f `catches` [Handler handleCachixExceptions, Handler handleCppExceptions]
+
+handleCachixExceptions :: CachixException -> IO ()
+handleCachixExceptions e = do
+  hPutStrLn stderr ""
+  hPutStr stderr (displayException e)
+  hFlush stderr
+  exitFailure

--- a/cachix/src/Cachix/Client/CNix.hs
+++ b/cachix/src/Cachix/Client/CNix.hs
@@ -1,19 +1,81 @@
 module Cachix.Client.CNix where
 
-import Hercules.CNix.Store (Store, StorePath, isValidPath, storePathToPath)
+import Hercules.CNix.Store (Store, StorePath)
+import qualified Hercules.CNix.Store as Store
+import Language.C.Inline.Cpp.Exception
 import Protolude
-import System.Console.Pretty (Color (..), color)
+import System.Console.Pretty (Color (..), Style (..), color, style)
+
+-- | Checks whether a store path is valid.
+validateStorePath :: Store -> StorePath -> IO (Maybe StorePath)
+validateStorePath store storePath = do
+  isValid <- Store.isValidPath store storePath `catchNixError` const (return False)
+  if isValid
+    then return (Just storePath)
+    else return Nothing
+
+-- | Like 'validateStorePath', but logs a warning when the path is invalid.
+filterInvalidStorePath :: Store -> StorePath -> IO (Maybe StorePath)
+filterInvalidStorePath store storePath = do
+  mstorePath <- validateStorePath store storePath
+
+  when (isNothing mstorePath) (logBadStorePath store storePath)
+
+  return mstorePath
 
 filterInvalidStorePaths :: Store -> [StorePath] -> IO [Maybe StorePath]
 filterInvalidStorePaths store =
   traverse (filterInvalidStorePath store)
 
-filterInvalidStorePath :: Store -> StorePath -> IO (Maybe StorePath)
-filterInvalidStorePath store storePath = do
-  isValid <- isValidPath store storePath
-  if isValid
-    then return $ Just storePath
-    else do
-      path <- storePathToPath store storePath
-      putErrText $ color Yellow $ "Warning: " <> decodeUtf8With lenientDecode path <> " is not valid, skipping"
+-- | Follows all symlinks to a store path, returning the final store path.
+--
+-- Returns Nothing if the path is invalid.
+followLinksToStorePath :: Store -> ByteString -> IO (Maybe StorePath)
+followLinksToStorePath store storePath =
+  (Just <$> Store.followLinksToStorePath store storePath)
+    `catchNixError` \e -> do
+      logNixError storePath e
       return Nothing
+
+data NixError = NixError
+  { typ :: Maybe Text,
+    msg :: Text
+  }
+  deriving (Show)
+
+-- | Capture and handle Nix errors
+catchNixError :: IO a -> (NixError -> IO a) -> IO a
+catchNixError f onError =
+  handleJust selectNixError onError f
+  where
+    selectNixError (CppStdException _eptr msg typ) =
+      Just $
+        NixError
+          { typ = decodeUtf8With lenientDecode <$> typ,
+            msg = decodeUtf8With lenientDecode msg
+          }
+    selectNixError _ = Nothing
+
+-- | Pretty-print a Nix error.
+--
+-- There might not be a valid store path at this point.
+logNixError :: ByteString -> NixError -> IO ()
+logNixError storePath (NixError {..}) =
+  case typ of
+    Just "nix::BadStorePath" -> logBadPath storePath
+    _ -> putErrText $ color Red $ style Bold $ "Nix " <> msg
+
+-- | Print a warning when a store path is invalid.
+logBadStorePath :: Store -> StorePath -> IO ()
+logBadStorePath store storePath = do
+  path <- Store.storePathToPath store storePath
+  logBadPath path
+
+-- | Print a warning when the path is invalid.
+--
+-- There are two use-cases when this should be used:
+-- 1. Converting a file path to a store path.
+-- 2. Filtering out a store path that is not valid.
+logBadPath :: ByteString -> IO ()
+logBadPath path =
+  putErrText $ color Yellow $ "Warning: " <> decodeUtf8With lenientDecode path <> " is not valid, skipping"

--- a/cachix/src/Cachix/Client/CNix.hs
+++ b/cachix/src/Cachix/Client/CNix.hs
@@ -79,3 +79,19 @@ logBadStorePath store storePath = do
 logBadPath :: ByteString -> IO ()
 logBadPath path =
   putErrText $ color Yellow $ "Warning: " <> decodeUtf8With lenientDecode path <> " is not valid, skipping"
+
+-- | Pretty-print unhandled C++ exceptions from Nix.
+handleCppExceptions :: CppException -> IO ()
+handleCppExceptions e = do
+  putErrText ""
+
+  case e of
+    CppStdException _eptr msg _t ->
+      putErrText $ color Red $ style Bold $ "Nix " <> decodeUtf8With lenientDecode msg
+    CppNonStdException _eptr mmsg -> do
+      let msg = fromMaybe "unknown exception" mmsg
+      putErrText $ color Red $ style Bold $ "C++ exception: " <> decodeUtf8With lenientDecode msg
+    CppHaskellException he ->
+      putErrText $ color Red $ style Bold $ "Haskell exception: " <> toS (displayException he)
+
+  exitFailure


### PR DESCRIPTION
- Adds a global pretty-printer for unhandled C++ errors.
- Catches common invalid/bad store path errors when following symlinks and filtering out paths.
- `cachix pin` now prints an error if the path provided is invalid.