### PR TITLE
daemon: handle event queueing and shutdown issues

### DIFF
--- a/cachix/src/Cachix/Daemon/EventLoop.hs
+++ b/cachix/src/Cachix/Daemon/EventLoop.hs
@@ -22,7 +22,7 @@ import Protolude
 new :: (MonadIO m) => m (EventLoop event a)
 new = do
   exitLatch <- liftIO newEmptyMVar
-  queue <- liftIO $ newTBMQueueIO 100
+  queue <- liftIO $ newTBMQueueIO 100_000
   return $ EventLoop {queue, exitLatch}
 
 -- | Send an event to the event loop with logging.

--- a/cachix/src/Cachix/Daemon/EventLoop.hs
+++ b/cachix/src/Cachix/Daemon/EventLoop.hs
@@ -4,11 +4,15 @@ module Cachix.Daemon.EventLoop
     sendIO,
     run,
     exitLoopWith,
+    exitLoopWithFailure,
     EventLoop,
   )
 where
 
+import Cachix.Daemon.ShutdownLatch (ShutdownLatch)
+import Cachix.Daemon.ShutdownLatch qualified as ShutdownLatch
 import Cachix.Daemon.Types.EventLoop (EventLoop (..), EventLoopError (..))
+import Control.Concurrent.STM
 import Control.Concurrent.STM.TBMQueue
   ( isFullTBMQueue,
     newTBMQueueIO,
@@ -21,9 +25,9 @@ import Protolude
 
 new :: (MonadIO m) => m (EventLoop event a)
 new = do
-  exitLatch <- liftIO newEmptyMVar
+  shutdownLatch <- ShutdownLatch.newShutdownLatch
   queue <- liftIO $ newTBMQueueIO 100_000
-  return $ EventLoop {queue, exitLatch}
+  return $ EventLoop {queue, shutdownLatch}
 
 -- | Send an event to the event loop with logging.
 send :: (Katip.KatipContext m) => EventLoop event a -> event -> m ()
@@ -38,41 +42,67 @@ sendIO = send' logger
     logger _ _ = return ()
 
 send' :: (MonadIO m) => (Katip.Severity -> Katip.LogStr -> m ()) -> EventLoop event a -> event -> m ()
-send' logger eventloop@(EventLoop {queue}) event = do
-  res <- liftIO $ atomically $ tryWriteTBMQueue queue event
-  case res of
-    -- The queue is closed.
-    Nothing ->
-      logger Katip.DebugS "Ignored an event because the event loop is closed"
-    -- Successfully wrote to the queue
-    Just True -> return ()
-    -- Failed to write to the queue
-    Just False -> do
-      isFull <- liftIO $ atomically $ isFullTBMQueue queue
-      let message =
-            if isFull
-              then "Event loop is full"
-              else "Unknown error"
-      logger Katip.ErrorS $ "Failed to write to event loop: " <> message
-      exitLoopWithFailure EventLoopFull eventloop
+send' logger eventloop@(EventLoop {queue, shutdownLatch}) event = do
+  -- First check if shutdown has been requested
+  isExiting <- ShutdownLatch.isShuttingDown shutdownLatch
+  if isExiting
+    then logger Katip.DebugS "Ignored an event because the event loop is shutting down"
+    else do
+      res <- liftIO $ atomically $ tryWriteTBMQueue queue event
+      case res of
+        -- The queue is closed.
+        Nothing ->
+          logger Katip.DebugS "Ignored an event because the event loop is closed"
+        -- Successfully wrote to the queue
+        Just True -> return ()
+        -- Failed to write to the queue
+        Just False -> do
+          isFull <- liftIO $ atomically $ isFullTBMQueue queue
+          let message =
+                if isFull
+                  then "Event loop is full"
+                  else "Unknown error"
+          logger Katip.ErrorS $ "Failed to write to event loop: " <> message
+          exitLoopWithFailure EventLoopFull eventloop
 
 -- | Run the event loop until it exits with 'exitLoopWith'.
 run :: (MonadIO m) => EventLoop event a -> (event -> m ()) -> m (Either EventLoopError a)
-run eventloop f = do
+run eventloop@(EventLoop {queue, shutdownLatch}) f =
   fix $ \loop -> do
-    mevent <- liftIO $ atomically $ readTBMQueue (queue eventloop)
-    case mevent of
-      Just event -> f event
-      Nothing -> exitLoopWithFailure EventLoopClosed eventloop
+    -- Wait for either a shutdown signal or a message from the queue
+    eitherResult <-
+      liftIO $
+        atomically $
+          fmap Left (ShutdownLatch.waitForShutdownSTM shutdownLatch)
+            `orElse`
+            -- Try to read from queue
+            ( do
+                mevent <- readTBMQueue queue
+                case mevent of
+                  -- Got an event, return it
+                  Just event -> return $ Right event
+                  -- Queue is closed, signal shutdown
+                  Nothing -> do
+                    ShutdownLatch.initiateShutdownWithResultSTM (Left EventLoopClosed) shutdownLatch
+                    result <- ShutdownLatch.waitForShutdownSTM shutdownLatch
+                    return $ Left result
+            )
 
-    liftIO (tryReadMVar (exitLatch eventloop)) >>= \case
-      Just exitValue -> return exitValue
-      Nothing -> loop
+    -- Process the result
+    case eitherResult of
+      -- Shutdown requested, return the result
+      Left result -> return result
+      -- Got an event, process it and continue looping
+      Right event -> do
+        f event
+        loop
 
 -- | Short-circuit the event loop and exit with a given return value.
 exitLoopWith :: (MonadIO m) => a -> EventLoop event a -> m ()
-exitLoopWith exitValue (EventLoop {exitLatch}) = void $ liftIO $ tryPutMVar exitLatch (Right exitValue)
+exitLoopWith exitValue (EventLoop {shutdownLatch}) =
+  ShutdownLatch.initiateShutdown exitValue shutdownLatch
 
 -- | Short-circuit the event loop in case of an internal error.
 exitLoopWithFailure :: (MonadIO m) => EventLoopError -> EventLoop event a -> m ()
-exitLoopWithFailure err (EventLoop {exitLatch}) = void $ liftIO $ tryPutMVar exitLatch (Left err)
+exitLoopWithFailure err (EventLoop {shutdownLatch}) =
+  ShutdownLatch.initiateShutdownWithResult (Left err) shutdownLatch

--- a/cachix/src/Cachix/Daemon/ShutdownLatch.hs
+++ b/cachix/src/Cachix/Daemon/ShutdownLatch.hs
@@ -3,24 +3,70 @@ module Cachix.Daemon.ShutdownLatch
     newShutdownLatch,
     waitForShutdown,
     initiateShutdown,
+    initiateShutdownWithResult,
+    getResult,
     isShuttingDown,
+    -- STM operations
+    isShuttingDownSTM,
+    initiateShutdownSTM,
+    initiateShutdownWithResultSTM,
+    getResultSTM,
+    waitForShutdownSTM,
   )
 where
 
