### PR TITLE
fix: ignore sigPIPE

### DIFF
--- a/cachix/src/Cachix/Client/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon.hs
@@ -70,9 +70,6 @@ start daemonEnv daemonOptions daemonPushOptions daemonCacheName = do
 -- | Run a daemon from a given configuration
 run :: DaemonEnv -> IO ()
 run daemon@DaemonEnv {..} = runDaemon daemon $ do
-  -- Ignore SIGPIPE errors
-  _ <- liftIO $ Signals.installHandler Signals.sigPIPE Signals.Ignore Nothing
-
   Katip.logFM Katip.InfoS "Starting Cachix Daemon"
 
   config <- showConfiguration

--- a/cachix/src/Cachix/Client/Env.hs
+++ b/cachix/src/Cachix/Client/Env.hs
@@ -11,8 +11,6 @@ import qualified Cachix.Client.Config as Config
 import qualified Cachix.Client.OptionsParser as Options
 import Cachix.Client.URI (getBaseUrl)
 import Cachix.Client.Version (cachixVersion)
-import qualified Hercules.CNix as CNix
-import qualified Hercules.CNix.Util as CNix.Util
 import Network.HTTP.Client
   ( ManagerSettings,
     managerModifyRequest,
@@ -25,7 +23,6 @@ import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Client.Streaming (ClientEnv, mkClientEnv)
 import System.Directory (canonicalizePath)
-import System.Posix.Signals (getSignalMask, setSignalMask)
 
 data Env = Env
   { cachixoptions :: Config.CachixOptions,
@@ -35,17 +32,6 @@ data Env = Env
 
 mkEnv :: Options.Flags -> IO Env
 mkEnv flags = do
-  signalset <- getSignalMask
-  -- Initialize the Nix library
-  CNix.init
-
-  -- darwin: restore the signal mask modified by Nix
-  -- https://github.com/cachix/cachix/issues/501
-  setSignalMask signalset
-
-  -- Interrupt Nix before throwing UserInterrupt
-  CNix.Util.installDefaultSigINTHandler
-
   -- make sure path to the config is passed as absolute to dhall logic
   canonicalConfigPath <- canonicalizePath (Options.configPath flags)
   cfg <- Config.getConfig canonicalConfigPath


### PR DESCRIPTION
The default sigPIPE handler terminates the process. We'd prefer to see an exception and be able to handle it ourselves.

Related to #594.