### PR TITLE
daemon: implement an event loop for the main thread

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -69,6 +69,7 @@ library
     Cachix.Client.Config.Orphans
     Cachix.Client.Daemon
     Cachix.Client.Daemon.Client
+    Cachix.Client.Daemon.EventLoop
     Cachix.Client.Daemon.Listen
     Cachix.Client.Daemon.Log
     Cachix.Client.Daemon.PostBuildHook
@@ -78,12 +79,15 @@ library
     Cachix.Client.Daemon.PushManager
     Cachix.Client.Daemon.PushManager.PushJob
     Cachix.Client.Daemon.ShutdownLatch
+    Cachix.Client.Daemon.SocketStore
     Cachix.Client.Daemon.Subscription
     Cachix.Client.Daemon.Types
     Cachix.Client.Daemon.Types.Daemon
+    Cachix.Client.Daemon.Types.EventLoop
     Cachix.Client.Daemon.Types.Log
     Cachix.Client.Daemon.Types.PushEvent
     Cachix.Client.Daemon.Types.PushManager
+    Cachix.Client.Daemon.Types.SocketStore
     Cachix.Client.Daemon.Worker
     Cachix.Client.Env
     Cachix.Client.Exception

--- a/cachix/src/Cachix/Client/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon.hs
@@ -91,14 +91,13 @@ start daemonEnv daemonOptions daemonPushOptions daemonCacheName = do
   installSignalHandlers daemon
   void $ run daemon
 
--- | Run a daemon from a given configuration
+-- | Run a daemon from a given configuration.
 run :: DaemonEnv -> IO ExitCode
 run daemon = runDaemon daemon $ flip E.onError (return $ ExitFailure 1) $ do
   Katip.logFM Katip.InfoS "Starting Cachix Daemon"
   DaemonEnv {..} <- ask
 
-  config <- showConfiguration
-  Katip.logFM Katip.InfoS $ Katip.ls $ "Configuration:\n" <> config
+  printConfiguration
 
   Push.withPushParams $ \pushParams -> do
     subscriptionManagerThread <-
@@ -168,7 +167,13 @@ subscribe DaemonEnv {..} = do
     subscribeToAllSTM daemonSubscriptionManager (SubChannel chan)
     dupTMChan chan
 
--- | Print debug information about the daemon configuration
+-- | Print the daemon configuration to the log.
+printConfiguration :: Daemon ()
+printConfiguration = do
+  config <- showConfiguration
+  Katip.logFM Katip.InfoS $ Katip.ls $ "Configuration:\n" <> config
+
+-- | Fetch debug information about the daemon configuration.
 showConfiguration :: Daemon Text
 showConfiguration = do
   DaemonEnv {..} <- ask

--- a/cachix/src/Cachix/Client/Daemon/Client.hs
+++ b/cachix/src/Cachix/Client/Daemon/Client.hs
@@ -52,11 +52,6 @@ withDaemonConn optionalSocketPath f = do
     open socketPath = do
       sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
       Socket.connect sock (Socket.SockAddrUnix socketPath)
-
-      -- Network.Socket.accept sets the socket to non-blocking by default.
-      Socket.withFdSocket sock $ \fd ->
-        Posix.setFdOption (fromIntegral fd) Posix.NonBlockingRead False
-
       return sock
 
     failedToConnectTo :: FilePath -> IO ()

--- a/cachix/src/Cachix/Client/Daemon/Client.hs
+++ b/cachix/src/Cachix/Client/Daemon/Client.hs
@@ -4,15 +4,34 @@ import Cachix.Client.Daemon.Listen (getSocketPath)
 import Cachix.Client.Daemon.Protocol as Protocol
 import Cachix.Client.Env as Env
 import Cachix.Client.OptionsParser (DaemonOptions (..))
+import qualified Cachix.Client.Retry as Retry
 import qualified Control.Concurrent.Async as Async
+import Control.Concurrent.STM.TBMQueue
 import Control.Exception.Safe (catchAny)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy.Char8 as Lazy.Char8
+import Data.IORef
+import Data.Time.Clock
 import qualified Network.Socket as Socket
 import qualified Network.Socket.ByteString as Socket.BS
 import qualified Network.Socket.ByteString.Lazy as Socket.LBS
 import Protolude
