### PR TITLE
stack.yaml: nix-narinfo 0.1.0.1 -> 0.1.0.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 extra-deps:
 - hercules-ci-cnix-store-0.3.4.0
 - cabal-pkg-config-version-hook-0.1.0.0
-- nix-narinfo-0.1.0.1
+- nix-narinfo-0.1.0.2
 - hnix-store-core-0.6.1.0
 - algebraic-graphs-0.6.1
 nix:


### PR DESCRIPTION
Just a minor release adding `hspec-discover` to `build-tool-depends`.