### PR TITLE
daemon: batch narinfo requests across push jobs

### DIFF
--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -88,6 +88,7 @@ library
     Cachix.Daemon.EventLoop
     Cachix.Daemon.Listen
     Cachix.Daemon.Log
+    Cachix.Daemon.NarinfoBatch
     Cachix.Daemon.PostBuildHook
     Cachix.Daemon.Progress
     Cachix.Daemon.Protocol

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -11,6 +11,7 @@ import Cachix.Client.OptionsParser
   ( CachixCommand (..),
     DaemonCommand (..),
     PushArguments (..),
+    daemonNarinfoBatchOptions,
     getOpts,
   )
 import Cachix.Client.Version (cachixVersion)
@@ -40,7 +41,7 @@ main = displayConsoleRegions $ do
     Daemon (DaemonRun daemonOptions pushOptions mcacheName) -> Daemon.start env daemonOptions pushOptions mcacheName
     Daemon (DaemonStop daemonOptions) -> Daemon.Client.stop env daemonOptions
     Daemon (DaemonPushPaths daemonOptions daemonPushOptions storePaths) -> Daemon.Client.push env daemonOptions daemonPushOptions storePaths
-    Daemon (DaemonWatchExec pushOptions cacheName cmd args) -> Command.watchExecDaemon env pushOptions cacheName cmd args
+    Daemon (DaemonWatchExec daemonOptions pushOptions cacheName cmd args) -> Command.watchExecDaemon env pushOptions (daemonNarinfoBatchOptions daemonOptions) cacheName cmd args
     DeployCommand (DeployOptions.Agent opts) -> AgentCommand.run cachixOptions opts
     DeployCommand (DeployOptions.Activate opts) -> ActivateCommand.run env opts
     GenerateKeypair name -> Command.generateKeypair env name
@@ -52,8 +53,8 @@ main = displayConsoleRegions $ do
     Remove name -> Command.remove env name
     Use name useOptions -> Command.use env name useOptions
     Version -> putText cachixVersion
-    WatchExec watchExecMode pushArgs name cmd args ->
-      Command.watchExec env watchExecMode pushArgs name cmd args
+    WatchExec watchExecMode pushArgs batchOptions name cmd args ->
+      Command.watchExec env watchExecMode pushArgs batchOptions name cmd args
     WatchStore watchArgs name -> Command.watchStore env watchArgs name
 
 -- | Install client-wide signal handlers.

--- a/cachix/src/Cachix/Client/Command/Watch.hs
+++ b/cachix/src/Cachix/Client/Command/Watch.hs
@@ -78,9 +78,9 @@ watchExecDaemon env pushOpts batchOptions cacheName cmd args =
       withStore $ \store -> do
         let daemonOptions =
               DaemonOptions