-import qualified System.Posix.IO as Posix
+
+data SocketError
+  = -- | The socket has been closed
+    SocketClosed
+  | -- | The socket has stopped responding to pings
+    SocketStalled
+  | -- | Failed to decode a message from the socket
+    SocketDecodingError !Text
+  deriving stock (Show)
+
+instance Exception SocketError where
+  displayException = \case
+    SocketClosed -> "The socket has been closed"
+    SocketStalled -> "The socket has stopped responding to pings"
+    SocketDecodingError err -> "Failed to decode message from socket: " <> toS err
 
 -- | Queue up push requests with the daemon
 --
@@ -20,7 +39,7 @@ import qualified System.Posix.IO as Posix
 push :: Env -> DaemonOptions -> [FilePath] -> IO ()
 push _env daemonOptions storePaths =
   withDaemonConn (daemonSocketPath daemonOptions) $ \sock -> do
-    Socket.LBS.sendAll sock (Aeson.encode pushRequest)
+    Socket.LBS.sendAll sock $ Aeson.encode pushRequest `Lazy.Char8.snoc` '\n'
   where
     pushRequest =
       Protocol.ClientPushRequest $
@@ -30,31 +49,84 @@ push _env daemonOptions storePaths =
 stop :: Env -> DaemonOptions -> IO ()
 stop _env daemonOptions =
   withDaemonConn (daemonSocketPath daemonOptions) $ \sock -> do
-    Async.concurrently_ (waitForResponse sock) $
-      Socket.LBS.sendAll sock (Aeson.encode Protocol.ClientStop)
+    let size = 100
+    (rx, tx) <- atomically $ (,) <$> newTBMQueue size <*> newTBMQueue size
+
+    rxThread <- Async.async (handleIncoming rx sock)
+    txThread <- Async.async (handleOutgoing tx sock)
+
+    lastPongRef <- newIORef =<< getCurrentTime
+    pingThread <- Async.async (runPingThread lastPongRef rx tx)
+
+    -- mapM_ Async.link [rxThread, txThread, pingThread]
+
+    -- Request the daemon to stop
+    atomically $ writeTBMQueue tx Protocol.ClientStop
+
+    fix $ \loop -> do
+      mmsg <- atomically (readTBMQueue rx)
+      case mmsg of
+        Nothing -> return ()
+        Just (Left err) -> putErrText $ toS $ displayException err
+        Just (Right msg) ->
+          case msg of
+            Protocol.DaemonPong -> do
+              writeIORef lastPongRef =<< getCurrentTime
+              loop
+            Protocol.DaemonBye -> exitSuccess
   where
-    waitForResponse sock = do
-      -- Wait for the socket to close
-      bs <- Socket.BS.recv sock 4096 `catchAny` (\_ -> return BS.empty)
+    runPingThread lastPongRef rx tx = go
+      where
+        go = do
+          timestamp <- getCurrentTime
+          lastPong <- readIORef lastPongRef
 
-      -- A zero-length response means that the daemon has closed the socket
-      guard $ not $ BS.null bs
+          if timestamp >= addUTCTime 20 lastPong
+            then atomically $ writeTBMQueue rx (Left SocketStalled)
+            else do
+              atomically $ writeTBMQueue tx Protocol.ClientPing
+              threadDelay (2 * 1000 * 1000)
+              go
 
-      case Aeson.eitherDecodeStrict bs of
-        Left err -> putErrText (toS err)
-        Right DaemonBye -> return ()
+    handleOutgoing tx sock = go
+      where
+        go = do
+          mmsg <- atomically $ readTBMQueue tx
+          case mmsg of
+            Nothing -> return ()
+            Just msg -> do
+              Retry.retryAll $ const $ Socket.LBS.sendAll sock $ Aeson.encode msg `Lazy.Char8.snoc` '\n'
+              go
+
+    handleIncoming rx sock = go
+      where
+        go = do
+          -- Wait for the socket to close
+          bs <- Socket.BS.recv sock 4096 `catchAny` (\_ -> return BS.empty)
+
+          -- A zero-length response means that the daemon has closed the socket
+          if BS.null bs
+            then atomically $ writeTBMQueue rx (Left SocketClosed)
+            else case Aeson.eitherDecodeStrict bs of
+              Left err -> do
+                let terr = toS err
+                putErrText terr
+                atomically $ writeTBMQueue rx (Left (SocketDecodingError terr))
+              Right msg -> do
+                atomically $ writeTBMQueue rx (Right msg)
+                go
 
 withDaemonConn :: Maybe FilePath -> (Socket.Socket -> IO a) -> IO a
 withDaemonConn optionalSocketPath f = do
   socketPath <- maybe getSocketPath pure optionalSocketPath
