### PR TITLE
Allow setting chunk size and concurrency

### DIFF
--- a/cachix/src/Cachix/Client/Daemon/PushManager.hs
+++ b/cachix/src/Cachix/Client/Daemon/PushManager.hs
@@ -298,6 +298,8 @@ newPushStrategy store authToken opts cacheName compressionMethod storePath =
           onDone = onDone,
           Client.Push.compressionMethod = compressionMethod,
           Client.Push.compressionLevel = Client.OptionsParser.compressionLevel opts,
+          Client.Push.chunkSize = Client.OptionsParser.chunkSize opts,
+          Client.Push.numConcurrentChunks = Client.OptionsParser.numConcurrentChunks opts,
           Client.Push.omitDeriver = Client.OptionsParser.omitDeriver opts
         }
 


### PR DESCRIPTION
New push options:

- `--chunk-size`: defaults to 32MiB
- `--num-concurrent-chunks`: defaults to 4