-                { daemonSocketPath = Just (Daemon.PostBuildHook.daemonSock hookEnv),
+                { daemonAllowRemoteStop = False,
                   daemonNarinfoBatchOptions = batchOptions,
-                  allowRemoteStop = False
+                  daemonSocketPath = Just (Daemon.PostBuildHook.daemonSock hookEnv)
                 }
         daemon <- Daemon.new env store daemonOptions (Just logHandle) pushOpts cacheName
 

--- a/cachix/src/Cachix/Client/Command/Watch.hs
+++ b/cachix/src/Cachix/Client/Command/Watch.hs
@@ -75,7 +75,14 @@ watchExecDaemon env pushOpts cacheName cmd args =
   Daemon.PostBuildHook.withSetup Nothing $ \hookEnv ->
     withTempFile (Daemon.PostBuildHook.tempDir hookEnv) "daemon-log-capture" $ \_ logHandle ->
       withStore $ \store -> do
-        let daemonOptions = DaemonOptions {daemonSocketPath = Just (Daemon.PostBuildHook.daemonSock hookEnv), allowRemoteStop = False}
+        let daemonOptions =
+              DaemonOptions
+                { daemonSocketPath = Just (Daemon.PostBuildHook.daemonSock hookEnv),
+                  allowRemoteStop = False,
+                  narinfoBatchEnable = Nothing,
+                  narinfoBatchSize = Nothing,
+                  narinfoBatchTimeout = Nothing
+                }
         daemon <- Daemon.new env store daemonOptions (Just logHandle) pushOpts cacheName
 
         exitCode <-

--- a/cachix/src/Cachix/Client/Command/Watch.hs
+++ b/cachix/src/Cachix/Client/Command/Watch.hs
@@ -17,7 +17,7 @@ import Cachix.Client.OptionsParser
 import Cachix.Client.Push
 import Cachix.Client.WatchStore qualified as WatchStore
 import Cachix.Daemon qualified as Daemon
-import Cachix.Daemon.NarinfoBatch qualified as NarinfoBatch
+import Cachix.Daemon.NarinfoBatch (NarinfoBatchOptions)
 import Cachix.Daemon.PostBuildHook qualified as Daemon.PostBuildHook
 import Cachix.Daemon.Progress qualified as Daemon.Progress
 import Cachix.Daemon.Types
@@ -49,18 +49,18 @@ watchStore env opts name = do
 --
 -- In auto mode, registers a post-build hook if the user is trusted.
 -- Otherwise, falls back to watching the entire Nix store.
-watchExec :: Env -> WatchExecMode -> PushOptions -> BinaryCacheName -> Text -> [Text] -> IO ()
-watchExec env watchExecMode pushOptions cacheName cmd args = do
+watchExec :: Env -> WatchExecMode -> PushOptions -> NarinfoBatchOptions -> BinaryCacheName -> Text -> [Text] -> IO ()
+watchExec env watchExecMode pushOptions batchOptions cacheName cmd args = do
   case watchExecMode of
     PostBuildHook ->
-      watchExecDaemon env pushOptions cacheName cmd args
+      watchExecDaemon env pushOptions batchOptions cacheName cmd args
     Store ->
       watchExecStore env pushOptions cacheName cmd args
     Auto -> do
       nixEnv <- InstallationMode.getNixEnv
 
       if InstallationMode.isTrusted nixEnv
-        then watchExecDaemon env pushOptions cacheName cmd args
+        then watchExecDaemon env pushOptions batchOptions cacheName cmd args
         else do
           putErrText fallbackWarning
           watchExecStore env pushOptions cacheName cmd args
@@ -71,15 +71,15 @@ watchExec env watchExecMode pushOptions cacheName cmd args = do
 -- | Run a command and push any new paths to the binary cache.
 --
 -- Requires the user to be a trusted user in a multi-user installation.
-watchExecDaemon :: Env -> PushOptions -> BinaryCacheName -> Text -> [Text] -> IO ()
-watchExecDaemon env pushOpts cacheName cmd args =
+watchExecDaemon :: Env -> PushOptions -> NarinfoBatchOptions -> BinaryCacheName -> Text -> [Text] -> IO ()
+watchExecDaemon env pushOpts batchOptions cacheName cmd args =
   Daemon.PostBuildHook.withSetup Nothing $ \hookEnv ->
     withTempFile (Daemon.PostBuildHook.tempDir hookEnv) "daemon-log-capture" $ \_ logHandle ->
       withStore $ \store -> do
         let daemonOptions =
               DaemonOptions
                 { daemonSocketPath = Just (Daemon.PostBuildHook.daemonSock hookEnv),
-                  daemonNarinfoBatchOptions = NarinfoBatch.defaultNarinfoBatchOptions,
+                  daemonNarinfoBatchOptions = batchOptions,
                   allowRemoteStop = False
                 }
         daemon <- Daemon.new env store daemonOptions (Just logHandle) pushOpts cacheName

--- a/cachix/src/Cachix/Client/Command/Watch.hs
+++ b/cachix/src/Cachix/Client/Command/Watch.hs
@@ -17,6 +17,7 @@ import Cachix.Client.OptionsParser
 import Cachix.Client.Push
 import Cachix.Client.WatchStore qualified as WatchStore
 import Cachix.Daemon qualified as Daemon
+import Cachix.Daemon.NarinfoBatch qualified as NarinfoBatch
 import Cachix.Daemon.PostBuildHook qualified as Daemon.PostBuildHook
 import Cachix.Daemon.Progress qualified as Daemon.Progress
 import Cachix.Daemon.Types
@@ -78,10 +79,8 @@ watchExecDaemon env pushOpts cacheName cmd args =
         let daemonOptions =
               DaemonOptions
                 { daemonSocketPath = Just (Daemon.PostBuildHook.daemonSock hookEnv),
-                  allowRemoteStop = False,
-                  narinfoBatchEnable = Nothing,
-                  narinfoBatchSize = Nothing,
-                  narinfoBatchTimeout = Nothing
+                  daemonNarinfoBatchOptions = NarinfoBatch.defaultNarinfoBatchOptions,
+                  allowRemoteStop = False
                 }
         daemon <- Daemon.new env store daemonOptions (Just logHandle) pushOpts cacheName
 

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -84,7 +84,7 @@ data CachixCommand
   | Import PushOptions Text URI
   | Pin PinOptions
   | WatchStore PushOptions Text
-  | WatchExec WatchExecMode PushOptions Text Text [Text]
+  | WatchExec WatchExecMode PushOptions NarinfoBatchOptions Text Text [Text]
   | Use BinaryCacheName InstallationMode.UseOptions
   | Remove BinaryCacheName
   | DeployCommand DeployOptions.DeployCommand
@@ -167,7 +167,7 @@ data DaemonCommand
   = DaemonPushPaths DaemonOptions DaemonPushOptions [FilePath]
   | DaemonRun DaemonOptions PushOptions BinaryCacheName
   | DaemonStop DaemonOptions
-  | DaemonWatchExec PushOptions BinaryCacheName Text [Text]
+  | DaemonWatchExec DaemonOptions PushOptions BinaryCacheName Text [Text]
   deriving (Show)
 
 data DaemonOptions = DaemonOptions
@@ -522,7 +522,8 @@ daemonStop = DaemonStop <$> daemonOptionsParser
 daemonWatchExec :: Parser DaemonCommand
 daemonWatchExec =
   DaemonWatchExec
-    <$> pushOptionsParser
+    <$> daemonOptionsParser
+    <*> pushOptionsParser
     <*> cacheNameParser
     <*> strArgument (metavar "CMD")
     <*> many (strArgument (metavar "-- ARGS"))
@@ -586,6 +587,7 @@ watchExecCommand =
   WatchExec
     <$> watchExecModeParser
     <*> pushOptionsParser
+    <*> batchConfigParser
     <*> cacheNameParser
     <*> strArgument (metavar "CMD")
     <*> many (strArgument (metavar "-- ARGS"))

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -171,9 +171,9 @@ data DaemonCommand
   deriving (Show)
 
 data DaemonOptions = DaemonOptions
-  { daemonSocketPath :: Maybe FilePath,
+  { daemonAllowRemoteStop :: Bool,
     daemonNarinfoBatchOptions :: NarinfoBatchOptions,
-    allowRemoteStop :: Bool
+    daemonSocketPath :: Maybe FilePath
   }
   deriving (Show)
 
@@ -531,9 +531,9 @@ daemonWatchExec =
 daemonOptionsParser :: Parser DaemonOptions
 daemonOptionsParser =
   DaemonOptions
-    <$> socketOption
+    <$> remoteStopOption
     <*> batchConfigParser
-    <*> remoteStopOption
+    <*> socketOption
   where
     socketOption =
       optional . strOption $

--- a/cachix/src/Cachix/Daemon.hs
+++ b/cachix/src/Cachix/Daemon.hs
@@ -150,7 +150,7 @@ run daemon = fmap join <$> runDaemon daemon $ do
             Nothing -> Katip.logFM Katip.ErrorS "Failed to queue push request"
         ClientStop -> do
           DaemonEnv {daemonOptions = opts, daemonClients = clients} <- ask
-          if Options.allowRemoteStop opts
+          if Options.daemonAllowRemoteStop opts
             then EventLoop.send daemonEventLoop ShutdownGracefully
             else do
               let errorMsg = "Remote stop is disabled on this daemon"

--- a/cachix/src/Cachix/Daemon.hs
+++ b/cachix/src/Cachix/Daemon.hs
@@ -92,7 +92,7 @@ new daemonEnv nixStore daemonOptions daemonLogHandle daemonPushOptions daemonCac
   let onPushEvent = Subscription.pushEvent daemonSubscriptionManager
 
   let pushParams = Push.newPushParams nixStore (clientenv daemonEnv) daemonBinaryCache daemonPushSecret daemonPushOptions
-  daemonPushManager <- PushManager.newPushManagerEnv daemonPushOptions pushParams onPushEvent daemonLogger (daemonNarinfoBatchOptions daemonOptions)
+  daemonPushManager <- PushManager.newPushManagerEnv daemonPushOptions (daemonNarinfoBatchOptions daemonOptions) pushParams onPushEvent daemonLogger
 
   daemonWorkerThreads <- newEmptyMVar
 

--- a/cachix/src/Cachix/Daemon.hs
+++ b/cachix/src/Cachix/Daemon.hs
@@ -21,7 +21,6 @@ import Cachix.Client.Push
 import Cachix.Daemon.EventLoop qualified as EventLoop
 import Cachix.Daemon.Listen as Listen
 import Cachix.Daemon.Log qualified as Log
-import Cachix.Daemon.NarinfoBatch qualified as NarinfoBatch
 import Cachix.Daemon.Protocol as Protocol
 import Cachix.Daemon.Push as Push
 import Cachix.Daemon.PushManager qualified as PushManager
@@ -47,7 +46,6 @@ import System.Environment (lookupEnv)
 import System.IO.Error (isResourceVanishedError)
 import System.Posix.Process (getProcessID)
 import System.Posix.Signals qualified as Signal
-import Text.Read qualified
 import UnliftIO (MonadUnliftIO, withRunInIO)
 import UnliftIO.Async qualified as Async
 import UnliftIO.Exception (bracket)

--- a/cachix/src/Cachix/Daemon.hs
+++ b/cachix/src/Cachix/Daemon.hs
@@ -94,7 +94,8 @@ new daemonEnv nixStore daemonOptions daemonLogHandle daemonPushOptions daemonCac
   let onPushEvent = Subscription.pushEvent daemonSubscriptionManager
 
   let pushParams = Push.newPushParams nixStore (clientenv daemonEnv) daemonBinaryCache daemonPushSecret daemonPushOptions
-  daemonPushManager <- PushManager.newPushManagerEnv daemonPushOptions pushParams onPushEvent daemonLogger
+      batchConfig = Options.daemonOptionsToBatchConfig daemonOptions
+  daemonPushManager <- PushManager.newPushManagerEnv daemonPushOptions pushParams onPushEvent daemonLogger batchConfig
 
   daemonWorkerThreads <- newEmptyMVar
 

--- a/cachix/src/Cachix/Daemon.hs
+++ b/cachix/src/Cachix/Daemon.hs
@@ -15,7 +15,7 @@ import Cachix.Client.Command.Push qualified as Command.Push
 import Cachix.Client.Config qualified as Config
 import Cachix.Client.Config.Orphans ()
 import Cachix.Client.Env as Env
-import Cachix.Client.OptionsParser (DaemonOptions, PushOptions)
+import Cachix.Client.OptionsParser (DaemonOptions, PushOptions, daemonNarinfoBatchOptions)
 import Cachix.Client.OptionsParser qualified as Options
 import Cachix.Client.Push
 import Cachix.Daemon.EventLoop qualified as EventLoop
@@ -92,8 +92,7 @@ new daemonEnv nixStore daemonOptions daemonLogHandle daemonPushOptions daemonCac
   let onPushEvent = Subscription.pushEvent daemonSubscriptionManager
 
   let pushParams = Push.newPushParams nixStore (clientenv daemonEnv) daemonBinaryCache daemonPushSecret daemonPushOptions
-      batchConfig = Options.daemonOptionsToBatchConfig daemonOptions
-  daemonPushManager <- PushManager.newPushManagerEnv daemonPushOptions pushParams onPushEvent daemonLogger batchConfig
+  daemonPushManager <- PushManager.newPushManagerEnv daemonPushOptions pushParams onPushEvent daemonLogger (daemonNarinfoBatchOptions daemonOptions)
 
   daemonWorkerThreads <- newEmptyMVar
 

--- a/cachix/src/Cachix/Daemon/NarinfoBatch.hs
+++ b/cachix/src/Cachix/Daemon/NarinfoBatch.hs
@@ -1,0 +1,304 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Cachix.Daemon.NarinfoBatch
+  ( -- * Types
+    NarinfoBatchManager,
+    BatchRequest (..),
+    BatchResponse (..),
+    BatchConfig (..),
+    defaultBatchConfig,
+
+    -- * Operations
+    newNarinfoBatchManager,
+    submitBatchRequest,
+    startBatchProcessor,
+    stopBatchProcessor,
+  )
+where
+
+import Control.Concurrent.STM
+import Control.Exception.Safe (bracket_, throwM)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Data.HashMap.Strict qualified as HashMap
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Time (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import Hercules.CNix.Store (Store, StorePath)
+import Katip qualified
+import Protolude
+import UnliftIO.Async qualified as Async
+
+-- | Configuration for the narinfo batch manager
+data BatchConfig = BatchConfig
+  { -- | Maximum number of paths to accumulate before triggering a batch
+    bcMaxBatchSize :: !Int,
+    -- | Maximum time to wait before triggering a batch (in seconds)
+    bcMaxWaitTime :: !NominalDiffTime,
+    -- | Whether the batch processor is enabled
+    bcEnabled :: !Bool
+  }
+  deriving stock (Eq, Show)
+
+-- | Default configuration with reasonable values
+defaultBatchConfig :: BatchConfig
+defaultBatchConfig =
+  BatchConfig
+    { bcMaxBatchSize = 100,
+      bcMaxWaitTime = 2.0, -- 2 seconds
+      bcEnabled = True
+    }
+
+-- | A request to check narinfo for store paths
+data BatchRequest = BatchRequest
+  { -- | Unique identifier for this request
+    brRequestId :: !Text,
+    -- | Store paths to check
+    brStorePaths :: ![StorePath],
+    -- | Response channel for this request
+    brResponseChan :: !(TMVar BatchResponse)
+  }
+
+-- | Response to a batch request
+data BatchResponse = BatchResponse
+  { -- | All paths in the dependency closure
+    brAllPaths :: ![StorePath],
+    -- | Paths missing from the cache
+    brMissingPaths :: ![StorePath]
+  }
+  deriving stock (Eq, Show)
+
+-- | Internal state of the batch manager
+data BatchState = BatchState
+  { -- | Accumulated requests waiting to be processed
+    bsPendingRequests :: ![BatchRequest],
+    -- | All unique paths from pending requests
+    bsAccumulatedPaths :: !(Set StorePath),
+    -- | Time when the first request in this batch was added
+    bsBatchStartTime :: !(Maybe UTCTime),
+    -- | Whether the processor should continue running
+    bsRunning :: !Bool
+  }
+
+-- | Manager for batching narinfo queries
+data NarinfoBatchManager = NarinfoBatchManager
+  { -- | Configuration
+    nbmConfig :: !BatchConfig,
+    -- | Internal state
+    nbmState :: !(TVar BatchState),
+    -- | Condition variable to signal new work
+    nbmWorkAvailable :: !(TMVar ()),
+    -- | Handle to the processor thread
+    nbmProcessorThread :: !(MVar (Async ()))
+  }
+
+-- | Create a new narinfo batch manager
+newNarinfoBatchManager :: (MonadIO m) => BatchConfig -> m NarinfoBatchManager
+newNarinfoBatchManager nbmConfig = liftIO $ do
+  nbmState <- newTVarIO initialState
+  nbmWorkAvailable <- newEmptyTMVarIO
+  nbmProcessorThread <- newEmptyMVar
+  return NarinfoBatchManager {..}
+  where
+    initialState =
+      BatchState
+        { bsPendingRequests = [],
+          bsAccumulatedPaths = Set.empty,
+          bsBatchStartTime = Nothing,
+          bsRunning = True
+        }
+
+-- | Submit a request to the batch manager
+submitBatchRequest ::
+  (MonadIO m) =>
+  NarinfoBatchManager ->
+  Text ->
+  [StorePath] ->
+  m BatchResponse
+submitBatchRequest NarinfoBatchManager {nbmConfig, nbmState, nbmWorkAvailable} requestId storePaths = liftIO $ do
+  if not (bcEnabled nbmConfig)
+    then -- Batching disabled, return empty response
+      return $ BatchResponse storePaths []
+    else do
+      -- Create response channel
+      responseChan <- newEmptyTMVarIO
+
+      -- Add request to pending queue
+      now <- getCurrentTime
+      atomically $ do
+        modifyTVar' nbmState $ \state ->
+          let newPaths = Set.fromList storePaths
+              updatedPaths = bsAccumulatedPaths state <> newPaths
+              newRequest = BatchRequest requestId storePaths responseChan
+              newStartTime = case bsBatchStartTime state of
+                Nothing -> Just now
+                justTime -> justTime
+           in state
+                { bsPendingRequests = newRequest : bsPendingRequests state,
+                  bsAccumulatedPaths = updatedPaths,
+                  bsBatchStartTime = newStartTime
+                }
+
+        -- Signal that work is available
+        void $ tryPutTMVar nbmWorkAvailable ()
+
+      -- Wait for response
+      atomically $ readTMVar responseChan
+
+-- | Start the batch processor thread
+startBatchProcessor ::
+  (MonadUnliftIO m, MonadMask m, Katip.KatipContext m) =>
+  NarinfoBatchManager ->
+  -- | Function to process a batch of paths
+  ([StorePath] -> m ([StorePath], [StorePath])) ->
+  m ()
+startBatchProcessor manager@NarinfoBatchManager {nbmProcessorThread} processBatch = do
+  -- Start processor thread
+  thread <- Async.async $ runBatchProcessor manager processBatch
+  liftIO $ putMVar nbmProcessorThread thread
+
+-- | Stop the batch processor
+stopBatchProcessor :: (MonadIO m) => NarinfoBatchManager -> m ()
+stopBatchProcessor NarinfoBatchManager {nbmState, nbmWorkAvailable, nbmProcessorThread} = liftIO $ do
+  -- Signal shutdown
+  atomically $ do
+    modifyTVar' nbmState $ \state -> state {bsRunning = False}
+    void $ tryPutTMVar nbmWorkAvailable ()
+
+  -- Wait for processor thread to finish
+  thread <- tryTakeMVar nbmProcessorThread
+  for_ thread Async.wait
+
+-- | Main batch processor loop
+runBatchProcessor ::
+  (MonadUnliftIO m, MonadMask m, Katip.KatipContext m) =>
+  NarinfoBatchManager ->
+  ([StorePath] -> m ([StorePath], [StorePath])) ->
+  m ()
+runBatchProcessor manager@NarinfoBatchManager {nbmConfig, nbmState, nbmWorkAvailable} processBatch = do
+  loop
+  where
+    loop = do
+      -- Wait for work or timeout
+      shouldProcess <- liftIO $ atomically $ do
+        state <- readTVar nbmState
+        if not (bsRunning state)
+          then return Nothing -- Shutdown requested
+          else
+            if null (bsPendingRequests state)
+              then do
+                -- No work, wait for signal
+                takeTMVar nbmWorkAvailable
+                return $ Just False -- Check again
+              else do
+                -- We have work, check if we should process
+                return $ Just True
+
+      case shouldProcess of
+        Nothing -> return () -- Shutdown
+        Just False -> loop -- Check again
+        Just True -> do
+          -- Check if batch is ready
+          now <- liftIO getCurrentTime
+          ready <- liftIO $ atomically $ do
+            state <- readTVar nbmState
+            let pathCount = Set.size (bsAccumulatedPaths state)
+                timeElapsed = case bsBatchStartTime state of
+                  Nothing -> 0
+                  Just startTime -> now `diffUTCTime` startTime
+
+            return $
+              pathCount >= bcMaxBatchSize nbmConfig
+                || timeElapsed >= bcMaxWaitTime nbmConfig
+
+          if ready
+            then do
+              -- Process the batch
+              processPendingBatch manager processBatch
+              loop
+            else do
+              -- Not ready yet, wait a bit
+              liftIO $ threadDelay 100000 -- 100ms
+              loop
+
+-- | Process all pending requests as a single batch
+processPendingBatch ::
+  (MonadUnliftIO m, MonadMask m, Katip.KatipContext m) =>
+  NarinfoBatchManager ->
+  ([StorePath] -> m ([StorePath], [StorePath])) ->
+  m ()
+processPendingBatch NarinfoBatchManager {nbmState} processBatch = do
+  -- Extract pending requests
+  (requests, allPaths, batchStartTime) <- liftIO $ atomically $ do
+    state <- readTVar nbmState
+    let requests = reverse (bsPendingRequests state) -- Process in FIFO order
+        allPaths = Set.toList (bsAccumulatedPaths state)
+        startTime = bsBatchStartTime state
+
+    -- Clear the state
+    writeTVar nbmState $
+      state
+        { bsPendingRequests = [],
+          bsAccumulatedPaths = Set.empty,
+          bsBatchStartTime = Nothing
+        }
+
+    return (requests, allPaths, startTime)
+
+  -- Process the batch if we have paths
+  unless (null allPaths) $ do
+    processingStartTime <- liftIO getCurrentTime
+
+    -- Log batch statistics
+    let requestCount = length requests
+        pathCount = length allPaths
+        waitTime = case batchStartTime of
+          Nothing -> 0
+          Just startTime -> processingStartTime `diffUTCTime` startTime
+
+    Katip.logFM Katip.InfoS $
+      Katip.ls $
+        T.intercalate
+          " "
+          [ "Processing narinfo batch:",
+            show requestCount :: Text,
+            "requests,",
+            show pathCount :: Text,
+            "paths,",
+            "waited",
+            show waitTime
+          ]
+
+    -- Query narinfo for all paths at once
+    (allPathsInClosure, missingPaths) <- processBatch allPaths
+
+    processingEndTime <- liftIO getCurrentTime
+    let processingTime = processingEndTime `diffUTCTime` processingStartTime
+        closureSize = length allPathsInClosure
+        missingCount = length missingPaths
+
+    Katip.logFM Katip.InfoS $
+      Katip.ls $
+        T.intercalate
+          " "
+          [ "Batch completed in",
+            show processingTime <> ":",
+            show closureSize :: Text,
+            "total paths,",
+            show missingCount :: Text,
+            "missing"
+          ]
+
+    -- Build lookup tables
+    let allPathsSet = Set.fromList allPathsInClosure
+        missingPathsSet = Set.fromList missingPaths
+
+    -- Respond to each request
+    liftIO $ forM_ requests $ \BatchRequest {brStorePaths, brResponseChan} -> do
+      -- Filter paths relevant to this request
+      let requestPaths = filter (`Set.member` allPathsSet) brStorePaths
+          requestMissing = filter (`Set.member` missingPathsSet) brStorePaths
+          response = BatchResponse requestPaths requestMissing
+
+      atomically $ putTMVar brResponseChan response

--- a/cachix/src/Cachix/Daemon/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/PushManager.hs
@@ -82,7 +82,7 @@ import Servant.Auth.Client
 import Servant.Conduit ()
 import UnliftIO.QSem qualified as QSem
 
-newPushManagerEnv :: (MonadIO m) => PushOptions -> PushParams PushManager () -> OnPushEvent -> Logger -> NarinfoBatch.BatchConfig -> m PushManagerEnv
+newPushManagerEnv :: (MonadIO m) => PushOptions -> PushParams PushManager () -> OnPushEvent -> Logger -> NarinfoBatch.NarinfoBatchOptions -> m PushManagerEnv
 newPushManagerEnv pushOptions pmPushParams onPushEvent pmLogger batchConfig = liftIO $ do
   pmPushJobs <- newTVarIO mempty
   pmPendingJobCount <- newTVarIO 0

--- a/cachix/src/Cachix/Daemon/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/PushManager.hs
@@ -82,8 +82,8 @@ import Servant.Auth.Client
 import Servant.Conduit ()
 import UnliftIO.QSem qualified as QSem
 
-newPushManagerEnv :: (MonadIO m) => PushOptions -> PushParams PushManager () -> OnPushEvent -> Logger -> NarinfoBatch.NarinfoBatchOptions -> m PushManagerEnv
-newPushManagerEnv pushOptions pmPushParams onPushEvent pmLogger batchConfig = liftIO $ do
+newPushManagerEnv :: (MonadIO m) => PushOptions -> NarinfoBatch.NarinfoBatchOptions -> PushParams PushManager () -> OnPushEvent -> Logger -> m PushManagerEnv
+newPushManagerEnv pushOptions batchOptions pmPushParams onPushEvent pmLogger = liftIO $ do
   pmPushJobs <- newTVarIO mempty
   pmPendingJobCount <- newTVarIO 0
   pmStorePathIndex <- newTVarIO mempty
@@ -99,7 +99,7 @@ newPushManagerEnv pushOptions pmPushParams onPushEvent pmLogger batchConfig = li
           case result of
             Just True -> return ()
             _ -> retry -- Queue is full, keep trying
-  pmNarinfoBatchManager <- NarinfoBatch.newNarinfoBatchManager batchConfig batchCallback
+  pmNarinfoBatchManager <- NarinfoBatch.newNarinfoBatchManager batchOptions batchCallback
 
   return $ PushManagerEnv {..}
 

--- a/cachix/src/Cachix/Daemon/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/PushManager.hs
@@ -114,7 +114,7 @@ stopPushManager timeoutOptions PushManagerEnv {..} = do
   atomically $ closeTBMQueue pmTaskQueue
 
 -- | Start the batch processor for narinfo queries
-startBatchProcessor :: (MonadUnliftIO m, E.MonadMask m, Katip.KatipContext m) => PushManagerEnv -> m ()
+startBatchProcessor :: (MonadUnliftIO m, Katip.KatipContext m) => PushManagerEnv -> m ()
 startBatchProcessor env@PushManagerEnv {pmNarinfoBatchManager} = do
   NarinfoBatch.startBatchProcessor pmNarinfoBatchManager $ \paths ->
     runPushManager env (processBatchedNarinfo paths)

--- a/cachix/src/Cachix/Daemon/Types/Daemon.hs
+++ b/cachix/src/Cachix/Daemon/Types/Daemon.hs
@@ -14,6 +14,7 @@ import Cachix.Client.Config.Orphans ()
 import Cachix.Client.Env as Env
 import Cachix.Client.OptionsParser (DaemonOptions, PushOptions)
 import Cachix.Daemon.Log qualified as Log
+import Cachix.Daemon.NarinfoBatch (NarinfoBatchManager)
 import Cachix.Daemon.Protocol qualified as Protocol
 import Cachix.Daemon.Subscription (SubscriptionManager)
 import Cachix.Daemon.Types.Error (DaemonError (DaemonUnhandledException), UnhandledException (..))
@@ -70,6 +71,8 @@ data DaemonEnv = DaemonEnv
     daemonSubscriptionManager :: SubscriptionManager Protocol.PushRequestId PushEvent,
     -- | A thread handle for the subscription manager
     daemonSubscriptionManagerThread :: MVar (Async ()),
+    -- | Manager for batching narinfo queries
+    daemonNarinfoBatchManager :: NarinfoBatchManager,
     -- | Logging env
     daemonLogger :: Logger,
     -- | The PID of the daemon process

--- a/cachix/src/Cachix/Daemon/Types/Daemon.hs
+++ b/cachix/src/Cachix/Daemon/Types/Daemon.hs
@@ -14,7 +14,6 @@ import Cachix.Client.Config.Orphans ()
 import Cachix.Client.Env as Env
 import Cachix.Client.OptionsParser (DaemonOptions, PushOptions)
 import Cachix.Daemon.Log qualified as Log
-import Cachix.Daemon.NarinfoBatch (NarinfoBatchManager)
 import Cachix.Daemon.Protocol qualified as Protocol
 import Cachix.Daemon.Subscription (SubscriptionManager)
 import Cachix.Daemon.Types.Error (DaemonError (DaemonUnhandledException), UnhandledException (..))
@@ -71,8 +70,6 @@ data DaemonEnv = DaemonEnv
     daemonSubscriptionManager :: SubscriptionManager Protocol.PushRequestId PushEvent,
     -- | A thread handle for the subscription manager
     daemonSubscriptionManagerThread :: MVar (Async ()),
-    -- | Manager for batching narinfo queries
-    daemonNarinfoBatchManager :: NarinfoBatchManager,
     -- | Logging env
     daemonLogger :: Logger,
     -- | The PID of the daemon process

--- a/cachix/src/Cachix/Daemon/Types/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/Types/PushManager.hs
@@ -19,6 +19,7 @@ where
 import Cachix.Client.Push (PushParams)
 import Cachix.Daemon.Log qualified as Log
 import Cachix.Daemon.NarinfoBatch (NarinfoBatchManager)
+import Cachix.Daemon.NarinfoBatch qualified as NarinfoBatch
 import Cachix.Daemon.Protocol qualified as Protocol
 import Cachix.Daemon.Types.Log (Logger)
 import Cachix.Daemon.Types.PushEvent (PushEvent (..))
@@ -33,6 +34,7 @@ import Protolude
 
 data Task
   = ResolveClosure Protocol.PushRequestId
+  | ProcessBatchResponse Protocol.PushRequestId NarinfoBatch.BatchResponse
   | PushStorePath FilePath
 
 type PushJobStore = TVar (HashMap Protocol.PushRequestId PushJob)
@@ -60,7 +62,7 @@ data PushManagerEnv = PushManagerEnv
     -- | The number of pending (uncompleted) jobs.
     pmPendingJobCount :: TVar Int,
     -- | Manager for batching narinfo queries
-    pmNarinfoBatchManager :: NarinfoBatchManager,
+    pmNarinfoBatchManager :: NarinfoBatchManager Protocol.PushRequestId,
     pmLogger :: Logger
   }
 

--- a/cachix/src/Cachix/Daemon/Types/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/Types/PushManager.hs
@@ -18,6 +18,7 @@ where
 
 import Cachix.Client.Push (PushParams)
 import Cachix.Daemon.Log qualified as Log
+import Cachix.Daemon.NarinfoBatch (NarinfoBatchManager)
 import Cachix.Daemon.Protocol qualified as Protocol
 import Cachix.Daemon.Types.Log (Logger)
 import Cachix.Daemon.Types.PushEvent (PushEvent (..))
@@ -58,6 +59,8 @@ data PushManagerEnv = PushManagerEnv
     pmLastEventTimestamp :: TVar UTCTime,
     -- | The number of pending (uncompleted) jobs.
     pmPendingJobCount :: TVar Int,
+    -- | Manager for batching narinfo queries
+    pmNarinfoBatchManager :: NarinfoBatchManager,
     pmLogger :: Logger
   }
 

--- a/cachix/test/Daemon/PushManagerSpec.hs
+++ b/cachix/test/Daemon/PushManagerSpec.hs
@@ -4,6 +4,7 @@ import Cachix.Client.Env qualified as Env
 import Cachix.Client.OptionsParser (defaultPushOptions)
 import Cachix.Client.Push (PushSecret (PushToken))
 import Cachix.Daemon.Log qualified as Log
+import Cachix.Daemon.NarinfoBatch (defaultNarinfoBatchOptions)
 import Cachix.Daemon.Protocol qualified as Protocol
 import Cachix.Daemon.Push qualified as Daemon.Push
 import Cachix.Daemon.PushManager
@@ -187,8 +188,9 @@ withPushManager f = do
     let binaryCache = newBinaryCache "test"
         pushSecret = PushToken (Token "test")
         pushOptions = defaultPushOptions
+        batchOptions = defaultNarinfoBatchOptions
         pushParams = Daemon.Push.newPushParams store clientEnv binaryCache pushSecret pushOptions
-    newPushManagerEnv pushOptions pushParams mempty logger >>= f
+    newPushManagerEnv pushOptions batchOptions pushParams mempty logger >>= f
 
 inPushManager :: PushManager a -> IO a
 inPushManager f = withPushManager (`runPushManager` f)


### PR DESCRIPTION
Batch narinfo requests across push jobs.

This optimization is particularly relevant for build pipelines using post-build hooks.
Most post-build callbacks will contain a single store path.
As a result, in the pathological case, the daemon would send a request per path instead of grouping them.
