### PR TITLE
cnix: refactor the API to create already validated store paths

### DIFF
--- a/cachix/src/Cachix/Client/CNix.hs
+++ b/cachix/src/Cachix/Client/CNix.hs
@@ -1,4 +1,24 @@
-module Cachix.Client.CNix where
+module Cachix.Client.CNix
+  ( -- * Store path validation
+    StorePathError (..),
+    resolveStorePath,
+    resolveStorePaths,
+    validateStorePath,
+    formatStorePathWarning,
+    logStorePathWarning,
+    logStorePathWarning',
+
+    -- * Legacy API (deprecated)
+    filterInvalidStorePath,
+    filterInvalidStorePaths,
+    followLinksToStorePath,
+
+    -- * Error handling
+    NixError (..),
+    catchNixError,
+    handleCppExceptions,
+  )
+where
 
 import Hercules.CNix.Store (Store, StorePath)
 import Hercules.CNix.Store qualified as Store
@@ -6,35 +26,97 @@ import Language.C.Inline.Cpp.Exception
 import Protolude
 import System.Console.Pretty (Color (..), Style (..), color, style)
 
--- | Checks whether a store path is valid.
-validateStorePath :: Store -> StorePath -> IO (Maybe StorePath)
-validateStorePath store storePath = do
-  isValid <- Store.isValidPath store storePath `catchNixError` const (return False)
-  if isValid
-    then return (Just storePath)
-    else return Nothing
+-- | Error when resolving a store path
+data StorePathError
+  = -- | Path could not be resolved (doesn't exist, bad symlink, etc.)
+    StorePathNotFound Text
+  | -- | Path exists but is not valid in the Nix store
+    StorePathNotValid
+  | -- | Error occurred during validation (e.g., permission denied)
+    StorePathError Text
+  deriving (Show, Eq)
 
--- | Like 'validateStorePath', but logs a warning when the path is invalid.
+-- | Resolve a file path to a validated store path.
 --
--- When validation fails due to an error (e.g., permission denied),
--- the actual error message is logged instead of a generic "is not valid" message.
-filterInvalidStorePath :: Store -> StorePath -> IO (Maybe StorePath)
-filterInvalidStorePath store storePath = do
+-- Follows symlinks and validates the resulting store path.
+resolveStorePath :: Store -> FilePath -> IO (Either StorePathError StorePath)
+resolveStorePath store fp = do
+  let pathBytes = encodeUtf8 (toS fp :: Text)
+  resolveResult <- tryResolve pathBytes
+  case resolveResult of
+    Left err -> pure $ Left (StorePathNotFound (msg err))
+    Right storePath -> validateStorePath store storePath
+  where
+    tryResolve pathBytes =
+      (Right <$> Store.followLinksToStorePath store pathBytes)
+        `catchNixError` (pure . Left)
+
+-- | Resolve multiple file paths to validated store paths.
+--
+-- Returns a pair of (errors, valid paths). Errors are paired with their
+-- original file path for error reporting.
+resolveStorePaths :: Store -> [FilePath] -> IO ([(FilePath, StorePathError)], [StorePath])
+resolveStorePaths store paths = do
+  results <- mapM (resolveStorePath store) paths
+  pure $ foldr go ([], []) (zip paths results)
+  where
+    go (path, Left err) (errs, oks) = ((path, err) : errs, oks)
+    go (_, Right sp) (errs, oks) = (errs, sp : oks)
+
+-- | Format a store path error as a user-friendly warning message.
+formatStorePathWarning :: FilePath -> StorePathError -> Text
+formatStorePathWarning path = \case
+  StorePathNotFound reason -> toS path <> ": " <> reason
+  StorePathNotValid -> toS path <> " is not valid"
+  StorePathError reason -> toS path <> ": " <> reason
+
+-- | Log a store path error as a warning (yellow, to stderr).
+logStorePathWarning :: FilePath -> StorePathError -> IO ()
+logStorePathWarning path err =
+  putErrText $ color Yellow $ "Warning: " <> formatStorePathWarning path err <> ", skipping"
+
+-- | Log a store path validation error as a warning.
+--
+-- Like 'logStorePathWarning' but for when you have a 'StorePath' instead of a 'FilePath'.
+logStorePathWarning' :: Store -> StorePath -> StorePathError -> IO ()
+logStorePathWarning' store storePath err = do
+  pathBytes <- Store.storePathToPath store storePath
+  let path = toS (decodeUtf8With lenientDecode pathBytes :: Text)
+  logStorePathWarning path err
+
+-- | Validate that an existing store path is still valid in the Nix store.
+--
+-- Use this to re-check a previously resolved path, e.g., before pushing
+-- a path that may have been garbage collected since it was queued.
+validateStorePath :: Store -> StorePath -> IO (Either StorePathError StorePath)
+validateStorePath store storePath = do
   result <- tryValidate
   case result of
-    Right True -> return (Just storePath)
-    Right False -> do
-      logBadStorePath store storePath
-      return Nothing
-    Left err -> do
-      logStorePathError store storePath err
-      return Nothing
+    Left err -> pure $ Left (StorePathError (msg err))
+    Right True -> pure $ Right storePath
+    Right False -> pure $ Left StorePathNotValid
   where
-    tryValidate = (Right <$> Store.isValidPath store storePath) `catchNixError` (return . Left)
+    tryValidate =
+      (Right <$> Store.isValidPath store storePath)
+        `catchNixError` (pure . Left)
 
+{-# DEPRECATED filterInvalidStorePath "Use validateStorePath + logStorePathWarning' instead" #-}
+
+-- | Like 'validateStorePath', but logs a warning when the path is invalid.
+filterInvalidStorePath :: Store -> StorePath -> IO (Maybe StorePath)
+filterInvalidStorePath store storePath =
+  validateStorePath store storePath >>= \case
+    Right sp -> return (Just sp)
+    Left err -> do
+      logStorePathWarning' store storePath err
+      return Nothing
+
+{-# DEPRECATED filterInvalidStorePaths "Use resolveStorePath + logStorePathWarning instead" #-}
 filterInvalidStorePaths :: Store -> [StorePath] -> IO [Maybe StorePath]
 filterInvalidStorePaths store =
   traverse (filterInvalidStorePath store)
+
+{-# DEPRECATED followLinksToStorePath "Use resolveStorePath instead" #-}
 
 -- | Follows all symlinks to a store path, returning the final store path.
 --
@@ -73,19 +155,6 @@ logNixError storePath (NixError {..}) =
   case typ of
     Just "nix::BadStorePath" -> logBadPath storePath
     _ -> putErrText $ color Red $ style Bold $ "Nix " <> msg
-
--- | Print a warning when a store path is invalid.
-logBadStorePath :: Store -> StorePath -> IO ()
-logBadStorePath store storePath = do
-  path <- Store.storePathToPath store storePath
-  logBadPath path
-
--- | Print a warning with the actual error when accessing a store path fails.
-logStorePathError :: Store -> StorePath -> NixError -> IO ()
-logStorePathError store storePath (NixError {..}) = do
-  path <- Store.storePathToPath store storePath
-  let pathText = decodeUtf8With lenientDecode path
-  putErrText $ color Yellow $ "Warning: " <> pathText <> " - " <> msg <> ", skipping"
 
 -- | Print a warning when the path is invalid.
 --

--- a/cachix/src/Cachix/Client/Exception.hs
+++ b/cachix/src/Cachix/Client/Exception.hs
@@ -22,6 +22,7 @@ data CachixException
   | BinaryCacheNotFound Text
   | ImportUnsupportedHash Text
   | RemoveCacheUnsupported Text
+  | InvalidStorePath Text
   deriving (Show, Typeable)
 
 instance Exception CachixException where
@@ -44,3 +45,4 @@ instance Exception CachixException where
   displayException (BinaryCacheNotFound s) = toS s
   displayException (ImportUnsupportedHash s) = toS s
   displayException (RemoveCacheUnsupported s) = toS s
+  displayException (InvalidStorePath s) = toS s


### PR DESCRIPTION
Cleans thing up so that we parse file paths into StorePath, instead of validating them post-fact.