### PR TITLE
daemon: lifecycle hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 == x86_64
         # macos-latest == macos-14 == aarch64
@@ -50,6 +51,7 @@ jobs:
     - name: "watch-exec test"
       env:
         signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+        NIX_USER_CONF_FILES: ""
       if: ${{ env.signingKey != '' }}
       run: ${{ steps.cachix.outputs.cachix }} watch-exec cachix -- nix-build genpaths.nix --substituters 'https://cache.nixos.org'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,13 @@ jobs:
     - uses: cachix/cachix-action@v14
       with:
         name: cachix
-
-    - uses: cachix/cachix-action@v14
-      with:
-        name: cachix
-        installCommand: NIXPKGS_ALLOW_BROKEN=1 nix-env -if .
+        installCommand: nix profile install -L --show-trace --accept-flake-config
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
-    - run:  nix build -L '.#ci' '.#cachix' --show-trace --impure
+    - run: nix build -L '.#ci' '.#cachix' --show-trace --impure
 
     - name: Install dev Cachix
-      run: nix-env -if .
-
-    # TODO; remove this
-    # make sure it's all uploaded to cachix
-    - run: echo > /tmp/store-path-pre-build
+      run: nix profile install -L --show-trace
 
     - name: "watch-exec test"
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26
-    - uses: cachix/cachix-action@master
+    - name: Setup read-only Cachix cache
+      uses: cachix/cachix-action@master
       with:
         name: cachix
         skipPush: true
@@ -29,14 +30,16 @@ jobs:
         echo "out_path=$out_path" >> "$GITHUB_OUTPUT"
         echo "cachix=$out_path/bin/cachix" >> "$GITHUB_OUTPUT"
 
-    - uses: cachix/cachix-action@master
+    - name: Cache dev build
+      uses: cachix/cachix-action@master
       with:
         name: cachix
         cachixBin: '${{ steps.cachix.outputs.cachix }}'
         pathsToPush: '${{ steps.cachix.outputs.out_path }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
-    - uses: cachix/cachix-action@master
+    - name: Setup Cachix cache with dev build
+      uses: cachix/cachix-action@master
       with:
         name: cachix
         cachixBin: '${{ steps.cachix.outputs.cachix }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         # macos-13 == x86_64
         # macos-latest == macos-14 == aarch64
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, [self-hosted, linux, ARM64], macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,18 @@ jobs:
     - uses: cachix/cachix-action@v14
       with:
         name: cachix
