### PR TITLE
feat: add support for nix.conf include directives

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,2 +1,3 @@
 - ignore: { name: Use newtype instead of data }
 - ignore: { name: Redundant do }
+- ignore: { name: "Eta reduce" }

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -263,6 +263,7 @@ test-suite cachix-test
     , dhall
     , directory
     , extra
+    , filepath
     , hercules-ci-cnix-store
     , here
     , hspec

--- a/cachix/src/Cachix/Client/Exception.hs
+++ b/cachix/src/Cachix/Client/Exception.hs
@@ -12,6 +12,8 @@ data CachixException
   | NoInput Text
   | NoConfig Text
   | NetRcParseError Text
+  | IncludeNotFound Text
+  | CircularInclude Text
   | NarStreamingError ExitCode Text
   | NarHashMismatch Text
   | DeprecatedCommand Text
@@ -33,6 +35,8 @@ instance Exception CachixException where
   displayException (ArtifactNotFound s) = toS s
   displayException (NoSigningKey s) = toS s
   displayException (NetRcParseError s) = toS s
+  displayException (IncludeNotFound s) = toS s
+  displayException (CircularInclude s) = toS s
   displayException (NarStreamingError _ s) = toS s
   displayException (NarHashMismatch s) = toS s
   displayException (DeprecatedCommand s) = toS s

--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -82,7 +82,7 @@ getNixEnv :: IO NixEnv
 getNixEnv = do
   user <- getUser
   ncs <- NixConf.resolveIncludes =<< NixConf.readWithDefault NixConf.Global
-  isTrusted <- isTrustedUser $ NixConf.readLines ncs NixConf.isTrustedUsers
+  isTrusted <- isTrustedUser $ concatMap (NixConf.readLines NixConf.isTrustedUsers) ncs
   isNixOS <- doesFileExist "/run/current-system/nixos-version"
   return $
     NixEnv
@@ -139,14 +139,14 @@ addBinaryCache config bc useOptions WriteNixOS =
 addBinaryCache config bc _ (Install ncl) = do
   (input, output) <- prepareNixConf ncl
   netrcLocMaybe <- forM (guard $ not (BinaryCache.isPublic bc)) $ const $ addPrivateBinaryCacheNetRC config bc ncl
-  let addNetRCLine :: NixConf.NixConf -> NixConf.NixConf
+  let addNetRCLine :: NixConf.NixConfSource -> NixConf.NixConfSource
       addNetRCLine = fromMaybe identity $ do
         netrcLoc <- netrcLocMaybe :: Maybe FilePath
         -- We only add the netrc line for local user configs for now.
         -- On NixOS we assume it will be picked up from the default location.
         guard (ncl == NixConf.Local)
-        pure (NixConf.setNetRC $ toS netrcLoc)
-  NixConf.write ncl $ addNetRCLine $ NixConf.add bc input output
+        pure $ setNetRC (toS netrcLoc)
+  NixConf.write $ addNetRCLine $ NixConf.add bc input output
   filename <- NixConf.getFilename ncl
   putStrLn $ "Configured " <> BinaryCache.uri bc <> " binary cache in " <> toS filename
 
@@ -158,7 +158,7 @@ addBinaryCache config bc _ (Install ncl) = do
 --
 -- Inputs are any confs included by the output conf, plus any additional external resolutions.
 -- For example, for the local Nix conf, we also return the global one.
-prepareNixConf :: NixConf.NixConfLoc -> IO ([NixConf.NixConf], NixConf.NixConf)
+prepareNixConf :: NixConf.NixConfLoc -> IO ([NixConf.NixConfSource], NixConf.NixConfSource)
 prepareNixConf ncl = do
   outputPath <- NixConf.getFilename ncl
   -- TODO: might need locking one day
@@ -187,7 +187,7 @@ removeBinaryCache :: URI.URI -> Text -> InstallationMode -> IO ()
 removeBinaryCache uri name (Install ncl) = do
   contents <- NixConf.readWithDefault ncl
   let (final, removed) = NixConf.remove uri name [contents] contents
-  NixConf.write ncl final
+  NixConf.write final
   filename <- NixConf.getFilename ncl
   if removed
     then putStrLn $ "Removed " <> host <> " binary cache in " <> toS filename
@@ -196,6 +196,12 @@ removeBinaryCache uri name (Install ncl) = do
     host = URI.toByteString (URI.appendSubdomain name uri)
 removeBinaryCache _ _ _ = do
   throwIO $ RemoveCacheUnsupported "Removing binary caches is only supported for nix.conf"