-  bracket (open socketPath) Socket.close f `onException` failedToConnectTo socketPath
+  bracket (open socketPath `onException` failedToConnectTo socketPath) Socket.close f
   where
     open socketPath = do
       sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
-      Socket.connect sock (Socket.SockAddrUnix socketPath)
+      Retry.retryAll $ const $ Socket.connect sock (Socket.SockAddrUnix socketPath)
       return sock
 
     failedToConnectTo :: FilePath -> IO ()
     failedToConnectTo socketPath = do
-      putErrText "Failed to connect to Cachix Daemon"
+      putErrText "\nFailed to connect to Cachix Daemon"
       putErrText $ "Tried to connect to: " <> toS socketPath <> "\n"

--- a/cachix/src/Cachix/Client/Daemon/Client.hs
+++ b/cachix/src/Cachix/Client/Daemon/Client.hs
@@ -58,7 +58,7 @@ stop _env daemonOptions =
     lastPongRef <- newIORef =<< getCurrentTime
     pingThread <- Async.async (runPingThread lastPongRef rx tx)
 
-    -- mapM_ Async.link [rxThread, txThread, pingThread]
+    mapM_ Async.link [rxThread, txThread, pingThread]
 
     -- Request the daemon to stop
     atomically $ writeTBMQueue tx Protocol.ClientStop

--- a/cachix/src/Cachix/Client/Daemon/EventLoop.hs
+++ b/cachix/src/Cachix/Client/Daemon/EventLoop.hs
@@ -1,0 +1,29 @@
+module Cachix.Client.Daemon.EventLoop (new, send, run, exitLoopWith, EventLoop, DaemonEvent (..)) where
+
+import Cachix.Client.Daemon.Types.EventLoop (DaemonEvent (..), EventLoop)
+import Control.Concurrent.STM.TBMQueue (newTBMQueueIO, readTBMQueue, writeTBMQueue)
+import Protolude
+
+type ExitLatch = MVar ExitCode
+
+new :: (MonadIO m) => m EventLoop
+new = liftIO $ newTBMQueueIO 100
+
+send :: (MonadIO m) => EventLoop -> DaemonEvent -> m ()
+send eventloop = liftIO . atomically . writeTBMQueue eventloop
+
+run :: (MonadIO m) => EventLoop -> ((ExitLatch, DaemonEvent) -> m ()) -> m ExitCode
+run eventloop f = do
+  exitLatch <- liftIO newEmptyMVar
+  fix $ \loop -> do
+    mevent <- liftIO $ atomically $ readTBMQueue eventloop
+    case mevent of
+      Just event -> f (exitLatch, event)
+      Nothing -> void $ liftIO $ tryPutMVar exitLatch ExitSuccess
+
+    liftIO (tryReadMVar exitLatch) >>= \case
+      Just exitCode -> return exitCode
+      Nothing -> loop
+
+exitLoopWith :: (MonadIO m) => ExitCode -> ExitLatch -> m ()
+exitLoopWith exitCode exitLatch = void $ liftIO $ tryPutMVar exitLatch exitCode

--- a/cachix/src/Cachix/Client/Daemon/EventLoop.hs
+++ b/cachix/src/Cachix/Client/Daemon/EventLoop.hs
@@ -1,29 +1,73 @@
-module Cachix.Client.Daemon.EventLoop (new, send, run, exitLoopWith, EventLoop, DaemonEvent (..)) where
+module Cachix.Client.Daemon.EventLoop
+  ( new,
+    send,
+    sendIO,
+    run,
+    exitLoopWith,
+    EventLoop,
+    DaemonEvent (..),
+  )
+where
 
-import Cachix.Client.Daemon.Types.EventLoop (DaemonEvent (..), EventLoop)
-import Control.Concurrent.STM.TBMQueue (newTBMQueueIO, readTBMQueue, writeTBMQueue)
+import Cachix.Client.Daemon.Types.EventLoop (DaemonEvent (..), EventLoop (..))
+import Control.Concurrent.STM.TBMQueue
+  ( isFullTBMQueue,
+    newTBMQueueIO,
+    readTBMQueue,
+    tryWriteTBMQueue,
+  )
+import Data.Text.Lazy.Builder (toLazyText)
+import qualified Katip
 import Protolude
 