-        installCommand: nix profile install -L --show-trace --accept-flake-config
+        skipPush: true
+
+    - name: Build dev Cachix
+      id: cachix
+      run: |
+        out_path=$(nix build .#cachix -L --show-trace --print-out-paths)
+        echo "cachix=$out_path/bin/cachix" >> "$GITHUB_OUTPUT"
+
+    - uses: cachix/cachix-action@v14
+      with:
+        name: cachix
+        cachixBin: '${{ steps.cachix.outputs.cachix }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
     - run: nix build -L '.#ci' '.#cachix' --show-trace --impure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26
-    - uses: cachix/cachix-action@v14
+    - uses: cachix/cachix-action@master
       with:
         name: cachix
         skipPush: true
+        # TODO: allow skipping install
+        # installCommand: ""
 
     - name: Build dev Cachix
       id: cachix
@@ -26,7 +28,7 @@ jobs:
         out_path=$(nix build .#cachix -L --show-trace --print-out-paths)
         echo "cachix=$out_path/bin/cachix" >> "$GITHUB_OUTPUT"
 
-    - uses: cachix/cachix-action@v14
+    - uses: cachix/cachix-action@master
       with:
         name: cachix
         cachixBin: '${{ steps.cachix.outputs.cachix }}'
@@ -34,17 +36,14 @@ jobs:
 
     - run: nix build -L '.#ci' '.#cachix' --show-trace --impure
 
-    - name: Install dev Cachix
-      run: nix profile install -L --show-trace
-
     - name: "watch-exec test"
       env:
         signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
       if: ${{ env.signingKey != '' }}
-      run: cachix watch-exec cachix -- nix-build genpaths.nix --substituters 'https://cache.nixos.org'
+      run: ${{ steps.cachix.outputs.cachix }} watch-exec cachix -- nix-build genpaths.nix --substituters 'https://cache.nixos.org'
 
     - name: "daemon watch-exec test"
       env:
         signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
       if: ${{ env.signingKey != '' }}
-      run: cachix daemon watch-exec cachix -- nix-build genpaths.nix --substituters 'https://cache.nixos.org'
+      run: ${{ steps.cachix.outputs.cachix }} daemon watch-exec cachix -- nix-build genpaths.nix --substituters 'https://cache.nixos.org'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,15 @@ jobs:
       id: cachix
       run: |
         out_path=$(nix build .#cachix -L --show-trace --print-out-paths)
+        echo "out_path=$out_path" >> "$GITHUB_OUTPUT"
         echo "cachix=$out_path/bin/cachix" >> "$GITHUB_OUTPUT"
+
+    - uses: cachix/cachix-action@master
+      with:
+        name: cachix
+        cachixBin: '${{ steps.cachix.outputs.cachix }}'
+        pathsToPush: '${{ steps.cachix.outputs.out_path }}'
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
     - uses: cachix/cachix-action@master
       with:

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -69,6 +69,7 @@ library
     Cachix.Client.Config.Orphans
     Cachix.Client.Daemon
     Cachix.Client.Daemon.Client
+    Cachix.Client.Daemon.EventLoop
     Cachix.Client.Daemon.Listen
     Cachix.Client.Daemon.Log
     Cachix.Client.Daemon.PostBuildHook
@@ -78,12 +79,15 @@ library
     Cachix.Client.Daemon.PushManager
     Cachix.Client.Daemon.PushManager.PushJob
     Cachix.Client.Daemon.ShutdownLatch
+    Cachix.Client.Daemon.SocketStore
     Cachix.Client.Daemon.Subscription
     Cachix.Client.Daemon.Types
     Cachix.Client.Daemon.Types.Daemon
+    Cachix.Client.Daemon.Types.EventLoop
     Cachix.Client.Daemon.Types.Log
     Cachix.Client.Daemon.Types.PushEvent
     Cachix.Client.Daemon.Types.PushManager
+    Cachix.Client.Daemon.Types.SocketStore
     Cachix.Client.Daemon.Worker
     Cachix.Client.Env
     Cachix.Client.Exception

--- a/cachix/src/Cachix/Client/Daemon/Client.hs
+++ b/cachix/src/Cachix/Client/Daemon/Client.hs
@@ -7,6 +7,7 @@ import Cachix.Client.OptionsParser (DaemonOptions (..))
 import qualified Cachix.Client.Retry as Retry
 import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.STM.TBMQueue
+import Control.Exception.Safe (catchAny)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as Lazy.Char8
@@ -101,7 +102,7 @@ stop _env daemonOptions =
       where
         go = do
           -- Wait for the socket to close
-          bs <- Socket.BS.recv sock 4096 `onException` return BS.empty
+          bs <- Socket.BS.recv sock 4096 `catchAny` (\_ -> return BS.empty)
 
           -- A zero-length response means that the daemon has closed the socket
           if BS.null bs

--- a/cachix/src/Cachix/Client/Daemon/Client.hs
+++ b/cachix/src/Cachix/Client/Daemon/Client.hs
@@ -4,23 +4,33 @@ import Cachix.Client.Daemon.Listen (getSocketPath)
 import Cachix.Client.Daemon.Protocol as Protocol
 import Cachix.Client.Env as Env
 import Cachix.Client.OptionsParser (DaemonOptions (..))
+import qualified Cachix.Client.Retry as Retry
 import qualified Control.Concurrent.Async as Async
-import Control.Concurrent.MVar
 import Control.Concurrent.STM.TBMQueue
-import Control.Exception.Safe (catchAny)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy.Char8 as Lazy.Char8
 import Data.IORef
 import Data.Time.Clock
 import qualified Network.Socket as Socket
 import qualified Network.Socket.ByteString as Socket.BS
 import qualified Network.Socket.ByteString.Lazy as Socket.LBS
 import Protolude
-import qualified System.Posix.IO as Posix
 
-data DaemonException = Unresponsive deriving (Show)
+data SocketError
+  = -- | The socket has been closed
+    SocketClosed
+  | -- | The socket has stopped responding to pings
+    SocketStalled
+  | -- | Failed to decode a message from the socket
+    SocketDecodingError !Text
+  deriving stock (Show)
 
-instance Exception DaemonException
+instance Exception SocketError where
+  displayException = \case
+    SocketClosed -> "The socket has been closed"
+    SocketStalled -> "The socket has stopped responding to pings"
+    SocketDecodingError err -> "Failed to decode message from socket: " <> toS err
 
 -- | Queue up push requests with the daemon
 --
@@ -28,7 +38,7 @@ instance Exception DaemonException
 push :: Env -> DaemonOptions -> [FilePath] -> IO ()
 push _env daemonOptions storePaths =
   withDaemonConn (daemonSocketPath daemonOptions) $ \sock -> do
-    Socket.LBS.sendAll sock (Aeson.encode pushRequest)
+    Socket.LBS.sendAll sock $ Aeson.encode pushRequest `Lazy.Char8.snoc` '\n'
   where
     pushRequest =
       Protocol.ClientPushRequest $
@@ -38,84 +48,84 @@ push _env daemonOptions storePaths =
 stop :: Env -> DaemonOptions -> IO ()
 stop _env daemonOptions =
   withDaemonConn (daemonSocketPath daemonOptions) $ \sock -> do
-    putErrText "Setting up queues for daemon communication"
     let size = 100
-    (rx, tx) :: (TBMQueue Protocol.DaemonMessage, TBMQueue Protocol.ClientMessage) <-
-      atomically $ (,) <$> newTBMQueue size <*> newTBMQueue size
+    (rx, tx) <- atomically $ (,) <$> newTBMQueue size <*> newTBMQueue size
 
-    mainThread <- myThreadId
+    rxThread <- Async.async (handleIncoming rx sock)
+    txThread <- Async.async (handleOutgoing tx sock)
+
     lastPongRef <- newIORef =<< getCurrentTime
-    rxThread <- Async.async $ fix $ \loop -> do
-      -- Wait for the socket to close
-      bs <- Socket.BS.recv sock 4096 `catchAny` (\_ -> putErrText "socket error" >> pure BS.empty)
+    pingThread <- Async.async (runPingThread lastPongRef rx tx)
 
-      -- A zero-length response means that the daemon has closed the socket
-      if BS.null bs
-        then do
-          putErrText "Got nothing. sleeping"
-          threadDelay (1 * 1000 * 1000)
-          loop
-        else case Aeson.eitherDecodeStrict bs of
-          Left err -> do
-            putErrText (toS err)
-            throwTo mainThread Unresponsive
-          Right msg -> do
-            putErrText $ "Received message from daemon: " <> show msg
-            atomically $ writeTBMQueue rx msg
-            loop
-
-    txThread <- Async.async $ fix $ \loop -> do
-      mmsg <- atomically $ readTBMQueue tx
-      for_ mmsg $ \msg -> do
-        Socket.LBS.sendAll sock (Aeson.encode msg)
-        loop
-
-    pingThread <- Async.async $ forever $ do
-      timestamp <- getCurrentTime
-      lastPong <- readIORef lastPongRef
-      when (timestamp >= addUTCTime 30 lastPong) $ do
-        putErrText "Daemon is unresponsive, killing"
-        throwTo mainThread Unresponsive
-      putErrText "Sending ping to daemon"
-      atomically $ writeTBMQueue tx Protocol.ClientPing
-      threadDelay (20 * 1000 * 1000)
+    -- mapM_ Async.link [rxThread, txThread, pingThread]
 
     -- Request the daemon to stop
-    putErrText "Sending client stop"
     atomically $ writeTBMQueue tx Protocol.ClientStop
 
     fix $ \loop -> do
-      atomically (readTBMQueue rx) >>= \case
+      mmsg <- atomically (readTBMQueue rx)
+      case mmsg of
         Nothing -> return ()
-        Just Protocol.DaemonPong -> do
-          putErrText "Got back pong"
-          writeIORef lastPongRef =<< getCurrentTime
-          loop
-        Just Protocol.DaemonBye -> do
-          Async.cancel rxThread
-          Async.cancel txThread
-          Async.cancel pingThread
-          return ()
+        Just (Left err) -> putErrText $ toS $ displayException err
+        Just (Right msg) ->
+          case msg of
+            Protocol.DaemonPong -> do
+              writeIORef lastPongRef =<< getCurrentTime
+              loop
+            Protocol.DaemonBye -> exitSuccess
+  where
+    runPingThread lastPongRef rx tx = go
+      where
+        go = do
+          timestamp <- getCurrentTime
+          lastPong <- readIORef lastPongRef
+
+          if timestamp >= addUTCTime 20 lastPong
+            then atomically $ writeTBMQueue rx (Left SocketStalled)
+            else do
+              atomically $ writeTBMQueue tx Protocol.ClientPing
+              threadDelay (2 * 1000 * 1000)
+              go
+
+    handleOutgoing tx sock = go
+      where
+        go = do
+          mmsg <- atomically $ readTBMQueue tx
+          case mmsg of
+            Nothing -> return ()
+            Just msg -> do
+              Retry.retryAll $ const $ Socket.LBS.sendAll sock $ Aeson.encode msg `Lazy.Char8.snoc` '\n'
+              go
+
+    handleIncoming rx sock = go
+      where
+        go = do
+          -- Wait for the socket to close
+          bs <- Socket.BS.recv sock 4096 `onException` return BS.empty
+
+          -- A zero-length response means that the daemon has closed the socket
+          if BS.null bs
+            then atomically $ writeTBMQueue rx (Left SocketClosed)
+            else case Aeson.eitherDecodeStrict bs of
+              Left err -> do
+                let terr = toS err
+                putErrText terr
+                atomically $ writeTBMQueue rx (Left (SocketDecodingError terr))
+              Right msg -> do
+                atomically $ writeTBMQueue rx (Right msg)
+                go
 
 withDaemonConn :: Maybe FilePath -> (Socket.Socket -> IO a) -> IO a
 withDaemonConn optionalSocketPath f = do
-  putErrText "Connecting to Cachix Daemon"
   socketPath <- maybe getSocketPath pure optionalSocketPath
-  bracket (open socketPath) Socket.close f `onException` failedToConnectTo socketPath
+  bracket (open socketPath `onException` failedToConnectTo socketPath) Socket.close f
   where
     open socketPath = do
       sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
-      putErrText $ "Connecting to: " <> show socketPath
-      Socket.connect sock (Socket.SockAddrUnix socketPath)
-
-      -- putErrText "Setting up non-blocking socket"
-      -- Network.Socket.accept sets the socket to non-blocking by default.
-      -- Socket.withFdSocket sock $ \fd ->
-      --   Posix.setFdOption (fromIntegral fd) Posix.NonBlockingRead False
-
+      Retry.retryAll $ const $ Socket.connect sock (Socket.SockAddrUnix socketPath)
       return sock
 
     failedToConnectTo :: FilePath -> IO ()
     failedToConnectTo socketPath = do
-      putErrText "Failed to connect to Cachix Daemon"
+      putErrText "\nFailed to connect to Cachix Daemon"
       putErrText $ "Tried to connect to: " <> toS socketPath <> "\n"

--- a/cachix/src/Cachix/Client/Daemon/Client.hs
+++ b/cachix/src/Cachix/Client/Daemon/Client.hs
@@ -5,14 +5,21 @@ import Cachix.Client.Daemon.Protocol as Protocol
 import Cachix.Client.Env as Env
 import Cachix.Client.OptionsParser (DaemonOptions (..))
 import qualified Control.Concurrent.Async as Async
+import Control.Concurrent.MVar
+import Control.Concurrent.STM.TBMQueue
 import Control.Exception.Safe (catchAny)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
+import Data.Time.Clock
 import qualified Network.Socket as Socket
 import qualified Network.Socket.ByteString as Socket.BS
 import qualified Network.Socket.ByteString.Lazy as Socket.LBS
 import Protolude
 import qualified System.Posix.IO as Posix
+
+data DaemonException = Unresponsive deriving (Show)
+
+instance Exception DaemonException
 
 -- | Queue up push requests with the daemon
 --
@@ -30,10 +37,13 @@ push _env daemonOptions storePaths =
 stop :: Env -> DaemonOptions -> IO ()
 stop _env daemonOptions =
   withDaemonConn (daemonSocketPath daemonOptions) $ \sock -> do
-    Async.concurrently_ (waitForResponse sock) $
-      Socket.LBS.sendAll sock (Aeson.encode Protocol.ClientStop)
-  where
-    waitForResponse sock = do
+    let size = 100
+    (rx, tx) :: (TBMQueue Protocol.DaemonMessage, TBMQueue Protocol.ClientMessage) <-
+      atomically $ (,) <$> newTBMQueue size <*> newTBMQueue size
+
+    mainThread <- myThreadId
+    lastPongMVar <- newEmptyMVar
+    rxThread <- Async.async $ fix $ \loop -> do
       -- Wait for the socket to close
       bs <- Socket.BS.recv sock 4096 `catchAny` (\_ -> return BS.empty)
 
@@ -41,8 +51,43 @@ stop _env daemonOptions =
       guard $ not $ BS.null bs
 
       case Aeson.eitherDecodeStrict bs of
-        Left err -> putErrText (toS err)
-        Right DaemonBye -> return ()
+        Left err -> do
+          putErrText (toS err)
+          throwTo mainThread Unresponsive
+        Right msg -> do
+          atomically $ writeTBMQueue rx msg
+          loop
+
+    txThread <- Async.async $ fix $ \loop -> do
+      mmsg <- atomically $ readTBMQueue tx
+      for_ mmsg $ \msg -> do
+        Socket.LBS.sendAll sock (Aeson.encode msg)
+        loop
+
+    pingThread <- Async.async $ forever $ do
+      threadDelay (20 * 1000 * 1000)
+      timestamp <- getCurrentTime
+      lastPong <- readMVar lastPongMVar
+      when (timestamp >= addUTCTime 30 lastPong) $ do
+        putErrText "Daemon is unresponsive, killing"
+        throwTo mainThread Unresponsive
+      putErrText "Sending ping to daemon"
+      atomically $ writeTBMQueue tx Protocol.ClientPing
+
+    -- Request the daemon to stop
+    atomically $ writeTBMQueue tx Protocol.ClientStop
+
+    fix $ \loop -> do
+      atomically (readTBMQueue rx) >>= \case
+        Nothing -> return ()
+        Just Protocol.DaemonPong -> do
+          putMVar lastPongMVar =<< getCurrentTime
+          loop
+        Just Protocol.DaemonBye -> do
+          Async.cancel rxThread
+          Async.cancel txThread
+          Async.cancel pingThread
+          return ()
 
 withDaemonConn :: Maybe FilePath -> (Socket.Socket -> IO a) -> IO a
 withDaemonConn optionalSocketPath f = do

--- a/cachix/src/Cachix/Client/Daemon/EventLoop.hs
+++ b/cachix/src/Cachix/Client/Daemon/EventLoop.hs
@@ -1,0 +1,29 @@
+module Cachix.Client.Daemon.EventLoop (new, send, run, exitLoopWith, EventLoop, DaemonEvent (..)) where
+
+import Cachix.Client.Daemon.Types.EventLoop (DaemonEvent (..), EventLoop)
+import Control.Concurrent.STM.TBMQueue (newTBMQueueIO, readTBMQueue, writeTBMQueue)
+import Protolude
+
+type ExitLatch = MVar ExitCode
+
+new :: (MonadIO m) => m EventLoop
+new = liftIO $ newTBMQueueIO 100
+
+send :: (MonadIO m) => EventLoop -> DaemonEvent -> m ()
+send eventloop = liftIO . atomically . writeTBMQueue eventloop
+
+run :: (MonadIO m) => EventLoop -> ((ExitLatch, DaemonEvent) -> m ()) -> m ExitCode
+run eventloop f = do
+  exitLatch <- liftIO newEmptyMVar
+  fix $ \loop -> do
+    mevent <- liftIO $ atomically $ readTBMQueue eventloop
+    case mevent of
+      Just event -> f (exitLatch, event)
+      Nothing -> void $ liftIO $ tryPutMVar exitLatch ExitSuccess
+
+    liftIO (tryReadMVar exitLatch) >>= \case
+      Just exitCode -> return exitCode
+      Nothing -> loop
+
+exitLoopWith :: (MonadIO m) => ExitCode -> ExitLatch -> m ()
+exitLoopWith exitCode exitLatch = void $ liftIO $ tryPutMVar exitLatch exitCode

--- a/cachix/src/Cachix/Client/Daemon/Listen.hs
+++ b/cachix/src/Cachix/Client/Daemon/Listen.hs
@@ -13,7 +13,7 @@ import qualified Cachix.Client.Daemon.EventLoop as EventLoop
 import Cachix.Client.Daemon.Protocol as Protocol
 import Cachix.Client.Daemon.Types.EventLoop (EventLoop)
 import Cachix.Client.Daemon.Types.SocketStore (SocketId)
-import qualified Control.Exception.Safe as Safe
+import Control.Exception.Safe (catchAny)
 import qualified Control.Monad.Catch as E
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
@@ -95,7 +95,7 @@ handleClient eventloop socketId conn = do
 
 serverBye :: Socket.Socket -> IO ()
 serverBye sock =
-  Socket.LBS.sendAll sock (Aeson.encode DaemonBye) `onException` return ()
+  Socket.LBS.sendAll sock (Aeson.encode DaemonBye) `catchAny` (\_ -> return ())
 
 -- mapSyncException :: (Exception e1, Exception e2, Safe.MonadCatch m) => m a -> (e1 -> e2) -> m a
 -- mapSyncException a f = a `Safe.catch` (Safe.throwM . f)

--- a/cachix/src/Cachix/Client/Daemon/Listen.hs
+++ b/cachix/src/Cachix/Client/Daemon/Listen.hs
@@ -68,7 +68,9 @@ listen onClientStop onPushRequest sock = loop
         Left err@(DecodingError _) -> do
           Katip.logFM Katip.ErrorS $ Katip.ls $ displayException err
           loop
-        Left err -> throwIO err
+        Left err -> do
+          Katip.logFM Katip.ErrorS $ Katip.ls $ displayException err
+          throwIO err
 
 serverBye :: Socket.Socket -> IO ()
 serverBye sock =

--- a/cachix/src/Cachix/Client/Daemon/Listen.hs
+++ b/cachix/src/Cachix/Client/Daemon/Listen.hs
@@ -54,7 +54,12 @@ listen onClientStop onPushRequest sock = loop
       result <- liftIO $ runExceptT $ readPushRequest sock
 
       case result of
+        Right (ClientPing, clientConn) -> do
+          Katip.logFM Katip.DebugS "Received ping"
+          liftIO $ Socket.LBS.sendAll clientConn (Aeson.encode DaemonPong)
+          loop
         Right (ClientStop, clientConn) -> do
+          Katip.logFM Katip.DebugS "Received stop request"
           onClientStop
           return clientConn
         Right (ClientPushRequest pushRequest, clientConn) -> do

--- a/cachix/src/Cachix/Client/Daemon/Listen.hs
+++ b/cachix/src/Cachix/Client/Daemon/Listen.hs
@@ -1,5 +1,6 @@
 module Cachix.Client.Daemon.Listen
   ( listen,
+    handleClient,
     serverBye,
     getSocketPath,
     openSocket,
@@ -8,11 +9,17 @@ module Cachix.Client.Daemon.Listen
 where
 
 import Cachix.Client.Config.Orphans ()
+import qualified Cachix.Client.Daemon.EventLoop as EventLoop
 import Cachix.Client.Daemon.Protocol as Protocol
-import Control.Exception.Safe (catchAny)
+import Cachix.Client.Daemon.Types.EventLoop (EventLoop)
+import Cachix.Client.Daemon.Types.SocketStore (SocketId)
 import qualified Control.Exception.Safe as Safe
+import qualified Control.Monad.Catch as E
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as Char8
 import qualified Katip
+import Network.Socket (Socket)
 import qualified Network.Socket as Socket
 import qualified Network.Socket.ByteString as Socket.BS
 import qualified Network.Socket.ByteString.Lazy as Socket.LBS
@@ -35,66 +42,63 @@ data ListenError
 instance Exception ListenError where
   displayException = \case
     SocketError err -> "Failed to read from the daemon socket: " <> show err
-    DecodingError err -> "Failed to decode request: " <> toS err
+    DecodingError err -> "Failed to decode request:\n" <> toS err
 
 -- | The main daemon server loop.
 listen ::
-  (Katip.KatipContext m) =>
-  -- | An action to run when the daemon is requested to stop
-  m () ->
-  -- | An action to run when a push request is received
-  (Protocol.PushRequest -> Socket.Socket -> m ()) ->
-  -- | An active socket to listen on
-  Socket.Socket ->
-  -- | Returns a socket to the client that requested the daemon to stop
-  m Socket.Socket
-listen onClientStop onPushRequest sock = loop
-  where
-    loop = do
-      result <- liftIO $ runExceptT $ readPushRequest sock
+  (MonadIO m, E.MonadMask m) =>
+  EventLoop ->
+  FilePath ->
+  m ()
+listen eventloop daemonSocketPath = forever $ do
+  E.bracketOnError (openSocket daemonSocketPath) closeSocket $ \sock -> do
+    liftIO $ Socket.listen sock Socket.maxListenQueue
+    (conn, _peerAddr) <- liftIO $ Socket.accept sock
+    EventLoop.send eventloop (EventLoop.AddSocketClient conn)
 
-      case result of
-        Right (ClientPing, clientConn) -> do
-          Katip.logFM Katip.DebugS "Received ping"
-          liftIO $ Socket.LBS.sendAll clientConn (Aeson.encode DaemonPong)
-          loop
-        Right (ClientStop, clientConn) -> do
-          Katip.logFM Katip.DebugS "Received stop request"
-          onClientStop
-          return clientConn
-        Right (ClientPushRequest pushRequest, clientConn) -> do
-          onPushRequest pushRequest clientConn
-          loop
-        Left err@(DecodingError _) -> do
-          Katip.logFM Katip.ErrorS $ Katip.ls $ displayException err
-          loop
+handleClient ::
+  forall m.
+  (E.MonadCatch m, Katip.KatipContext m) =>
+  EventLoop ->
+  SocketId ->
+  Socket ->
+  m ()
+handleClient eventloop socketId conn = do
+  go `E.onException` removeClient
+  where
+    go = do
+      bs <- liftIO $ Socket.BS.recv conn 4096
+      -- If the socket returns 0 bytes, then it is closed
+      if BS.null bs
+        then removeClient
+        else do
+          msgs <- catMaybes <$> mapM decodeMessage (Char8.split '\n' bs)
+          liftIO $ putErrText $ "Received: " <> show msgs
+
+          forM_ msgs $ \msg -> do
+            EventLoop.send eventloop (EventLoop.ReceivedMessage msg)
+            case msg of
+              Protocol.ClientPing ->
+                liftIO $ Socket.LBS.sendAll conn (Aeson.encode DaemonPong)
+              _ -> return ()
+
+    decodeMessage :: ByteString -> m (Maybe Protocol.ClientMessage)
+    decodeMessage "" = return Nothing
+    decodeMessage bs =
+      case Aeson.eitherDecodeStrict bs of
         Left err -> do
-          Katip.logFM Katip.ErrorS $ Katip.ls $ displayException err
-          throwIO err
+          Katip.logFM Katip.ErrorS $ Katip.ls $ displayException (DecodingError (toS err))
+          return Nothing
+        Right msg -> return (Just msg)
+
+    removeClient = EventLoop.send eventloop (EventLoop.RemoveSocketClient socketId)
 
 serverBye :: Socket.Socket -> IO ()
 serverBye sock =
-  Socket.LBS.sendAll sock (Aeson.encode DaemonBye) `catchAny` (\_ -> return ())
+  Socket.LBS.sendAll sock (Aeson.encode DaemonBye) `onException` return ()
 
--- | Try to read and decode a push request.
-readPushRequest :: Socket.Socket -> ExceptT ListenError IO (ClientMessage, Socket.Socket)
-readPushRequest sock = do
-  (bs, clientConn) <- readFromSocket `mapSyncException` SocketError
-  decodeMessage clientConn bs
-  where
-    readFromSocket = liftIO $ do
-      -- NOTE: this sets up a non-blocking socket to the client
-      (conn, _peerAddr) <- Socket.accept sock
-      bs <- Socket.BS.recv conn 4096
-      return (bs, conn)
-
-    decodeMessage conn bs =
-      case Aeson.eitherDecodeStrict bs of
-        Left err -> throwE $ DecodingError (toS err)
-        Right pushRequest -> return (pushRequest, conn)
-
-mapSyncException :: (Exception e1, Exception e2, Safe.MonadCatch m) => m a -> (e1 -> e2) -> m a
-mapSyncException a f = a `Safe.catch` (Safe.throwM . f)
+-- mapSyncException :: (Exception e1, Exception e2, Safe.MonadCatch m) => m a -> (e1 -> e2) -> m a
+-- mapSyncException a f = a `Safe.catch` (Safe.throwM . f)
 
 getSocketPath :: IO FilePath
 getSocketPath = do

--- a/cachix/src/Cachix/Client/Daemon/Protocol.hs
+++ b/cachix/src/Cachix/Client/Daemon/Protocol.hs
@@ -16,14 +16,16 @@ import Protolude
 
 -- | JSON messages that the client can send to the daemon
 data ClientMessage
-  = ClientPushRequest PushRequest
+  = ClientPushRequest !PushRequest
   | ClientStop
+  | ClientPing
   deriving stock (Generic)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 -- | JSON messages that the daemon can send to the client
 data DaemonMessage
-  = DaemonBye
+  = DaemonPong
+  | DaemonBye
   deriving stock (Generic)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 

--- a/cachix/src/Cachix/Client/Daemon/Protocol.hs
+++ b/cachix/src/Cachix/Client/Daemon/Protocol.hs
@@ -19,14 +19,14 @@ data ClientMessage
   = ClientPushRequest !PushRequest
   | ClientStop
   | ClientPing
-  deriving stock (Generic)
+  deriving stock (Generic, Show)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 -- | JSON messages that the daemon can send to the client
 data DaemonMessage
   = DaemonPong
   | DaemonBye
-  deriving stock (Generic)
+  deriving stock (Generic, Show)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 newtype PushRequestId = PushRequestId UUID

--- a/cachix/src/Cachix/Client/Daemon/SocketStore.hs
+++ b/cachix/src/Cachix/Client/Daemon/SocketStore.hs
@@ -1,0 +1,38 @@
+module Cachix.Client.Daemon.SocketStore
+  ( newSocketStore,
+    addSocket,
+    removeSocket,
+    toList,
+    Socket (..),
+  )
+where
+
+import Cachix.Client.Daemon.Types.SocketStore (Socket (..), SocketId, SocketStore (..))
+import Control.Concurrent.STM.TVar
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.UUID.V4 as UUID
+import qualified Network.Socket
+import Protolude hiding (toList)
+import qualified UnliftIO.Async as Async
+
+newSocketStore :: (MonadIO m) => m SocketStore
+newSocketStore = SocketStore <$> liftIO (newTVarIO mempty)
+
+newSocketId :: (MonadIO m) => m SocketId
+newSocketId = liftIO UUID.nextRandom
+
+addSocket :: (MonadUnliftIO m) => Network.Socket.Socket -> (SocketId -> Network.Socket.Socket -> m ()) -> SocketStore -> m ()
+addSocket socket handler (SocketStore st) = do
+  socketId <- newSocketId
+  handlerThread <- Async.async (handler socketId socket)
+  liftIO $ atomically $ modifyTVar' st $ HashMap.insert socketId (Socket {..})
+
+removeSocket :: (MonadIO m) => SocketId -> SocketStore -> m ()
+removeSocket socketId (SocketStore st) =
+  liftIO $ atomically $ modifyTVar' st $ HashMap.delete socketId
+
+toList :: (MonadIO m) => SocketStore -> m [Socket]
+toList (SocketStore st) = do
+  hm <- liftIO $ readTVarIO st
+  return $ HashMap.elems hm

--- a/cachix/src/Cachix/Client/Daemon/Types/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types/Daemon.hs
@@ -13,9 +13,11 @@ import qualified Cachix.Client.Daemon.Log as Log
 import qualified Cachix.Client.Daemon.Protocol as Protocol
 import Cachix.Client.Daemon.ShutdownLatch (ShutdownLatch)
 import Cachix.Client.Daemon.Subscription (SubscriptionManager)
+import Cachix.Client.Daemon.Types.EventLoop (EventLoop)
 import Cachix.Client.Daemon.Types.Log (Logger)
 import Cachix.Client.Daemon.Types.PushEvent (PushEvent)
 import Cachix.Client.Daemon.Types.PushManager (PushManagerEnv (..))
+import Cachix.Client.Daemon.Types.SocketStore (SocketStore)
 import Cachix.Client.Env as Env
 import Cachix.Client.OptionsParser (PushOptions)
 import Cachix.Client.Push
@@ -29,10 +31,14 @@ import System.Posix.Types (ProcessID)
 data DaemonEnv = DaemonEnv
   { -- | Cachix client env
     daemonEnv :: Env,
+    -- | The main event loop
+    daemonEventLoop :: EventLoop,
     -- | Push options, like compression settings and number of jobs
     daemonPushOptions :: PushOptions,
     -- | Path to the socket that the daemon listens on
     daemonSocketPath :: FilePath,
+    -- | Main inbound socket thread
+    daemonSocketThread :: MVar (Async ()),
     -- | The push secret for the binary cache
     daemonPushSecret :: PushSecret,
     -- | The name of the binary cache to push to
@@ -41,6 +47,8 @@ data DaemonEnv = DaemonEnv
     daemonBinaryCache :: BinaryCache,
     -- | The state of active push requests
     daemonPushManager :: PushManagerEnv,
+    -- | Connected clients over the socket
+    daemonClients :: SocketStore,
     -- | A multiplexer for push events.
     daemonSubscriptionManager :: SubscriptionManager Protocol.PushRequestId PushEvent,
     -- | Logging env

--- a/cachix/src/Cachix/Client/Daemon/Types/EventLoop.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types/EventLoop.hs
@@ -1,0 +1,19 @@
+module Cachix.Client.Daemon.Types.EventLoop
+  ( EventLoop,
+    DaemonEvent (..),
+  )
+where
+
+import qualified Cachix.Client.Daemon.Protocol as Protocol
+import Cachix.Client.Daemon.Types.SocketStore (SocketId)
+import Control.Concurrent.STM.TBMQueue (TBMQueue)
+import Network.Socket (Socket)
+
+type EventLoop = TBMQueue DaemonEvent
+
+data DaemonEvent
+  = ShutdownGracefully
+  | ReconnectSocket
+  | AddSocketClient Socket
+  | RemoveSocketClient SocketId
+  | ReceivedMessage Protocol.ClientMessage

--- a/cachix/src/Cachix/Client/Daemon/Types/SocketStore.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types/SocketStore.hs
@@ -1,0 +1,23 @@
+module Cachix.Client.Daemon.Types.SocketStore (Socket (..), SocketId, SocketStore (..)) where
+
+import Control.Concurrent.STM.TVar (TVar)
+import Data.HashMap.Strict (HashMap)
+import Data.UUID (UUID)
+import qualified Network.Socket as Network (Socket)
+import Protolude
+
+data Socket = Socket
+  { socketId :: SocketId,
+    socket :: Network.Socket,
+    handlerThread :: Async ()
+  }
+
+instance Eq Socket where
+  (==) = (==) `on` socketId
+
+instance Ord Socket where
+  compare = comparing socketId
+
+type SocketId = UUID
+
+newtype SocketStore = SocketStore (TVar (HashMap SocketId Socket))

--- a/cachix/src/Cachix/Client/Daemon/Worker.hs
+++ b/cachix/src/Cachix/Client/Daemon/Worker.hs
@@ -3,6 +3,7 @@ module Cachix.Client.Daemon.Worker
     stopWorkers,
     startWorker,
     stopWorker,
+    Immortal.Thread,
   )
 where
 


### PR DESCRIPTION
- Refactor the main blocking thread into an event loop to make it possible to manage internal daemon state. For example, react to new messages, add and remove active sockets, etc.
- Add ping-pong messages to the protocol to allow for liveness checks.
- Remove socket conversion to blocking mode when connecting as a client. This causes hangs on some systems.