### PR TITLE
daemon: hide the retry number on initial push

### DIFF
--- a/cachix/src/Cachix/Daemon/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/PushManager.hs
@@ -343,7 +343,11 @@ newPushStrategy store authToken opts cacheName compressionMethod storePath =
 
       onAttempt retryStatus size = do
         sp <- liftIO $ storePathToPath store storePath
-        Katip.katipAddContext (Katip.sl "retry" (rsIterNumber retryStatus)) $
+        let retryContext =
+              if rsIterNumber retryStatus > 0
+                then Katip.katipAddContext (Katip.sl "retry" (rsIterNumber retryStatus))
+                else identity
+        retryContext $
           Katip.logFM Katip.InfoS $
             Katip.ls $
               "Pushing " <> (toS sp :: Text)


### PR DESCRIPTION
Removes the `retry` field from the logs on initial push.