### PR TITLE
daemon: support nix conf overrides

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -237,6 +237,7 @@ test-suite cachix-test
   main-is:            Main.hs
   hs-source-dirs:     test
   other-modules:
+    Daemon.PostBuildHookSpec
     Daemon.PushManagerSpec
     DeploySpec
     InstallationModeSpec

--- a/cachix/test/Daemon/PostBuildHookSpec.hs
+++ b/cachix/test/Daemon/PostBuildHookSpec.hs
@@ -1,0 +1,40 @@
+module Daemon.PostBuildHookSpec where
+
+import Cachix.Client.Daemon.PostBuildHook
+import Data.String
+import Protolude
+import qualified System.Environment as System
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  let scriptPath = "build-hook.sh"
+      configPath = "my-nix.conf"
+
+  describe "post build hook" $ do
+    it "builds the NIX_CONF environment variable" $ do
+      withTempEnv ("NIX_CONF", "") $ do
+        buildNixConfEnv scriptPath `shouldReturn` Nothing
+
+      withTempEnv ("NIX_CONF", "max-jobs = 8") $ do
+        buildNixConfEnv scriptPath `shouldReturn` Just ("NIX_CONF", "max-jobs = 8\npost-build-hook = " <> scriptPath)
+
+    it "builds the NIX_USER_CONF_FILES environment variable" $ do
+      withTempEnv ("NIX_USER_CONF_FILES", "") $ do
+        ("NIX_USER_CONF_FILES", conf) <- buildNixUserConfFilesEnv configPath
+        -- Should contain /etc/xdg and home config dirs as well
+        conf `shouldContain` configPath
+
+      withTempEnv ("NIX_USER_CONF_FILES", "/some/nix.conf") $ do
+        ("NIX_USER_CONF_FILES", conf) <- buildNixUserConfFilesEnv configPath
+        conf `shouldBe` intercalate ":" [configPath, "/some/nix.conf"]
+
+withTempEnv :: (String, String) -> IO a -> IO a
+withTempEnv (envName, envValue) f = bracket setEnv unsetEnv (const f)
+  where
+    setEnv = do
+      mprevEnv <- System.lookupEnv envName
+      System.setEnv envName envValue
+      return mprevEnv
+    unsetEnv =
+      maybe (System.unsetEnv envName) (System.setEnv envName)


### PR DESCRIPTION
Unlike `NIX_USER_CONF_FILES`, which concatenates multiple nix.confs, `NIX_CONF` completely overrides the config. This PR supports registering the daemon post-build-hook even if `NIX_CONF` is used.

Depends on #613.