### PR TITLE
nixconf: fix handling of optional `!include` statements

### DIFF
--- a/cachix/test/NixConfSpec.hs
+++ b/cachix/test/NixConfSpec.hs
@@ -197,7 +197,8 @@ spec = do
         NixConf.write conf
         readFile confPath `shouldReturn` confContents
 
-    it "resolves includes" $ do
+    -- Test that missing optional includes do not throw errors
+    it "resolves required and optional includes" $ do
       withTempDirectory "/tmp" "nixconf" $ \temp -> do
         let confPath = temp </> "nix.conf"
             requiredConfPath = temp </> "required.conf"


### PR DESCRIPTION
Optional includes would throw an error if the file was missing.

The issue was that the check handling missing/required files did not
implement all of the branches correctly.

https://github.com/cachix/cachix/pull/694/commits/64febd24594580333a5fb20f48e2a36dece45ca4 - fixes the logic and adds a test case.
https://github.com/cachix/cachix/pull/694/commits/03e957638dd34887d7d2ef0f572afcb502a56098 - dedupes the parsing and error handling logic.

Fixes #693.