-type ExitLatch = MVar ExitCode
-
 new :: (MonadIO m) => m EventLoop
-new = liftIO $ newTBMQueueIO 100
-
-send :: (MonadIO m) => EventLoop -> DaemonEvent -> m ()
-send eventloop = liftIO . atomically . writeTBMQueue eventloop
-
-run :: (MonadIO m) => EventLoop -> ((ExitLatch, DaemonEvent) -> m ()) -> m ExitCode
-run eventloop f = do
+new = do
   exitLatch <- liftIO newEmptyMVar
-  fix $ \loop -> do
-    mevent <- liftIO $ atomically $ readTBMQueue eventloop
-    case mevent of
-      Just event -> f (exitLatch, event)
-      Nothing -> void $ liftIO $ tryPutMVar exitLatch ExitSuccess
+  queue <- liftIO $ newTBMQueueIO 100
+  return $ EventLoop {queue, exitLatch}
 
-    liftIO (tryReadMVar exitLatch) >>= \case
+-- | Send an event to the event loop with logging.
+send :: (Katip.KatipContext m) => EventLoop -> DaemonEvent -> m ()
+send = send' Katip.logFM
+
+-- | Same as 'send', but does not require a 'Katip.KatipContext'.
+sendIO :: forall m. (MonadIO m) => EventLoop -> DaemonEvent -> m ()
+sendIO = send' logger
+  where
+    logger :: Katip.Severity -> Katip.LogStr -> m ()
+    logger Katip.ErrorS msg = liftIO $ hPutStrLn stderr (toLazyText $ Katip.unLogStr msg)
+    logger _ _ = return ()
+
+send' :: (MonadIO m) => (Katip.Severity -> Katip.LogStr -> m ()) -> EventLoop -> DaemonEvent -> m ()
+send' logger eventloop@(EventLoop {queue}) event = do
+  res <- liftIO $ atomically $ tryWriteTBMQueue queue event
+  case res of
+    -- The queue is closed.
+    Nothing ->
+      logger Katip.DebugS "Ignored an event because the event loop is closed"
+    -- Successfully wrote to the queue
+    Just True -> return ()
+    -- Failed to write to the queue
+    Just False -> do
+      isFull <- liftIO $ atomically $ isFullTBMQueue queue
+      let message =
+            if isFull
+              then "Event loop is full"
+              else "Unknown error"
+      logger Katip.ErrorS $ "Failed to write to event loop: " <> message
+      exitLoopWith (ExitFailure 1) eventloop
+
+run :: (MonadIO m) => EventLoop -> (DaemonEvent -> m ()) -> m ExitCode
+run eventloop f = do
+  fix $ \loop -> do
+    mevent <- liftIO $ atomically $ readTBMQueue (queue eventloop)
+    case mevent of
+      Just event -> f event
+      Nothing -> exitLoopWith (ExitFailure 1) eventloop
+
+    liftIO (tryReadMVar (exitLatch eventloop)) >>= \case
       Just exitCode -> return exitCode
       Nothing -> loop
 
-exitLoopWith :: (MonadIO m) => ExitCode -> ExitLatch -> m ()
-exitLoopWith exitCode exitLatch = void $ liftIO $ tryPutMVar exitLatch exitCode
+exitLoopWith :: (MonadIO m) => ExitCode -> EventLoop -> m ()
+exitLoopWith exitCode EventLoop {exitLatch} = void $ liftIO $ tryPutMVar exitLatch exitCode

--- a/cachix/src/Cachix/Client/Daemon/Listen.hs
+++ b/cachix/src/Cachix/Client/Daemon/Listen.hs
@@ -46,7 +46,7 @@ instance Exception ListenError where
 
 -- | The main daemon server loop.
 listen ::
-  (MonadIO m, E.MonadMask m) =>
+  (E.MonadMask m, Katip.KatipContext m) =>
   EventLoop ->
   FilePath ->
   m ()

--- a/cachix/src/Cachix/Client/Daemon/Protocol.hs
+++ b/cachix/src/Cachix/Client/Daemon/Protocol.hs
@@ -16,15 +16,17 @@ import Protolude
 
 -- | JSON messages that the client can send to the daemon
 data ClientMessage