-import Control.Concurrent.MVar
+import Control.Concurrent.STM
 import Protolude
 
 -- | A latch to keep track of the shutdown process.
-newtype ShutdownLatch = ShutdownLatch {unShutdownLatch :: MVar ()}
+-- A shutdown latch holds a result value (Either e a) when shutdown is initiated.
+-- Nothing means that shutdown has not been requested yet.
+newtype ShutdownLatch e a = ShutdownLatch {unShutdownLatch :: TVar (Maybe (Either e a))}
 
-newShutdownLatch :: (MonadIO m) => m ShutdownLatch
-newShutdownLatch = ShutdownLatch <$> liftIO newEmptyMVar
+-- | Create a new shutdown latch
+newShutdownLatch :: (MonadIO m) => m (ShutdownLatch e a)
+newShutdownLatch = ShutdownLatch <$> liftIO (newTVarIO Nothing)
 
-waitForShutdown :: (MonadIO m) => ShutdownLatch -> m ()
-waitForShutdown = liftIO . readMVar . unShutdownLatch
+-- | Block until shutdown is requested and return the result
+waitForShutdown :: (MonadIO m) => ShutdownLatch e a -> m (Either e a)
+waitForShutdown latch = liftIO $ atomically $ waitForShutdownSTM latch
 
-initiateShutdown :: (MonadIO m) => ShutdownLatch -> m ()
-initiateShutdown = void . liftIO . flip tryPutMVar () . unShutdownLatch
+-- | Signal shutdown with a "success" result
+initiateShutdown :: (MonadIO m) => a -> ShutdownLatch e a -> m ()
+initiateShutdown val latch = liftIO $ atomically $ initiateShutdownSTM val latch
 