+
+setNetRC :: Text -> NixConf.NixConfSource -> NixConf.NixConfSource
+setNetRC netrc conf = (fmap . fmap) (\ls -> filter noNetRc ls ++ [NixConf.NetRcFile netrc]) conf
+  where
+    noNetRc (NixConf.NetRcFile _) = False
+    noNetRc _ = True
 
 nixosBinaryCache :: Config -> BinaryCache.BinaryCache -> UseOptions -> IO ()
 nixosBinaryCache config bc UseOptions {useNixOSFolder = baseDirectory} = do

--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -152,7 +152,12 @@ addBinaryCache config bc _ (Install ncl) = do
 
 -- | Resolve and read the nix.conf.
 --
--- Returns a set of "inputs" confs and the "output" conf.
+-- Returns a set of "input" confs and the "output" conf.
+--
+-- The output is the parsed conf file at the location specified by the NixConfLoc.
+--
+-- Inputs are any confs included by the output conf, plus any additional external resolutions.
+-- For example, for the local Nix conf, we also return the global one.
 prepareNixConf :: NixConf.NixConfLoc -> IO ([NixConf.NixConf], NixConf.NixConf)
 prepareNixConf ncl = do
   -- TODO: might need locking one day

--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -82,7 +82,9 @@ getNixEnv :: IO NixEnv
 getNixEnv = do
   user <- getUser
   nc <- NixConf.read NixConf.Global
-  isTrusted <- isTrustedUser $ NixConf.readLines (catMaybes [nc]) NixConf.isTrustedUsers
+  ncPath <- NixConf.getFilename NixConf.Global
+  ncs <- traverse (NixConf.resolveIncludes ncPath) nc
+  isTrusted <- isTrustedUser $ NixConf.readLines (fromMaybe [] ncs) NixConf.isTrustedUsers
   isNixOS <- doesFileExist "/run/current-system/nixos-version"
   return $
     NixEnv

--- a/cachix/src/Cachix/Client/NixConf.hs
+++ b/cachix/src/Cachix/Client/NixConf.hs
@@ -132,6 +132,8 @@ render (NixConf nixconflines) = T.unlines $ fmap go nixconflines
     go (TrustedUsers xs) = "trusted-users = " <> T.unwords xs
     go (TrustedPublicKeys xs) = "trusted-public-keys" <> " = " <> T.unwords xs
     go (NetRcFile filename) = "netrc-file = " <> filename
+    go (Include (RequiredInclude path)) = "include " <> path
+    go (Include (OptionalInclude path)) = "!include " <> path
     go (Other line) = line
 
 write :: NixConfLoc -> NixConf -> IO ()

--- a/cachix/src/Cachix/Client/NixConf.hs
+++ b/cachix/src/Cachix/Client/NixConf.hs
@@ -143,6 +143,7 @@ write ncl nc = do
   createDirectoryIfMissing True (takeDirectory filename)
   writeFile filename $ render nc
 
+-- | Resolves includes in the given NixConf, starting from the given source file.
 resolveIncludes :: FilePath -> NixConf -> IO [NixConf]
 resolveIncludes sourceFile conf = resolveIncludesWithStack [normalise sourceFile] sourceFile conf
 

--- a/cachix/test/NixConfSpec.hs
+++ b/cachix/test/NixConfSpec.hs
@@ -33,6 +33,8 @@ spec = do
       property "substituters = a b c\n"
     it "handles all known keys" $
       property "substituters = a b c\ntrusted-users = him me\ntrusted-public-keys = a\n"
+    it "handles includes" $
+      property "include /etc/nix/nix.conf\n!include /etc/nix/nix.conf\n"
     it "random content" $
       property "blabla = foobar\nfoo = bar\n"
 
@@ -163,6 +165,14 @@ spec = do
     it "parses with missing endline" $
       parse "allowed-users = *"
         `shouldBe` Right (NixConf [Other "allowed-users = *"])
+
+    it "parses include" $
+      parse "include /etc/nix/nix.conf\n"
+        `shouldBe` Right (NixConf [Include (RequiredInclude "/etc/nix/nix.conf")])
+
+    it "parses !include" $
+      parse "!include /etc/nix/nix.conf\n"
+        `shouldBe` Right (NixConf [Include (OptionalInclude "/etc/nix/nix.conf")])
 
     it "parses a complex example" $
       parse realExample

--- a/cachix/test/NixConfSpec.hs
+++ b/cachix/test/NixConfSpec.hs
@@ -191,13 +191,14 @@ spec = do
         writeFile subConfPath realExample
 
         Just conf <- NixConf.read (Custom temp)
-        conf `shouldBe` parsedConfContents
-        NixConf.write (Custom temp) conf
+        conf `shouldBe` NixConfSource confPath parsedConfContents
+
+        NixConf.write conf
         readFile confPath `shouldReturn` confContents
 