-  = ClientPushRequest PushRequest
+  = ClientPushRequest !PushRequest
   | ClientStop
-  deriving stock (Generic)
+  | ClientPing
+  deriving stock (Generic, Show)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 -- | JSON messages that the daemon can send to the client
 data DaemonMessage
-  = DaemonBye
-  deriving stock (Generic)
+  = DaemonPong
+  | DaemonBye
+  deriving stock (Generic, Show)
   deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 newtype PushRequestId = PushRequestId UUID

--- a/cachix/src/Cachix/Client/Daemon/SocketStore.hs
+++ b/cachix/src/Cachix/Client/Daemon/SocketStore.hs
@@ -1,0 +1,38 @@
+module Cachix.Client.Daemon.SocketStore
+  ( newSocketStore,
+    addSocket,
+    removeSocket,
+    toList,
+    Socket (..),
+  )
+where
+
+import Cachix.Client.Daemon.Types.SocketStore (Socket (..), SocketId, SocketStore (..))
+import Control.Concurrent.STM.TVar
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.UUID.V4 as UUID
+import qualified Network.Socket
+import Protolude hiding (toList)
+import qualified UnliftIO.Async as Async
+
+newSocketStore :: (MonadIO m) => m SocketStore
+newSocketStore = SocketStore <$> liftIO (newTVarIO mempty)
+
+newSocketId :: (MonadIO m) => m SocketId
+newSocketId = liftIO UUID.nextRandom
+
+addSocket :: (MonadUnliftIO m) => Network.Socket.Socket -> (SocketId -> Network.Socket.Socket -> m ()) -> SocketStore -> m ()
+addSocket socket handler (SocketStore st) = do
+  socketId <- newSocketId
+  handlerThread <- Async.async (handler socketId socket)
+  liftIO $ atomically $ modifyTVar' st $ HashMap.insert socketId (Socket {..})
+
+removeSocket :: (MonadIO m) => SocketId -> SocketStore -> m ()
+removeSocket socketId (SocketStore st) =
+  liftIO $ atomically $ modifyTVar' st $ HashMap.delete socketId
+
+toList :: (MonadIO m) => SocketStore -> m [Socket]
+toList (SocketStore st) = do
+  hm <- liftIO $ readTVarIO st
+  return $ HashMap.elems hm

--- a/cachix/src/Cachix/Client/Daemon/Types/Daemon.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types/Daemon.hs
@@ -13,9 +13,11 @@ import qualified Cachix.Client.Daemon.Log as Log
 import qualified Cachix.Client.Daemon.Protocol as Protocol
 import Cachix.Client.Daemon.ShutdownLatch (ShutdownLatch)
 import Cachix.Client.Daemon.Subscription (SubscriptionManager)
+import Cachix.Client.Daemon.Types.EventLoop (EventLoop)
 import Cachix.Client.Daemon.Types.Log (Logger)
 import Cachix.Client.Daemon.Types.PushEvent (PushEvent)
 import Cachix.Client.Daemon.Types.PushManager (PushManagerEnv (..))
+import Cachix.Client.Daemon.Types.SocketStore (SocketStore)
 import Cachix.Client.Env as Env
 import Cachix.Client.OptionsParser (PushOptions)
 import Cachix.Client.Push