-isShuttingDown :: (MonadIO m) => ShutdownLatch -> m Bool
-isShuttingDown = liftIO . fmap not . isEmptyMVar . unShutdownLatch
+-- | Signal shutdown with a specific result
+initiateShutdownWithResult :: (MonadIO m) => Either e a -> ShutdownLatch e a -> m ()
+initiateShutdownWithResult result latch = liftIO $ atomically $ initiateShutdownWithResultSTM result latch
+
+-- | Get the shutdown result if available
+getResult :: (MonadIO m) => ShutdownLatch e a -> m (Maybe (Either e a))
+getResult latch = liftIO $ atomically $ getResultSTM latch
+
+-- | Check if shutdown has been requested
+isShuttingDown :: (MonadIO m) => ShutdownLatch e a -> m Bool
+isShuttingDown latch = liftIO $ atomically $ isShuttingDownSTM latch
+
+-- STM Operations for use in atomic transactions
+
+-- | Check if shutdown is requested
+isShuttingDownSTM :: ShutdownLatch e a -> STM Bool
+isShuttingDownSTM latch = isJust <$> readTVar (unShutdownLatch latch)
+
+-- | Signal shutdown with a "success" result
+initiateShutdownSTM :: a -> ShutdownLatch e a -> STM ()
+initiateShutdownSTM val latch = writeTVar (unShutdownLatch latch) (Just (Right val))
+
+-- | Signal shutdown with a specific result
+initiateShutdownWithResultSTM :: Either e a -> ShutdownLatch e a -> STM ()
+initiateShutdownWithResultSTM result latch = writeTVar (unShutdownLatch latch) (Just result)
+
+-- | Get the shutdown result (if available)
+getResultSTM :: ShutdownLatch e a -> STM (Maybe (Either e a))
+getResultSTM = readTVar . unShutdownLatch
+
+-- | Block until shutdown is requested, then return the result
+waitForShutdownSTM :: ShutdownLatch e a -> STM (Either e a)
+waitForShutdownSTM latch = do
+  mresult <- readTVar (unShutdownLatch latch)
+  maybe retry return mresult

--- a/cachix/src/Cachix/Daemon/Types.hs
+++ b/cachix/src/Cachix/Daemon/Types.hs
@@ -9,6 +9,9 @@ module Cachix.Daemon.Types
     DaemonError (..),
     HasExitCode (..),
 
+    -- * EventLoop errors
+    EventLoop.EventLoopError (..),
+
     -- * Log
     LogLevel (..),
 
@@ -27,6 +30,7 @@ where
 
 import Cachix.Daemon.Types.Daemon
 import Cachix.Daemon.Types.Error
+import Cachix.Daemon.Types.EventLoop as EventLoop
 import Cachix.Daemon.Types.Log
 import Cachix.Daemon.Types.PushEvent as PushEvent
 import Cachix.Daemon.Types.PushManager as PushManager

--- a/cachix/src/Cachix/Daemon/Types/Daemon.hs
+++ b/cachix/src/Cachix/Daemon/Types/Daemon.hs
@@ -73,8 +73,6 @@ data DaemonEnv = DaemonEnv
     daemonSubscriptionManagerThread :: MVar (Async ()),
     -- | Logging env
     daemonLogger :: Logger,
-    -- | Shutdown latch
-    daemonShutdownLatch :: ShutdownLatch,
     -- | The PID of the daemon process
     daemonPid :: ProcessID
   }

--- a/cachix/src/Cachix/Daemon/Types/EventLoop.hs
+++ b/cachix/src/Cachix/Daemon/Types/EventLoop.hs
@@ -1,22 +1,19 @@
 module Cachix.Daemon.Types.EventLoop
   ( EventLoop (..),
     EventLoopError (..),
-    ExitLatch,
   )
 where
 
+import Cachix.Daemon.ShutdownLatch (ShutdownLatch)
 import Control.Concurrent.STM.TBMQueue (TBMQueue)
 import Protolude
 
 -- | An event loop that processes a queue of events.
 data EventLoop event output = EventLoop
   { queue :: TBMQueue event,
-    exitLatch :: ExitLatch output
+    -- | Latch for signaling shutdown and returning results
+    shutdownLatch :: ShutdownLatch EventLoopError output
   }
-
--- | An exit latch is a semaphore that signals the event loop to exit.
--- The exit code should be returned by the 'EventLoop'.
-type ExitLatch a = MVar (Either EventLoopError a)
 
 data EventLoopError
   = EventLoopClosed


### PR DESCRIPTION
- The event loop (main message queue) is now larger.
- `sigTERM` triggers the immediate shutdown of the daemon.
- `sigINT` attempts to gracefully shut down the daemon. Exits immediately if a second signal is sent.
- The event loop runner can now be short-circuited by the shutdown latch, even if stuck waiting for messages.