### PR TITLE
Surface unrecoverable errors sooner

### DIFF
--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -212,46 +212,42 @@ uploadStorePath cache storePath retrystatus = do
         | isErr err status401 ->
             on401 strategy err
         | otherwise ->
-            void $ onError strategy err
-      Right (narId, uploadId, parts) -> liftIO $ do
-        narSize <- readIORef narSizeRef
-        narHash <- ("sha256:" <>) . System.Nix.Base32.encode <$> readIORef narHashRef
-        narHashNix <- Store.validPathInfoNarHash32 pathinfo
-        when (narHash /= toS narHashNix) $ throwM $ NarHashMismatch $ toS storePathText <> ": Nar hash mismatch between nix-store --dump and nix db. You can repair db metadata by running as root: $ nix-store --verify --repair --check-contents"
-        fileHash <- readIORef fileHashRef
-        fileSize <- readIORef fileSizeRef
-        deriverPath <-
-          if omitDeriver strategy
-            then pure Nothing
-            else Store.validPathInfoDeriver store pathinfo
-        deriver <- for deriverPath Store.getStorePathBaseName
-        referencesPathSet <- Store.validPathInfoReferences store pathinfo
-        referencesPaths <- sort . fmap toS <$> for referencesPathSet (Store.storePathToPath store)
-        references <- sort . fmap toS <$> for referencesPathSet Store.getStorePathBaseName
-        let fp = fingerprint (decodeUtf8With lenientDecode storePathText) narHash narSize referencesPaths
-            sig = case pushParamsSecret cache of
-              PushToken _ -> Nothing
-              PushSigningKey _ signKey -> Just $ toS $ B64.encode $ unSignature $ dsign (signingSecretKey signKey) fp
-            nic =
-              Api.NarInfoCreate
-                { Api.cStoreHash = storeHash,
-                  Api.cStoreSuffix = storeSuffix,
-                  Api.cNarHash = narHash,
-                  Api.cNarSize = narSize,
-                  Api.cFileSize = fileSize,
-                  Api.cFileHash = toS fileHash,
-                  Api.cReferences = references,
-                  Api.cDeriver = maybe "unknown-deriver" (decodeUtf8With lenientDecode) deriver,
-                  Api.cSig = sig
-                }
-        escalate $ Api.isNarInfoCreateValid nic
+            onError strategy err
+      Right (narId, uploadId, parts) -> do
+        liftIO $ do
+          narHash <- ("sha256:" <>) . System.Nix.Base32.encode <$> readIORef narHashRef
+          narHashNix <- Store.validPathInfoNarHash32 pathinfo
+          when (narHash /= toS narHashNix) $
+            throwM $
+              NarHashMismatch $
+                toS storePathText <> ": Nar hash mismatch between nix-store --dump and nix db. You can repair db metadata by running as root: $ nix-store --verify --repair --check-contents"
 
-        -- Complete the multipart upload and upload the narinfo
-        let completeMultipartUploadRequest =
-              API.completeNarUpload cachixClient authToken cacheName narId uploadId $
-                Multipart.CompletedMultipartUpload
-                  { Multipart.parts = parts,
-                    Multipart.narInfoCreate = nic
+          narSize <- readIORef narSizeRef
+          fileHash <- readIORef fileHashRef
+          fileSize <- readIORef fileSizeRef
+          deriverPath <-
+            if omitDeriver strategy
+              then pure Nothing
+              else Store.validPathInfoDeriver store pathinfo
+          deriver <- for deriverPath Store.getStorePathBaseName
+          referencesPathSet <- Store.validPathInfoReferences store pathinfo
+          referencesPaths <- sort . fmap toS <$> for referencesPathSet (Store.storePathToPath store)
+          references <- sort . fmap toS <$> for referencesPathSet Store.getStorePathBaseName
+          let fp = fingerprint (decodeUtf8With lenientDecode storePathText) narHash narSize referencesPaths
+              sig = case pushParamsSecret cache of
+                PushToken _ -> Nothing
+                PushSigningKey _ signKey -> Just $ toS $ B64.encode $ unSignature $ dsign (signingSecretKey signKey) fp
+              nic =
+                Api.NarInfoCreate
+                  { Api.cStoreHash = storeHash,
+                    Api.cStoreSuffix = storeSuffix,
+                    Api.cNarHash = narHash,
+                    Api.cNarSize = narSize,
+                    Api.cFileSize = fileSize,
+                    Api.cFileHash = toS fileHash,
+                    Api.cReferences = references,
+                    Api.cDeriver = maybe "unknown-deriver" (decodeUtf8With lenientDecode) deriver,
+                    Api.cSig = sig
                   }
           escalate $ Api.isNarInfoCreateValid nic
 

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -141,12 +141,13 @@ pushSingleStorePath cache storePath = retryAll $ \retrystatus -> do
   -- Check if narinfo already exists
   res <-
     liftIO $
-      (`runClientM` pushParamsClientEnv cache) $
-        API.narinfoHead
-          cachixClient
-          (getCacheAuthToken (pushParamsSecret cache))
-          name
-          (NarInfoHash.NarInfoHash (decodeUtf8With lenientDecode storeHash))
+      retryHttp $
+        (`runClientM` pushParamsClientEnv cache) $
+          API.narinfoHead
+            cachixClient
+            (getCacheAuthToken (pushParamsSecret cache))
+            name
+            (NarInfoHash.NarInfoHash (decodeUtf8With lenientDecode storeHash))
   case res of
     Right NoContent -> onAlreadyPresent strategy -- we're done as store path is already in the cache
     Left err

--- a/cachix/src/Cachix/Deploy/ActivateCommand.hs
+++ b/cachix/src/Cachix/Deploy/ActivateCommand.hs
@@ -113,7 +113,7 @@ pollDeploymentStatus clientEnv token deploymentID = loop
   where
     loop = do
       deployment <-
-        Retry.retryAll . const $
+        Retry.retryHttp $
           escalate <=< (`runClientM` clientEnv) $
             API.V1.getDeployment deployClientV1 token deploymentID
 


### PR DESCRIPTION
- Don't retry unrecoverable exceptions, ie. auth errors. This helps surface errors sooner.
- Replace `retryAll` with `retryHttp` for HTTP requests.