### PR TITLE
push: exit when parent process dies to prevent orphaned spinners

### DIFF
--- a/cachix/src/Cachix/Client/Command/Push.hs
+++ b/cachix/src/Cachix/Client/Command/Push.hs
@@ -24,6 +24,7 @@ import Cachix.Client.Secrets
 import Cachix.Client.Servant
 import Cachix.Types.BinaryCache (BinaryCacheName)
 import Cachix.Types.BinaryCache qualified as BinaryCache
+import Control.Concurrent (forkIO, myThreadId, threadDelay, throwTo)
 import Control.Exception.Safe (throwM)
 import Control.Retry (RetryStatus (rsIterNumber))
 import Data.ByteString qualified as BS
@@ -33,7 +34,7 @@ import Data.Text qualified as T
 import Hercules.CNix (StorePath)
 import Hercules.CNix.Store (Store, storePathToPath, withStore)
 import Network.HTTP.Types (status401, status404)
-import Protolude hiding (toS)
+import Protolude hiding (toS, throwTo)
 import Protolude.Conv
 import Servant.Auth ()
 import Servant.Auth.Client
@@ -43,6 +44,8 @@ import System.Console.AsciiProgress
 import System.Console.Pretty
 import System.Environment (lookupEnv)
 import System.IO (hIsTerminalDevice)
+import System.Posix.Process (getParentProcessID)
+import System.Posix.Types (ProcessID)
 
 push :: Env -> PushOptions -> BinaryCacheName -> [Text] -> IO ()
 push env opts name cliPaths = do
@@ -57,6 +60,12 @@ push env opts name cliPaths = do
       -- that may or may not be written to by the caller.
       -- This is somewhat like the behavior of `cat` for example.
       (_, paths) -> return paths
+  -- Exit when the parent process dies to avoid orphaned cachix processes
+  -- spinning on dead connections (see parentWatchdog).
+  when hasStdin $ do
+    parentPid <- getParentProcessID
+    mainTid <- myThreadId
+    void $ forkIO $ parentWatchdog mainTid parentPid
   withPushParams env opts name $ \pushParams -> do
     (errors, validPaths) <- liftIO $ resolveStorePaths (pushParamsStore pushParams) (map toS inputStorePaths)
     liftIO $ forM_ errors $ uncurry logStorePathWarning
@@ -237,3 +246,17 @@ getPushSecretRequired config name = do
 -- This is safe to use when printing from multiple threads, unlike hPutStrLn which may fail to insert the newline at the right place.
 appendErrText :: (MonadIO m) => Text -> m ()
 appendErrText = hPutStr stderr
+
+-- | Exit the process when the parent dies.
+--
+-- When reading from a pipe (e.g. @nix-build | cachix push@), the parent may be
+-- killed while uploads are in-flight. HTTP requests hang on dead connections and
+-- the process spins at 100% CPU. This watchdog polls 'getParentProcessID' and
+-- exits when it changes (i.e. the process has been re-parented).
+parentWatchdog :: ThreadId -> ProcessID -> IO ()
+parentWatchdog mainTid originalParent = forever $ do
+  threadDelay 5_000_000
+  currentParent <- getParentProcessID
+  when (currentParent /= originalParent) $ do
+    putErrText "cachix: parent process died, exiting"
+    throwTo mainTid ExitSuccess


### PR DESCRIPTION
When `cachix push` reads store paths from stdin (e.g. `nix-build | cachix push`), the parent process may be killed while uploads are in-flight. Because the HTTP client uses `responseTimeoutNone`, requests hang indefinitely on dead (CLOSE-WAIT) connections. The orphaned cachix process then spins at 100% CPU on GHC's IO manager timerfd, consuming a full core forever.

This was observed on CI runners where ~40 orphaned `cachix push` processes accumulated over hours, each burning 100% CPU with CLOSE-WAIT sockets and PPID 1.

Fix: when reading from stdin, fork a watchdog thread that polls `getParentProcessID` every 5 seconds. If the parent PID changes (process re-parented to init), exit cleanly.

Tested by:
- Building a 500MB random store path
- Starting `cachix push` in a pipe from a setsid'd parent
- Blocking outbound traffic with iptables to force CLOSE-WAIT
- Killing the parent process

Master cachix (e8be573): orphaned at PPID 1, 100% CPU, CLOSE-WAIT sockets, alive indefinitely.
Patched cachix: detected parent death, printed "cachix: parent process died, exiting", exited in <5 seconds.