### PR TITLE
client: allow setting global options in subcommands

### DIFF
--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -255,7 +255,8 @@ commandParser =
 getOpts :: IO (Flags, CachixCommand)
 getOpts = do
   configpath <- Config.getDefaultFilename
-  customExecParser (prefs showHelpOnEmpty) (optsInfo configpath)
+  let preferences = showHelpOnError <> showHelpOnEmpty <> helpShowGlobals <> subparserInline
+  customExecParser (prefs preferences) (optsInfo configpath)
 
 optsInfo :: Config.ConfigPath -> ParserInfo (Flags, CachixCommand)
 optsInfo configpath = infoH parser desc


### PR DESCRIPTION
For example, you can now override the config _after_ choosing a subcommand:

`cachix push cachix-test ./result --config /tmp/other-config.dhall`

The help text for subcommands now also displays the available global options.

```console
❯ cachix push --help
Usage: cachix push [-c|--compression-level [0..16]]
                   [-m|--compression-method xz | zstd] [-j|--jobs ARG]
                   [--omit-deriver] CACHE-NAME [[PATHS...] | (-w|--watch-store)]

  Upload Nix store paths to a binary cache

Available options:
  -h,--help                Show this help text
  -c,--compression-level [0..16]
                           The compression level for XZ compression between 0-9
                           and ZSTD 0-16. (default: 2)
  -m,--compression-method xz | zstd
                           The compression method, either xz or zstd. Defaults
                           to zstd.
  -j,--jobs ARG            Number of threads used for pushing store paths.
                           (default: 8)
  --omit-deriver           Do not publish which derivations built the store
                           paths.
  -w,--watch-store         DEPRECATED: use watch-store command instead.

Global options:
  --hostname URI           Host to connect to (default: https://cachix.org)
  -c,--config CONFIGPATH   Cachix configuration file
                           (default: "/home/sandydoo/.config/cachix/cachix.dhall")
  -v,--verbose             Verbose mode
  -V,--version             Show cachix version
```