-        NixConf.resolveIncludes confPath conf
-          `shouldReturn` [ parsedConfContents,
-                           parsedRealExample
+        NixConf.resolveIncludes conf
+          `shouldReturn` [ NixConfSource confPath parsedConfContents,
+                           NixConfSource subConfPath parsedRealExample
                          ]
 
 realExample :: Text

--- a/cachix/test/NixConfSpec.hs
+++ b/cachix/test/NixConfSpec.hs
@@ -35,6 +35,7 @@ spec = do
       property "substituters = a b c\ntrusted-users = him me\ntrusted-public-keys = a\n"
     it "random content" $
       property "blabla = foobar\nfoo = bar\n"
+
   describe "add" $ do
     it "merges binary caches from both files" $
       let globalConf =
@@ -53,6 +54,7 @@ spec = do
                 TrustedPublicKeys [defaultSigningKey, "pub1", "pub2", "pub"]
               ]
        in add bc [globalConf, localConf] localConf `shouldBe` result
+
     it "is noop if binary cache exists in one file" $
       let globalConf =
             NixConf
@@ -66,6 +68,7 @@ spec = do
                 TrustedPublicKeys [defaultSigningKey, "pub"]
               ]
        in add bc [globalConf, localConf] localConf `shouldBe` result
+
     it "preserves other nixconf entries" $
       let globalConf =
             NixConf
@@ -87,6 +90,7 @@ spec = do
                 TrustedPublicKeys [defaultSigningKey, "pub1", "pub"]
               ]
        in add bc [globalConf, localConf] localConf `shouldBe` result
+
     it "removed duplicates" $
       let globalConf =
             NixConf
@@ -104,6 +108,7 @@ spec = do
                 TrustedPublicKeys [defaultSigningKey, "pub1", "pub2", "pub"]
               ]
        in add bc [globalConf, localConf] localConf `shouldBe` result
+
     it "adds binary cache and defaults if no existing entries exist" $
       let globalConf = NixConf []
           localConf = NixConf []
@@ -113,6 +118,7 @@ spec = do
                 TrustedPublicKeys [defaultSigningKey, "pub"]
               ]
        in add bc [globalConf, localConf] localConf `shouldBe` result
+
   describe "remove" $ do
     it "removes a binary cache" $
       let localConf =
@@ -126,6 +132,7 @@ spec = do
                 TrustedPublicKeys [defaultSigningKey]
               ]
        in remove "https://cachix.org" "name" [localConf] localConf `shouldBe` (result, True)
+
     it "removes nothing if the binary cache is missing" $
       let globalConf =
             NixConf
@@ -135,22 +142,28 @@ spec = do
           localConf = globalConf
           result = localConf
        in remove "https://cachix.org" "name" [globalConf, localConf] localConf `shouldBe` (result, False)
+
   describe "parse" $ do
     it "parses substituters" $
       parse "substituters = a\n"
         `shouldBe` Right (NixConf [Substituters ["a"]])
+
     it "parses long key" $
       parse "binary-caches-parallel-connections = 40\n"
         `shouldBe` Right (NixConf [Other "binary-caches-parallel-connections = 40"])
+
     it "parses substituters with multiple values" $
       parse "substituters = a b c\n"
         `shouldBe` Right (NixConf [Substituters ["a", "b", "c"]])
+
     it "parses equal sign after the first key as literal" $
       parse "substituters = a b c= d\n"
         `shouldBe` Right (NixConf [Substituters ["a", "b", "c=", "d"]])
+
     it "parses with missing endline" $
       parse "allowed-users = *"
         `shouldBe` Right (NixConf [Other "allowed-users = *"])
+
     it "parses a complex example" $
       parse realExample
         `shouldBe` Right


### PR DESCRIPTION
Implement parsing and resolution of include/!include directives in nix.conf files to support setups like determinate nix installer that split configs across multiple files.

## Key features:

- Support both required (include) and optional (!include) directives
- Detect and prevent circular includes

## Implementation details:

Following the [nix.conf specification](https://nix.dev/manual/nix/2.17/command-ref/conf-file#file-format):
- Required includes (`include`) error if file not found
- Optional includes (`!include`) continue silently if file missing
- Circular includes are detected, with a stack trace showing the include chain, example:

```sh
Circular include detected:
/path/to/nix.conf
    -> includes /path/to/nix.custom.conf
    -> includes /path/to/nix.conf (circular reference)
```

- Optional includes that would create a circular reference are skipped silently
- All paths are resolved relative to the including file

This allows Cachix to properly read trusted-users and other settings from included config files.

---

I'm new to Haskell, so I'd really appreciate feedback on the implementation approach. Happy to adjust based on your input!

Related issue: #680 
