### PR TITLE
lix: support parsing lix version strings

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -266,5 +266,6 @@ test-suite cachix-test
     , stm
     , temporary
     , time
+    , versions
 
   build-tool-depends: hspec-discover:hspec-discover

--- a/cachix/src/Cachix/Client/NixVersion.hs
+++ b/cachix/src/Cachix/Client/NixVersion.hs
@@ -1,33 +1,64 @@
+-- TODO: we may need to revisit this when the various flavours of Nix start to diverge
 module Cachix.Client.NixVersion
   ( assertNixVersion,
     parseNixVersion,
+    minimalVersion,
   )
 where
 
+import Data.Either.Extra (mapLeft)
 import Data.Text as T
-import Data.Versions
+import Data.Versions hiding (versioning')
 import Protolude
 import System.Process (readProcessWithExitCode)
-
-assertNixVersion :: IO (Either Text ())
-assertNixVersion = do
-  (exitcode, out, err) <- readProcessWithExitCode "nix-env" ["--version"] mempty
-  unless (err == "") $ putStrLn $ "nix-env stderr: " <> err
-  return $ case exitcode of
-    ExitFailure i -> Left $ "'nix-env --version' exited with " <> show i
-    ExitSuccess -> parseNixVersion $ toS out
-
-parseNixVersion :: Text -> Either Text ()
-parseNixVersion output =
-  let verStr = T.drop 14 $ T.strip output
-      err = "Couldn't parse 'nix-env --version' output: " <> output
-   in case versioning verStr of
-        Left _ -> Left err
-        Right ver
-          | verStr == "" -> Left err
-          | ver < Ideal minimalVersion -> Left "Nix 2.0.2 or lower is not supported. Please upgrade: https://nixos.org/nix/"
-          | otherwise -> Right ()
+import Text.Megaparsec (Parsec, anySingle, choice, eof, lookAhead, manyTill, parse)
+import qualified Text.Megaparsec as P
+import Text.Megaparsec.Char (digitChar)
 
 minimalVersion :: SemVer
 minimalVersion =
   semver "2.0.1" & fromRight (panic "Couldn't parse minimalVersion")
+
+assertNixVersion :: IO (Either Text ())
+assertNixVersion = do
+  nixVersion <- fmap (>>= parseNixVersion) getRawNixVersion
+  return $ case nixVersion of
+    Left err -> Left err
+    Right ver
+      | ver < Ideal minimalVersion -> Left "Nix 2.0.2 or lower is not supported. Please upgrade: https://nixos.org/nix/"
+      | otherwise -> Right ()
+
+getRawNixVersion :: IO (Either Text Text)
+getRawNixVersion = do
+  (exitcode, out, err) <- readProcessWithExitCode "nix-env" ["--version"] mempty
+  unless (err == "") $ putStrLn $ "nix-env stderr: " <> err
+  return $ case exitcode of
+    ExitFailure i -> Left $ "'nix-env --version' exited with " <> show i
+    ExitSuccess -> Right (toS out)
+
+parseNixVersion :: Text -> Either Text Versioning
+parseNixVersion input =
+  mapLeft fromParsingError $ parse nixVersionParser "Nix version" input
+  where
+    fromParsingError pe =
+      unlines
+        [ "Couldn't parse 'nix-env --version' output: " <> input,
+          T.pack $ errorBundlePretty pe
+        ]
+
+-- | Parses a semver string out of the output of `nix-env --version` or `nix --version`.
+nixVersionParser :: Parsec Void Text Versioning
+nixVersionParser = do
+  _ <- manyTill anySingle (lookAhead digitChar)
+  v <- versioning'
+  _ <- manyTill anySingle eof
+  pure v
+
+-- | Same as `versioning'`, but without the restriction of preceding eof.
+versioning' :: Parsec Void Text Versioning
+versioning' =
+  choice
+    [ P.try (fmap Ideal semver'),
+      P.try (fmap General version'),
+      fmap Complex mess'
+    ]

--- a/cachix/test/NixVersionSpec.hs
+++ b/cachix/test/NixVersionSpec.hs
@@ -1,23 +1,39 @@
-module NixVersionSpec where
+module NixVersionSpec (spec) where
 
 import Cachix.Client.NixVersion
+import Data.Versions (Versioning, versioning)
 import Protolude
 import Test.Hspec
 
 spec :: Spec
-spec = describe "parseNixVersion" $ do
-  it "parses 'nix-env (Nix) 2.0' as Nix20" $
-    parseNixVersion "nix-env (Nix) 2.0"
-      `shouldBe` Left "Nix 2.0.2 or lower is not supported. Please upgrade: https://nixos.org/nix/"
-  it "parses 'nix-env (Nix) 2.0.1' as Nix201" $
-    parseNixVersion "nix-env (Nix) 2.0.1"
-      `shouldBe` Right ()
-  it "parses 'nix-env (Nix) 1.11.13' as Nix1XX" $
-    parseNixVersion "nix-env (Nix) 1.11.13"
-      `shouldBe` Left "Nix 2.0.2 or lower is not supported. Please upgrade: https://nixos.org/nix/"
-  it "parses 'nix-env (Nix) 2.0.2' as Nix202" $
-    parseNixVersion "nix-env (Nix) 2.0.2"
-      `shouldBe` Right ()
-  it "fails with unknown string 'foobar'" $
-    parseNixVersion "foobar"
-      `shouldBe` Left "Couldn't parse 'nix-env --version' output: foobar"
+spec = do
+  describe "parseNixVersion" $ do
+    it "fails with unknown string 'foobar'" $
+      parseNixVersion "foobar" `shouldSatisfy` isLeft
+
+    it "parses out a semver out of an unexpected string" $
+      parseNixVersion "foobar 2.0.1 other stuff"
+        `shouldBe` Right (toVersioning "2.0.1")
+
+    describe "Nix" $
+      runParserTests
+        [ ("nix-env (Nix) 2.0", toVersioning "2.0"),
+          ("nix-env (Nix) 2.0.1", toVersioning "2.0.1"),
+          ("nix-env (Nix) 2.0.1\n", toVersioning "2.0.1")
+        ]
+
+    describe "Lix" $
+      runParserTests
+        [ ("nix-env (Lix, like Nix) 2.90-beta.0", toVersioning "2.90-beta.0"),
+          ("nix-env (Lix, like Nix) 2.90-beta.1-lixpre20240506-b6799ab", toVersioning "2.90-beta.1-lixpre20240506-b6799ab")
+        ]
+
+runParserTests :: [(Text, Versioning)] -> Spec
+runParserTests tests = do
+  forM_ tests $ \(input, expected) ->
+    it ("parses '" <> toS input <> "'") $
+      parseNixVersion input `shouldBe` Right expected
+
+toVersioning :: Text -> Versioning
+toVersioning str =
+  versioning str & fromRight (panic "Couldn't parse version")


### PR DESCRIPTION
Improves how we parse out the semver string from `nix-env --version` (or `nix --version`).
We'll have to keep an eye out for how the various forks evolve and make a call on what we commit to support.

Fixes #644.