### PR TITLE
Cachix.Client.NixVersion: disambiguate show

### DIFF
--- a/cachix/src/Cachix/Client/NixVersion.hs
+++ b/cachix/src/Cachix/Client/NixVersion.hs
@@ -33,7 +33,7 @@ getRawNixVersion = do
   (exitcode, out, err) <- readProcessWithExitCode "nix-env" ["--version"] mempty
   unless (err == "") $ putStrLn $ "nix-env stderr: " <> err
   return $ case exitcode of
-    ExitFailure i -> Left $ "'nix-env --version' exited with " <> show i
+    ExitFailure i -> Left $ "'nix-env --version' exited with " <> Protolude.show i
     ExitSuccess -> Right (toS out)
 
 parseNixVersion :: Text -> Either Text Versioning


### PR DESCRIPTION
Required for GHC 9.10

> Add Data.Text.show and Data.Text.Lazy.show

https://github.com/haskell/text/blob/master/changelog.md#212

Choice is `Protolude.show` so that we don't require such a recent `text`