@@ -29,10 +31,14 @@ import System.Posix.Types (ProcessID)
 data DaemonEnv = DaemonEnv
   { -- | Cachix client env
     daemonEnv :: Env,
+    -- | The main event loop
+    daemonEventLoop :: EventLoop,
     -- | Push options, like compression settings and number of jobs
     daemonPushOptions :: PushOptions,
     -- | Path to the socket that the daemon listens on
     daemonSocketPath :: FilePath,
+    -- | Main inbound socket thread
+    daemonSocketThread :: MVar (Async ()),
     -- | The push secret for the binary cache
     daemonPushSecret :: PushSecret,
     -- | The name of the binary cache to push to
@@ -41,6 +47,8 @@ data DaemonEnv = DaemonEnv
     daemonBinaryCache :: BinaryCache,
     -- | The state of active push requests
     daemonPushManager :: PushManagerEnv,
+    -- | Connected clients over the socket
+    daemonClients :: SocketStore,
     -- | A multiplexer for push events.
     daemonSubscriptionManager :: SubscriptionManager Protocol.PushRequestId PushEvent,
     -- | Logging env

--- a/cachix/src/Cachix/Client/Daemon/Types/EventLoop.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types/EventLoop.hs
@@ -1,5 +1,6 @@
 module Cachix.Client.Daemon.Types.EventLoop
-  ( EventLoop,
+  ( EventLoop (..),
+    ExitLatch,
     DaemonEvent (..),
   )
 where
@@ -8,12 +9,27 @@ import qualified Cachix.Client.Daemon.Protocol as Protocol
 import Cachix.Client.Daemon.Types.SocketStore (SocketId)
 import Control.Concurrent.STM.TBMQueue (TBMQueue)
 import Network.Socket (Socket)
+import Protolude
 
-type EventLoop = TBMQueue DaemonEvent
+-- | An event loop that processes 'DaemonEvent's.
+data EventLoop = EventLoop
+  { queue :: TBMQueue DaemonEvent,
+    exitLatch :: ExitLatch
+  }
 
+-- | An exit latch is a semaphore that signals the event loop to exit.
+-- The exit code should be returned by the 'EventLoop'.
+type ExitLatch = MVar ExitCode
+
+-- | Daemon events that are handled by the 'EventLoop'.
 data DaemonEvent
-  = ShutdownGracefully
-  | ReconnectSocket
-  | AddSocketClient Socket
-  | RemoveSocketClient SocketId
-  | ReceivedMessage Protocol.ClientMessage
+  = -- | Shut down the daemon gracefully.
+    ShutdownGracefully
+  | -- | Re-establish the daemon socket
+    ReconnectSocket
+  | -- | Add a new client socket connection.
+    AddSocketClient Socket
+  | -- | Remove an existing client socket connection. For example, after it is closed.
+    RemoveSocketClient SocketId
+  | -- | Handle a new message from a client.
+    ReceivedMessage Protocol.ClientMessage

--- a/cachix/src/Cachix/Client/Daemon/Types/EventLoop.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types/EventLoop.hs
@@ -1,0 +1,19 @@
+module Cachix.Client.Daemon.Types.EventLoop
+  ( EventLoop,
+    DaemonEvent (..),
+  )
+where
+
+import qualified Cachix.Client.Daemon.Protocol as Protocol
+import Cachix.Client.Daemon.Types.SocketStore (SocketId)
+import Control.Concurrent.STM.TBMQueue (TBMQueue)
+import Network.Socket (Socket)
+
+type EventLoop = TBMQueue DaemonEvent
+
+data DaemonEvent
+  = ShutdownGracefully
+  | ReconnectSocket
+  | AddSocketClient Socket
+  | RemoveSocketClient SocketId
+  | ReceivedMessage Protocol.ClientMessage

--- a/cachix/src/Cachix/Client/Daemon/Types/SocketStore.hs
+++ b/cachix/src/Cachix/Client/Daemon/Types/SocketStore.hs
@@ -1,0 +1,23 @@
+module Cachix.Client.Daemon.Types.SocketStore (Socket (..), SocketId, SocketStore (..)) where
+
+import Control.Concurrent.STM.TVar (TVar)
+import Data.HashMap.Strict (HashMap)
+import Data.UUID (UUID)
+import qualified Network.Socket as Network (Socket)
+import Protolude
+
+data Socket = Socket
+  { socketId :: SocketId,
+    socket :: Network.Socket,
+    handlerThread :: Async ()
+  }
+
+instance Eq Socket where
+  (==) = (==) `on` socketId
+
+instance Ord Socket where
+  compare = comparing socketId
+
+type SocketId = UUID
+
+newtype SocketStore = SocketStore (TVar (HashMap SocketId Socket))

--- a/cachix/src/Cachix/Client/Daemon/Worker.hs
+++ b/cachix/src/Cachix/Client/Daemon/Worker.hs
@@ -3,6 +3,7 @@ module Cachix.Client.Daemon.Worker
     stopWorkers,
     startWorker,
     stopWorker,
+    Immortal.Thread,
   )
 where
 


### PR DESCRIPTION
- Refactor the main blocking thread into an event loop to make it possible to manage internal daemon state. For example, react to new messages, add and remove active sockets, etc.
- Add ping-pong messages to the protocol to allow for liveness checks.
- Track and handle active client sockets.
- Remove code that disabled non-blocking mode for client connections. This causes hangs in certain situations. Everything now works perfectly fine without this.