### PR TITLE
nix: use hnix-store-core@0.7 when available

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,10 +40,7 @@
       cachix = haskellPackages.callCabal2nix "cachix" ./cachix {
         inherit cachix-api;
         fsnotify = haskellPackages.fsnotify_0_4_1_0 or haskellPackages.fsnotify;
-        hnix-store-core =
-          haskellPackages.hnix-store-core_0_7_0_0
-          or haskellPackages.hnix-store-core_0_6_1_0
-          or haskellPackages.hnix-store-core;
+        hnix-store-core = haskellPackages.hnix-store-core;
         nix = getNix { inherit pkgs haskellPackages; };
       };
     };


### PR DESCRIPTION
As of https://github.com/NixOS/nixpkgs/pull/273490, the attribute `haskellPackages.hnix-store-core_0_7_0_0` no longer exists and the latest version is accessible at `haskellPackages.hnix-store-core`.