### PR TITLE
feat: CA derivations support via new C FFI bindings

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,17 @@
-packages: */*.cabal
+packages:
+  */*.cabal
+  ../hs-nix-c-api/hs-nix-c-api
+  ../hs-nix-c-api/hs-nix-c-api-sys
 
 allow-newer: lzma-conduit:*
+
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/hs-bindgen
+  tag: 4b6febb5cc6196835bd2890a3ab27a88dab1806b
+  subdir:
+    hs-bindgen-runtime
+    c-expr-runtime
 
 -- The hackage release for amazonka is outdated.
 -- Use the same rev from source as nixpkgs-unstable.

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,7 @@
 packages:
   */*.cabal
-  ../hs-nix-c-api/hs-nix-c-api
-  ../hs-nix-c-api/hs-nix-c-api-sys
+  ../nix-bindings-haskell/nix-bindings
+  ../nix-bindings-haskell/nix-bindings-sys
 
 allow-newer: lzma-conduit:*
 

--- a/cachix-api/cachix-api.cabal
+++ b/cachix-api/cachix-api.cabal
@@ -81,6 +81,7 @@ library
     Cachix.Types.NixCacheInfo
     Cachix.Types.Permission
     Cachix.Types.PinCreate
+    Cachix.Types.Realisation
     Cachix.Types.Servant
     Cachix.Types.Session
     Cachix.Types.SigningKeyCreate

--- a/cachix-api/src/Cachix/API.hs
+++ b/cachix-api/src/Cachix/API.hs
@@ -18,6 +18,7 @@ import qualified Cachix.Types.NarInfoCreate as NarInfoCreate
 import qualified Cachix.Types.NarInfoHash as NarInfoHash
 import qualified Cachix.Types.NixCacheInfo as NixCacheInfo
 import qualified Cachix.Types.PinCreate as PinCreate
+import qualified Cachix.Types.Realisation as Realisation
 import Cachix.Types.Servant (Get302, Head)
 import Cachix.Types.Session (Session)
 import qualified Cachix.Types.SigningKeyCreate as SigningKeyCreate
@@ -177,6 +178,22 @@ data BinaryCacheAPI route = BinaryCacheAPI
           :> Capture "name" Text
           :> "pin"
           :> ReqBody '[JSON] PinCreate.PinCreate
+          :> Post '[JSON] NoContent,
+    getRealisation ::
+      route
+        :- CachixAuth
+          :> "cache"
+          :> Capture "name" Text
+          :> "realisations"
+          :> Capture "drvOutputId" Text
+          :> Get '[JSON] Realisation.Realisation,
+    putRealisations ::
+      route
+        :- CachixAuth
+          :> "cache"
+          :> Capture "name" Text
+          :> "realisations"
+          :> ReqBody '[JSON] [Realisation.Realisation]
           :> Post '[JSON] NoContent
   }
   deriving (Generic)

--- a/cachix-api/src/Cachix/API.hs
+++ b/cachix-api/src/Cachix/API.hs
@@ -179,6 +179,9 @@ data BinaryCacheAPI route = BinaryCacheAPI
           :> "pin"
           :> ReqBody '[JSON] PinCreate.PinCreate
           :> Post '[JSON] NoContent,
+    -- | GET returns the bare 'UnkeyedRealisation' (outPath + signatures);
+    -- Nix's substituter parses @build-trace-v2\/\<drv\>\/\<output\>.doi@ as a
+    -- build-trace value for the key implied by the URL.
     getBuildTrace ::
       route
         :- CachixAuth
@@ -187,7 +190,7 @@ data BinaryCacheAPI route = BinaryCacheAPI
           :> "build-trace-v2"
           :> Capture "drvName" Text
           :> Capture "outputDoi" Text
-          :> Get '[JSON] Realisation.Realisation,
+          :> Get '[JSON] Realisation.UnkeyedRealisation,
     putBuildTraces ::
       route
         :- CachixAuth

--- a/cachix-api/src/Cachix/API.hs
+++ b/cachix-api/src/Cachix/API.hs
@@ -179,20 +179,21 @@ data BinaryCacheAPI route = BinaryCacheAPI
           :> "pin"
           :> ReqBody '[JSON] PinCreate.PinCreate
           :> Post '[JSON] NoContent,
-    getRealisation ::
+    getBuildTrace ::
       route
         :- CachixAuth
           :> "cache"
           :> Capture "name" Text
-          :> "realisations"
-          :> Capture "drvOutputId" Text
+          :> "build-trace-v2"
+          :> Capture "drvName" Text
+          :> Capture "outputDoi" Text
           :> Get '[JSON] Realisation.Realisation,
-    putRealisations ::
+    putBuildTraces ::
       route
         :- CachixAuth
           :> "cache"
           :> Capture "name" Text
-          :> "realisations"
+          :> "build-trace-v2"
           :> ReqBody '[JSON] [Realisation.Realisation]
           :> Post '[JSON] NoContent
   }

--- a/cachix-api/src/Cachix/Types/NarInfoCreate.hs
+++ b/cachix-api/src/Cachix/Types/NarInfoCreate.hs
@@ -26,7 +26,8 @@ data NarInfoCreate = NarInfoCreate
     cFileSize :: Integer,
     cReferences :: [Text],
     cDeriver :: Text,
-    cSig :: Maybe Text
+    cSig :: Maybe Text,
+    cCa :: Maybe Text
   }
   deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
 

--- a/cachix-api/src/Cachix/Types/Realisation.hs
+++ b/cachix-api/src/Cachix/Types/Realisation.hs
@@ -1,0 +1,71 @@
+module Cachix.Types.Realisation
+  ( Realisation (..),
+    splitDrvOutputId,
+    mkDrvOutputId,
+  )
+where
+
+import Data.Aeson
+  ( FromJSON (..),
+    ToJSON (..),
+    object,
+    withObject,
+    (.:),
+    (.=),
+  )
+import Data.Swagger (ToSchema)
+import qualified Data.Text as T
+import Protolude
+
+-- | A Nix realisation mapping a derivation output to its content-addressed store path.
+--
+-- JSON format matches what Nix expects at @realisations\/\<id\>.doi@:
+--
+-- @
+-- { "id": "sha256:\<hash\>!\<outputName\>"
+-- , "outPath": "\<storePathBaseName\>"
+-- , "signatures": [...]
+-- , "dependentRealisations": { "sha256:\<hash\>!\<out\>": "\<storePathBaseName\>", ... }
+-- }
+-- @
+data Realisation = Realisation
+  { -- | Derivation output id, e.g. "sha256:<hash>!<outputName>"
+    rId :: Text,
+    -- | Store path base name of the output
+    rOutPath :: Text,
+    -- | Signatures for this realisation
+    rSignatures :: [Text],
+    -- | Map from dependent derivation output ids to their store path base names
+    rDependentRealisations :: Map Text Text
+  }
+  deriving (Eq, Show, Generic, NFData, ToSchema)
+
+-- | Split a derivation output id "sha256:<hash>!<outputName>" into (drvHash, outputName).
+-- Returns Nothing if there is no "!" separator.
+splitDrvOutputId :: Text -> Maybe (Text, Text)
+splitDrvOutputId t =
+  case T.breakOn "!" t of
+    (_, rest) | T.null rest -> Nothing
+    (drvHash, rest) -> Just (drvHash, T.drop 1 rest)
+
+-- | Construct a derivation output id from drvHash and outputName.
+mkDrvOutputId :: Text -> Text -> Text
+mkDrvOutputId drvHash outputName = drvHash <> "!" <> outputName
+
+instance ToJSON Realisation where
+  toJSON Realisation {..} =
+    object
+      [ "id" .= rId,
+        "outPath" .= rOutPath,
+        "signatures" .= rSignatures,
+        "dependentRealisations" .= rDependentRealisations
+      ]
+
+instance FromJSON Realisation where
+  parseJSON = withObject "Realisation" $ \o ->
+    Realisation
+      <$> o
+      .: "id"
+      <*> o .: "outPath"
+      <*> o .: "signatures"
+      <*> o .: "dependentRealisations"

--- a/cachix-api/src/Cachix/Types/Realisation.hs
+++ b/cachix-api/src/Cachix/Types/Realisation.hs
@@ -1,7 +1,7 @@
 module Cachix.Types.Realisation
-  ( Realisation (..),
-    splitDrvOutputId,
-    mkDrvOutputId,
+  ( DrvOutput (..),
+    UnkeyedRealisation (..),
+    Realisation (..),
   )
 where
 
@@ -14,58 +14,61 @@ import Data.Aeson
     (.=),
   )
 import Data.Swagger (ToSchema)
-import qualified Data.Text as T
 import Protolude
 
--- | A Nix realisation mapping a derivation output to its content-addressed store path.
+-- | A build-trace key: a derivation store path and one of its output names.
 --
--- JSON format matches what Nix expects at @realisations\/\<id\>.doi@:
---
--- @
--- { "id": "sha256:\<hash\>!\<outputName\>"
--- , "outPath": "\<storePathBaseName\>"
--- , "signatures": [...]
--- , "dependentRealisations": { "sha256:\<hash\>!\<out\>": "\<storePathBaseName\>", ... }
--- }
--- @
-data Realisation = Realisation
-  { -- | Derivation output id, e.g. "sha256:<hash>!<outputName>"
-    rId :: Text,
-    -- | Store path base name of the output
-    rOutPath :: Text,
-    -- | Signatures for this realisation
-    rSignatures :: [Text],
-    -- | Map from dependent derivation output ids to their store path base names
-    rDependentRealisations :: Map Text Text
+-- Matches Nix's @DrvOutput@ in the @build-trace-v2@ wire format. @drvPath@ is
+-- the basename of the derivation store path (e.g. @abc...-foo.drv@), not a hash.
+data DrvOutput = DrvOutput
+  { drvPath :: Text,
+    outputName :: Text
+  }
+  deriving (Eq, Ord, Show, Generic, NFData, ToSchema)
+
+-- | The body of a realisation: which store path this output resolved to, plus signatures.
+data UnkeyedRealisation = UnkeyedRealisation
+  { outPath :: Text,
+    signatures :: [Text]
   }
   deriving (Eq, Show, Generic, NFData, ToSchema)
 
--- | Split a derivation output id "sha256:<hash>!<outputName>" into (drvHash, outputName).
--- Returns Nothing if there is no "!" separator.
-splitDrvOutputId :: Text -> Maybe (Text, Text)
-splitDrvOutputId t =
-  case T.breakOn "!" t of
-    (_, rest) | T.null rest -> Nothing
-    (drvHash, rest) -> Just (drvHash, T.drop 1 rest)
+-- | A full realisation entry as served at
+-- @build-trace-v2\/\<drvName\>\/\<outputName\>.doi@.
+--
+-- JSON wire format:
+--
+-- @
+-- { "key":   { "drvPath": "abc...-foo.drv", "outputName": "out" }
+-- , "value": { "outPath": "xyz...-foo",      "signatures": ["..."] }
+-- }
+-- @
+data Realisation = Realisation
+  { key :: DrvOutput,
+    value :: UnkeyedRealisation
+  }
+  deriving (Eq, Show, Generic, NFData, ToSchema)
 
--- | Construct a derivation output id from drvHash and outputName.
-mkDrvOutputId :: Text -> Text -> Text
-mkDrvOutputId drvHash outputName = drvHash <> "!" <> outputName
+instance ToJSON DrvOutput where
+  toJSON DrvOutput {drvPath, outputName} =
+    object ["drvPath" .= drvPath, "outputName" .= outputName]
+
+instance FromJSON DrvOutput where
+  parseJSON = withObject "DrvOutput" $ \o ->
+    DrvOutput <$> o .: "drvPath" <*> o .: "outputName"
+
+instance ToJSON UnkeyedRealisation where
+  toJSON UnkeyedRealisation {outPath, signatures} =
+    object ["outPath" .= outPath, "signatures" .= signatures]
+
+instance FromJSON UnkeyedRealisation where
+  parseJSON = withObject "UnkeyedRealisation" $ \o ->
+    UnkeyedRealisation <$> o .: "outPath" <*> o .: "signatures"
 
 instance ToJSON Realisation where
-  toJSON Realisation {..} =
-    object
-      [ "id" .= rId,
-        "outPath" .= rOutPath,
-        "signatures" .= rSignatures,
-        "dependentRealisations" .= rDependentRealisations
-      ]
+  toJSON Realisation {key, value} =
+    object ["key" .= key, "value" .= value]
 
 instance FromJSON Realisation where
   parseJSON = withObject "Realisation" $ \o ->
-    Realisation
-      <$> o
-      .: "id"
-      <*> o .: "outPath"
-      <*> o .: "signatures"
-      <*> o .: "dependentRealisations"
+    Realisation <$> o .: "key" <*> o .: "value"

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -151,10 +151,9 @@ library
     , either
     , exceptions
     , extra
-    , filepath
+    , filepath                >=1.4.200
     , fsnotify                >=0.4.1
     , generic-lens
-    , hs-nix-c-api
     , here
     , hnix-store-core         >=0.8
     , hnix-store-nar
@@ -163,7 +162,6 @@ library
     , http-conduit
     , http-types
     , immortal
-    , directory
     , katip
     , lukko
     , lzma-conduit
@@ -172,6 +170,7 @@ library
     , microlens
     , netrc
     , network
+    , nix-bindings
     , nix-narinfo
     , optparse-applicative
     , pqueue
@@ -271,11 +270,11 @@ test-suite cachix-test
     , dhall
     , directory
     , extra
-    , filepath
-    , hs-nix-c-api
+    , filepath             >=1.4.200
     , here
     , hspec
     , katip
+    , nix-bindings
     , protolude
     , retry
     , servant-auth-client

--- a/cachix/cachix.cabal
+++ b/cachix/cachix.cabal
@@ -154,7 +154,7 @@ library
     , filepath
     , fsnotify                >=0.4.1
     , generic-lens
-    , hercules-ci-cnix-store  >=0.4
+    , hs-nix-c-api
     , here
     , hnix-store-core         >=0.8
     , hnix-store-nar
@@ -163,7 +163,7 @@ library
     , http-conduit
     , http-types
     , immortal
-    , inline-c-cpp
+    , directory
     , katip
     , lukko
     , lzma-conduit
@@ -206,8 +206,7 @@ library
     , websockets
     , wuss
 
-  -- These versions are pinned in hercules-ci-cnix-store
-  pkgconfig-depends: nix-store
+  pkgconfig-depends: nix-store-c
 
 executable cachix
   import:          defaults
@@ -273,7 +272,7 @@ test-suite cachix-test
     , directory
     , extra
     , filepath
-    , hercules-ci-cnix-store
+    , hs-nix-c-api
     , here
     , hspec
     , katip

--- a/cachix/cachix/Main.hs
+++ b/cachix/cachix/Main.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import Cachix.Client qualified as CC
-import Cachix.Client.CNix (handleCppExceptions)
+import Cachix.Client.CNix (handleNixExceptions)
 import Cachix.Client.Exception (CachixException)
 import Control.Exception.Safe (Handler (..), catches, displayException)
 import GHC.IO.Encoding
@@ -17,7 +17,7 @@ main = do
   handleExceptions CC.main
 
 handleExceptions :: IO () -> IO ()
-handleExceptions f = f `catches` [Handler handleCachixExceptions, Handler handleCppExceptions]
+handleExceptions f = f `catches` [Handler handleCachixExceptions, Handler handleNixExceptions]
 
 handleCachixExceptions :: CachixException -> IO ()
 handleCachixExceptions e = do

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -20,7 +20,7 @@ import Cachix.Daemon.Client qualified as Daemon.Client
 import Cachix.Deploy.ActivateCommand as ActivateCommand
 import Cachix.Deploy.Agent qualified as AgentCommand
 import Cachix.Deploy.OptionsParser qualified as DeployOptions
-import Hercules.CNix qualified as CNix
+import Nix.Unsafe.Init qualified as NixInit
 import Protolude
 import System.Console.AsciiProgress (displayConsoleRegions)
 import System.Posix.Signals qualified as Signal
@@ -74,7 +74,7 @@ initNixStore = do
   signalset <- Signal.getSignalMask
 
   -- Initialize the Nix library
-  CNix.init
+  NixInit.initNix
 
   -- darwin: restore the signal mask modified by Nix
   -- https://github.com/cachix/cachix/issues/501

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -20,7 +20,7 @@ import Cachix.Daemon.Client qualified as Daemon.Client
 import Cachix.Deploy.ActivateCommand as ActivateCommand
 import Cachix.Deploy.Agent qualified as AgentCommand
 import Cachix.Deploy.OptionsParser qualified as DeployOptions
-import Nix.Unsafe.Init qualified as NixInit
+import Nix.C.Unsafe.Init qualified as NixInit
 import Protolude
 import System.Console.AsciiProgress (displayConsoleRegions)
 import System.Posix.Signals qualified as Signal

--- a/cachix/src/Cachix/Client/CNix.hs
+++ b/cachix/src/Cachix/Client/CNix.hs
@@ -20,12 +20,13 @@ module Cachix.Client.CNix
   )
 where
 
-import Nix.Context (NixError (..))
-import Nix.Unsafe.Store (Store, StorePath)
-import Nix.Unsafe.Store qualified as Store
+import Nix.C.Context (NixError (..))
+import Nix.C.Unsafe.Store (Store, StorePath)
+import Nix.C.Unsafe.Store qualified as Store
 import Protolude
 import System.Console.Pretty (Color (..), Style (..), color, style)
 import System.Directory (canonicalizePath)
+import System.OsPath qualified as OsPath
 
 -- | Error when resolving a store path
 data StorePathError
@@ -49,7 +50,8 @@ resolveStorePath store fp = do
   where
     tryResolve = do
       resolved <- canonicalizePath fp
-      (Right <$> Store.parseStorePath' store (encodeUtf8 (toS resolved :: Text)))
+      osPath <- OsPath.encodeFS resolved
+      (Right <$> Store.parseStorePath' store osPath)
         `catchNixError` (pure . Left)
 
 -- | Resolve multiple file paths to validated store paths.
@@ -88,8 +90,8 @@ logStorePathWarning path err =
 -- Like 'logStorePathWarning' but for when you have a 'StorePath' instead of a 'FilePath'.
 logStorePathWarning' :: Store -> StorePath -> StorePathError -> IO ()
 logStorePathWarning' store storePath err = do
-  pathBytes <- Store.storeRealPath store storePath
-  let path = toS (decodeUtf8With lenientDecode pathBytes :: Text)
+  osPath <- Store.storeRealPath store storePath
+  path <- OsPath.decodeFS osPath
   logStorePathWarning path err
 
 -- | Validate that an existing store path is still valid in the Nix store.

--- a/cachix/src/Cachix/Client/CNix.hs
+++ b/cachix/src/Cachix/Client/CNix.hs
@@ -15,17 +15,17 @@ module Cachix.Client.CNix
     followLinksToStorePath,
 
     -- * Error handling
-    NixError (..),
     catchNixError,
-    handleCppExceptions,
+    handleNixExceptions,
   )
 where
 
-import Hercules.CNix.Store (Store, StorePath)
-import Hercules.CNix.Store qualified as Store
-import Language.C.Inline.Cpp.Exception
+import Nix.Context (NixError (..))
+import Nix.Unsafe.Store (Store, StorePath)
+import Nix.Unsafe.Store qualified as Store
 import Protolude
 import System.Console.Pretty (Color (..), Style (..), color, style)
+import System.Directory (canonicalizePath)
 
 -- | Error when resolving a store path
 data StorePathError
@@ -42,14 +42,14 @@ data StorePathError
 -- Follows symlinks and validates the resulting store path.
 resolveStorePath :: Store -> FilePath -> IO (Either StorePathError StorePath)
 resolveStorePath store fp = do
-  let pathBytes = encodeUtf8 (toS fp :: Text)
-  resolveResult <- tryResolve pathBytes
+  resolveResult <- tryResolve
   case resolveResult of
-    Left err -> pure $ Left (StorePathNotFound (msg err))
+    Left err -> pure $ Left (StorePathNotFound (nixErrorMsg err))
     Right storePath -> validateStorePath store storePath
   where
-    tryResolve pathBytes =
-      (Right <$> Store.followLinksToStorePath store pathBytes)
+    tryResolve = do
+      resolved <- canonicalizePath fp
+      (Right <$> Store.parseStorePath' store (encodeUtf8 (toS resolved :: Text)))
         `catchNixError` (pure . Left)
 
 -- | Resolve multiple file paths to validated store paths.
@@ -88,7 +88,7 @@ logStorePathWarning path err =
 -- Like 'logStorePathWarning' but for when you have a 'StorePath' instead of a 'FilePath'.
 logStorePathWarning' :: Store -> StorePath -> StorePathError -> IO ()
 logStorePathWarning' store storePath err = do
-  pathBytes <- Store.storePathToPath store storePath
+  pathBytes <- Store.storeRealPath store storePath
   let path = toS (decodeUtf8With lenientDecode pathBytes :: Text)
   logStorePathWarning path err
 
@@ -100,7 +100,7 @@ validateStorePath :: Store -> StorePath -> IO (Either StorePathError StorePath)
 validateStorePath store storePath = do
   result <- tryValidate
   case result of
-    Left err -> pure $ Left (StorePathError (msg err))
+    Left err -> pure $ Left (StorePathError (nixErrorMsg err))
     Right True -> pure $ Right storePath
     Right False -> pure $ Left StorePathNotValid
   where
@@ -130,61 +130,29 @@ filterInvalidStorePaths store =
 --
 -- Returns Nothing if the path is invalid.
 followLinksToStorePath :: Store -> ByteString -> IO (Maybe StorePath)
-followLinksToStorePath store storePath =
-  (Just <$> Store.followLinksToStorePath store storePath)
-    `catchNixError` \e -> do
-      logNixError storePath e
+followLinksToStorePath store storePathBS = do
+  let filePath = toS (decodeUtf8With lenientDecode storePathBS :: Text)
+  resolveStorePath store filePath >>= \case
+    Right sp -> return (Just sp)
+    Left err -> do
+      logStorePathWarning filePath err
       return Nothing
 
-data NixError = NixError
-  { typ :: Maybe Text,
-    msg :: Text
-  }
-  deriving (Show)
+-- | Extract a human-readable message from a NixError.
+nixErrorMsg :: NixError -> Text
+nixErrorMsg (NixCError _ msg _info) = decodeUtf8With lenientDecode msg
+nixErrorMsg (NixTypeMismatch expected actual) = "type mismatch: expected " <> show expected <> ", got " <> show actual
+nixErrorMsg (NixMissingAttr name) = "missing attribute: " <> decodeUtf8With lenientDecode name
+nixErrorMsg (NixIndexOutOfBounds idx) = "index out of bounds: " <> show idx
 
 -- | Capture and handle Nix errors
 catchNixError :: IO a -> (NixError -> IO a) -> IO a
 catchNixError f onError =
-  handleJust selectNixError onError f
-  where
-    selectNixError (CppStdException _eptr msg typ) =
-      Just $
-        NixError
-          { typ = decodeUtf8With lenientDecode <$> typ,
-            msg = decodeUtf8With lenientDecode msg
-          }
-    selectNixError _ = Nothing
+  f `catch` onError
 
--- | Pretty-print a Nix error.
---
--- There might not be a valid store path at this point.
-logNixError :: ByteString -> NixError -> IO ()
-logNixError storePath (NixError {..}) =
-  case typ of
-    Just "nix::BadStorePath" -> logBadPath storePath
-    _ -> putErrText $ color Red $ style Bold $ "Nix " <> msg
-
--- | Print a warning when the path is invalid.
---
--- There are two use-cases when this should be used:
--- 1. Converting a file path to a store path.
--- 2. Filtering out a store path that is not valid.
-logBadPath :: ByteString -> IO ()
-logBadPath path =
-  putErrText $ color Yellow $ "Warning: " <> decodeUtf8With lenientDecode path <> " is not valid, skipping"
-
--- | Pretty-print unhandled C++ exceptions from Nix.
-handleCppExceptions :: CppException -> IO ()
-handleCppExceptions e = do
+-- | Pretty-print unhandled Nix exceptions.
+handleNixExceptions :: NixError -> IO ()
+handleNixExceptions e = do
   putErrText ""
-
-  case e of
-    CppStdException _eptr msg _t ->
-      putErrText $ color Red $ style Bold $ "Nix " <> decodeUtf8With lenientDecode msg
-    CppNonStdException _eptr mmsg -> do
-      let msg = fromMaybe "unknown exception" mmsg
-      putErrText $ color Red $ style Bold $ "C++ exception: " <> decodeUtf8With lenientDecode msg
-    CppHaskellException he ->
-      putErrText $ color Red $ style Bold $ "Haskell exception: " <> toS (displayException he)
-
+  putErrText $ color Red $ style Bold $ "Nix error: " <> nixErrorMsg e
   exitFailure

--- a/cachix/src/Cachix/Client/Command/Import.hs
+++ b/cachix/src/Cachix/Client/Command/Import.hs
@@ -34,14 +34,15 @@ import Data.Conduit.ConcurrentMap (concurrentMapM_)
 import Data.Conduit.List qualified as CL
 import Data.Generics.Labels ()
 import Data.Text qualified as T
-import Nix.Unsafe.Store (parseStorePath')
 import Lens.Micro
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Types (status404)
+import Nix.C.Unsafe.Store (parseStorePath')
 import Nix.NarInfo qualified as NarInfo
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.API (NoContent (..))
+import System.OsPath qualified as OsPath
 import URI.ByteString qualified as UBS
 
 discoverAwsEnv :: Maybe ByteString -> Maybe ByteString -> IO Amazonka.Env
@@ -131,7 +132,8 @@ import' env pushOptions name s3uri = do
             narinfoResponse <- liftIO $ narinfoExists pushParams (toS storeHash)
             let storePathText = NarInfo.storePath narInfo
                 store = pushParamsStore pushParams
-            storePath <- liftIO $ parseStorePath' store (toS storePathText)
+            osPath <- liftIO $ OsPath.encodeFS (toS storePathText)
+            storePath <- liftIO $ parseStorePath' store osPath
             let strategy = pushParamsStrategy pushParams storePath
 
             case narinfoResponse of

--- a/cachix/src/Cachix/Client/Command/Import.hs
+++ b/cachix/src/Cachix/Client/Command/Import.hs
@@ -34,7 +34,7 @@ import Data.Conduit.ConcurrentMap (concurrentMapM_)
 import Data.Conduit.List qualified as CL
 import Data.Generics.Labels ()
 import Data.Text qualified as T
-import Hercules.CNix.Store (parseStorePath)
+import Nix.Unsafe.Store (parseStorePath')
 import Lens.Micro
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Types (status404)
@@ -130,7 +130,7 @@ import' env pushOptions name s3uri = do
             narinfoResponse <- liftIO $ narinfoExists pushParams (toS storeHash)
             let storePathText = NarInfo.storePath narInfo
                 store = pushParamsStore pushParams
-            storePath <- liftIO $ parseStorePath store (toS storePathText)
+            storePath <- liftIO $ parseStorePath' store (toS storePathText)
             let strategy = pushParamsStrategy pushParams storePath
 
             case narinfoResponse of

--- a/cachix/src/Cachix/Client/Command/Import.hs
+++ b/cachix/src/Cachix/Client/Command/Import.hs
@@ -74,19 +74,20 @@ import' env pushOptions name s3uri = do
   awsEnv <- discoverAwsEnv (URI.getQueryParam s3uri "endpoint") (URI.getQueryParam s3uri "region")
   putErrText $ "Importing narinfos/nars using " <> show (numJobs pushOptions) <> " workers from " <> URI.serialize s3uri <> " to " <> name
   putErrText ""
-  Amazonka.runResourceT $
-    runConduit $
-      Amazonka.paginate awsEnv (Amazonka.S3.newListObjectsV2 bucketName)
-        .| CL.mapMaybe (^. listObjectsV2Response_contents)
-        .| CL.concat
-        .| CL.map (^. object_key)
-        .| CL.filter (T.isSuffixOf ".narinfo" . Amazonka.Data.Text.toText)
+  withPushParams env pushOptions name $ \pushParams ->
+    Amazonka.runResourceT $
+      runConduit $
+        Amazonka.paginate awsEnv (Amazonka.S3.newListObjectsV2 bucketName)
+          .| CL.mapMaybe (^. listObjectsV2Response_contents)
+          .| CL.concat
+          .| CL.map (^. object_key)
+          .| CL.filter (T.isSuffixOf ".narinfo" . Amazonka.Data.Text.toText)
 #if MIN_VERSION_conduit_concurrent_map(0,1,4)
-        .| concurrentMapM (numJobs pushOptions) (numJobs pushOptions * 2) (uploadNarinfo awsEnv)
+          .| concurrentMapM (numJobs pushOptions) (numJobs pushOptions * 2) (uploadNarinfo awsEnv pushParams)
 #else
-        .| concurrentMapM_ (numJobs pushOptions) (numJobs pushOptions * 2) (uploadNarinfo awsEnv)
+          .| concurrentMapM_ (numJobs pushOptions) (numJobs pushOptions * 2) (uploadNarinfo awsEnv pushParams)
 #endif
-        .| CL.sinkNull
+          .| CL.sinkNull
   putErrText "All done."
   where
     bucketName :: Amazonka.S3.BucketName
@@ -107,8 +108,8 @@ import' env pushOptions name s3uri = do
       | "sha256:" `T.isPrefixOf` s = return $ T.drop 7 s
       | otherwise = throwM $ ImportUnsupportedHash $ "file hash " <> s <> " is unsupported. Leave us feedback at https://github.com/cachix/cachix/issues/601"
 
-    uploadNarinfo :: Amazonka.Env -> Amazonka.S3.ObjectKey -> ResourceT IO ()
-    uploadNarinfo awsEnv entry = liftIO $ do
+    uploadNarinfo :: Amazonka.Env -> PushParams IO () -> Amazonka.S3.ObjectKey -> ResourceT IO ()
+    uploadNarinfo awsEnv pushParams entry = liftIO $ do
       let storeHash = T.dropEnd 8 $ Amazonka.Data.Text.toText entry
 
       -- get narinfo
@@ -126,7 +127,7 @@ import' env pushOptions name s3uri = do
             return $ parsedNarInfo {NarInfo.fileHash = fileHash}
 
           -- stream nar and narinfo
-          liftIO $ withPushParams env pushOptions name $ \pushParams -> do
+          do
             narinfoResponse <- liftIO $ narinfoExists pushParams (toS storeHash)
             let storePathText = NarInfo.storePath narInfo
                 store = pushParamsStore pushParams

--- a/cachix/src/Cachix/Client/Command/Pin.hs
+++ b/cachix/src/Cachix/Client/Command/Pin.hs
@@ -11,7 +11,7 @@ import Cachix.Client.Retry (retryHttp)
 import Cachix.Client.Servant
 import Cachix.Types.PinCreate qualified as PinCreate
 import Data.Text qualified as T
-import Hercules.CNix.Store (storePathToPath, withStore)
+import Nix.Unsafe.Store (storeRealPath, withStore)
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Client.Streaming
@@ -20,13 +20,13 @@ import System.Directory (doesFileExist)
 pin :: Env -> PinOptions -> IO ()
 pin env pinOpts = do
   authToken <- Config.getAuthTokenRequired (config env)
-  storePath <- withStore $ \store -> do
+  storePath <- withStore "auto" $ \store -> do
     let filePath = toS (pinStorePath pinOpts)
     resolveStorePath store filePath >>= \case
       Left err -> do
         putErrText $ formatStorePathWarning filePath err
         exitFailure
-      Right sp -> storePathToPath store sp
+      Right sp -> storeRealPath store sp
   traverse_ (validateArtifact (toS storePath)) (pinArtifacts pinOpts)
   let pinCreate =
         PinCreate.PinCreate

--- a/cachix/src/Cachix/Client/Command/Pin.hs
+++ b/cachix/src/Cachix/Client/Command/Pin.hs
@@ -11,11 +11,12 @@ import Cachix.Client.Retry (retryHttp)
 import Cachix.Client.Servant
 import Cachix.Types.PinCreate qualified as PinCreate
 import Data.Text qualified as T
-import Nix.Unsafe.Store (storeRealPath, withStore)
+import Nix.C.Unsafe.Store (storeRealPath, withStore)
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Client.Streaming
 import System.Directory (doesFileExist)
+import System.OsPath qualified as OsPath
 
 pin :: Env -> PinOptions -> IO ()
 pin env pinOpts = do
@@ -26,7 +27,9 @@ pin env pinOpts = do
       Left err -> do
         putErrText $ formatStorePathWarning filePath err
         exitFailure
-      Right sp -> storeRealPath store sp
+      Right sp -> do
+        osPath <- storeRealPath store sp
+        OsPath.decodeFS osPath
   traverse_ (validateArtifact (toS storePath)) (pinArtifacts pinOpts)
   let pinCreate =
         PinCreate.PinCreate

--- a/cachix/src/Cachix/Client/Command/Push.hs
+++ b/cachix/src/Cachix/Client/Command/Push.hs
@@ -30,8 +30,7 @@ import Data.ByteString qualified as BS
 import Data.Conduit qualified as Conduit
 import Data.String.Here
 import Data.Text qualified as T
-import Hercules.CNix (StorePath)
-import Hercules.CNix.Store (Store, storePathToPath, withStore)
+import Nix.Unsafe.Store (Store, StorePath, storeRealPath, withStore)
 import Network.HTTP.Types (status401, status404)
 import Protolude hiding (toS)
 import Protolude.Conv
@@ -94,7 +93,7 @@ pushStrategy store authToken opts name compressionMethod storePath =
 
     showUploadProgress retryStatus size = do
       let hSize = toS $ humanSize $ fromIntegral size
-      path <- liftIO $ decodeUtf8With lenientDecode <$> storePathToPath store storePath
+      path <- liftIO $ decodeUtf8With lenientDecode <$> storeRealPath store storePath
 
       isTerminal <- liftIO $ hIsTerminalDevice stderr
       isCI <- liftIO $ (== Just "true") <$> lookupEnv "CI"
@@ -144,7 +143,7 @@ withPushParams' env pushOpts name pushSecret m = do
   let compressionMethod =
         fromMaybe BinaryCache.ZSTD (head $ catMaybes [Options.compressionMethod pushOpts, compressionMethodBackend])
 
-  withStore $ \store ->
+  withStore "auto" $ \store ->
     m
       PushParams
         { pushParamsName = name,

--- a/cachix/src/Cachix/Client/Command/Push.hs
+++ b/cachix/src/Cachix/Client/Command/Push.hs
@@ -30,8 +30,8 @@ import Data.ByteString qualified as BS
 import Data.Conduit qualified as Conduit
 import Data.String.Here
 import Data.Text qualified as T
-import Nix.Unsafe.Store (Store, StorePath, storeRealPath, withStore)
 import Network.HTTP.Types (status401, status404)
+import Nix.C.Unsafe.Store (Store, StorePath, storeRealPath, withStore)
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Auth ()
@@ -42,6 +42,7 @@ import System.Console.AsciiProgress
 import System.Console.Pretty
 import System.Environment (lookupEnv)
 import System.IO (hIsTerminalDevice)
+import System.OsPath qualified as OsPath
 
 push :: Env -> PushOptions -> BinaryCacheName -> [Text] -> IO ()
 push env opts name cliPaths = do
@@ -93,7 +94,7 @@ pushStrategy store authToken opts name compressionMethod storePath =
 
     showUploadProgress retryStatus size = do
       let hSize = toS $ humanSize $ fromIntegral size
-      path <- liftIO $ decodeUtf8With lenientDecode <$> storeRealPath store storePath
+      path <- liftIO $ toS <$> (OsPath.decodeFS =<< storeRealPath store storePath)
 
       isTerminal <- liftIO $ hIsTerminalDevice stderr
       isCI <- liftIO $ (== Just "true") <$> lookupEnv "CI"

--- a/cachix/src/Cachix/Client/Command/Watch.hs
+++ b/cachix/src/Cachix/Client/Command/Watch.hs
@@ -31,7 +31,7 @@ import Data.Conduit.TMChan qualified as C
 import Data.Generics.Labels ()
 import Data.Text.IO (hGetLine)
 import GHC.IO.Handle (hDuplicate, hDuplicateTo)
-import Nix.Unsafe.Store (withStore)
+import Nix.C.Unsafe.Store (withStore)
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Conduit ()

--- a/cachix/src/Cachix/Client/Command/Watch.hs
+++ b/cachix/src/Cachix/Client/Command/Watch.hs
@@ -31,7 +31,7 @@ import Data.Conduit.TMChan qualified as C
 import Data.Generics.Labels ()
 import Data.Text.IO (hGetLine)
 import GHC.IO.Handle (hDuplicate, hDuplicateTo)
-import Hercules.CNix.Store (withStore)
+import Nix.Unsafe.Store (withStore)
 import Protolude hiding (toS)
 import Protolude.Conv
 import Servant.Conduit ()
@@ -78,7 +78,7 @@ watchExecDaemon env pushOpts batchOptions cacheName cmd args = do
   envSocketPath <- lookupEnv "CACHIX_DAEMON_SOCKET"
   Daemon.PostBuildHook.withSetup envSocketPath $ \hookEnv ->
     withTempFile (Daemon.PostBuildHook.tempDir hookEnv) "daemon-log-capture" $ \_ logHandle ->
-      withStore $ \store -> do
+      withStore "auto" $ \store -> do
         let daemonOptions =
               DaemonOptions
                 { daemonAllowRemoteStop = False,

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -74,6 +74,8 @@ import Data.Set qualified as Set
 import Data.String.Here (iTrim)
 import Data.Text qualified as T
 import Network.HTTP.Types (status401, status404)
+import Nix.C.Hash qualified as NixHash
+import Nix.C.Hash.Nix32 qualified as Nix32
 import Nix.C.Store.PathInfo qualified as NixPathInfo
 import Nix.C.Unsafe.Store (Store, StorePath)
 import Nix.C.Unsafe.Store qualified as Store
@@ -85,7 +87,6 @@ import Servant.Auth ()
 import Servant.Auth.Client
 import Servant.Client.Streaming
 import Servant.Conduit ()
-import System.Nix.Base32 qualified
 import System.Nix.Nar
 import System.OsPath qualified as OsPath
 
@@ -174,7 +175,7 @@ pushSingleStorePath ::
   -- | r is determined by the 'PushStrategy'
   m r
 pushSingleStorePath pushParams storePath = retryAll $ \retrystatus -> do
-  storeHash <- liftIO $ encodeUtf8 . System.Nix.Base32.encode <$> Store.storePathHash storePath
+  storeHash <- liftIO $ encodeUtf8 . Nix32.encode <$> Store.storePathHash storePath
   let strategy = pushParamsStrategy pushParams storePath
   res <- liftIO $ narinfoExists pushParams storeHash
   case res of
@@ -302,19 +303,28 @@ newPathInfoFromStorePath :: (MonadIO m) => Store -> StorePath -> m PathInfo
 newPathInfoFromStorePath store storePath = liftIO $ do
   osPath <- Store.storeRealPath store storePath
   path <- OsPath.decodeFS osPath
-  info <- Store.queryPathInfoJson store storePath NixPathInfo.PathInfoJsonFormatV2
+  info <- Store.queryPathInfo store storePath
 
-  let NixPathInfo.Hash algo digest = NixPathInfo.pathInfoNarHash info
-      narHash = NixPathInfo.hashAlgoText algo <> ":" <> System.Nix.Base32.encode digest
+  let narHash = NixHash.hashToNix32 (NixPathInfo.pathInfoNarHash info)
       narSize = fromIntegral $ NixPathInfo.pathInfoNarSize info
+
+  let getStorePathBaseName =
+        (OsPath.decodeFS . OsPath.takeFileName)
+          <=< Store.storeRealPath store
+
+  -- Convert StorePath references to basenames
+  refPaths <- for (NixPathInfo.pathInfoReferences info) getStorePathBaseName
+
+  -- Convert deriver StorePath to basename
+  deriver <- for (NixPathInfo.pathInfoDeriver info) (fmap toS . getStorePathBaseName)
 
   return $
     PathInfo
       { piPath = path,
         piNarHash = narHash,
         piNarSize = narSize,
-        piDeriver = NixPathInfo.pathInfoDeriver info,
-        piReferences = Set.fromList (fmap toS (NixPathInfo.pathInfoReferences info))
+        piDeriver = deriver,
+        piReferences = Set.fromList refPaths
       }
 
 -- | Create a 'PathInfo' for a store path from an existing NarInfo.
@@ -371,7 +381,7 @@ streamUploadNar pushParams storePath storePathSize retrystatus = do
 
   for result $ \uploadResult -> liftIO $ do
     narSize <- readIORef narSizeRef
-    narHash <- ("sha256:" <>) . System.Nix.Base32.encode <$> readIORef narHashRef
+    narHash <- ("sha256:" <>) . Nix32.encode <$> readIORef narHashRef
     fileSize <- readIORef fileSizeRef
     fileHash <- readIORef fileHashRef
 
@@ -515,7 +525,7 @@ queryNarInfoBulk pushParams paths = do
 
   pathsAndHashes <- liftIO $
     for paths $ \path -> do
-      hash' <- System.Nix.Base32.encode <$> Store.storePathHash path
+      hash' <- Nix32.encode <$> Store.storePathHash path
       pure (hash', path)
   let hashes = fmap fst pathsAndHashes
   let processBatch hashesChunk = retryHttp $ liftIO $ do

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -302,9 +302,8 @@ newPathInfoFromStorePath store storePath = liftIO $ do
   path <- Store.storeRealPath store storePath
   info <- Store.queryPathInfoJson store storePath NixPathInfo.PathInfoJsonFormatV2
 
-  let narHash = case NixPathInfo.pathInfoNarHash info of
-        NixPathInfo.HashStructured algo val -> hashAlgoText algo <> ":" <> val
-        NixPathInfo.HashSRI t -> t
+  let NixPathInfo.Hash algo digest = NixPathInfo.pathInfoNarHash info
+      narHash = NixPathInfo.hashAlgoText algo <> ":" <> System.Nix.Base32.encode digest
       narSize = fromIntegral $ NixPathInfo.pathInfoNarSize info
 
   return $
@@ -315,14 +314,6 @@ newPathInfoFromStorePath store storePath = liftIO $ do
         piDeriver = NixPathInfo.pathInfoDeriver info,
         piReferences = Set.fromList (fmap toS (NixPathInfo.pathInfoReferences info))
       }
-
-hashAlgoText :: NixPathInfo.HashAlgo -> Text
-hashAlgoText NixPathInfo.MD5 = "md5"
-hashAlgoText NixPathInfo.SHA1 = "sha1"
-hashAlgoText NixPathInfo.SHA256 = "sha256"
-hashAlgoText NixPathInfo.SHA512 = "sha512"
-hashAlgoText NixPathInfo.BLAKE3 = "blake3"
-hashAlgoText (NixPathInfo.HashAlgoUnknown t) = t
 
 -- | Create a 'PathInfo' for a store path from an existing NarInfo.
 newPathInfoFromNarInfo :: (Applicative m) => NarInfo.SimpleNarInfo -> m PathInfo

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -73,10 +73,9 @@ import Data.List.Extra (chunksOf)
 import Data.Set qualified as Set
 import Data.String.Here (iTrim)
 import Data.Text qualified as T
-import Hercules.CNix (StorePath)
-import Hercules.CNix.Std.Set qualified as Std.Set
-import Hercules.CNix.Store (Store)
-import Hercules.CNix.Store qualified as Store
+import Nix.Unsafe.Store (Store, StorePath)
+import Nix.Unsafe.Store qualified as Store
+import Nix.Store.PathInfo qualified as NixPathInfo
 import Network.HTTP.Types (status401, status404)
 import Nix.NarInfo qualified as NarInfo
 import Protolude hiding (toS)
@@ -174,7 +173,7 @@ pushSingleStorePath ::
   -- | r is determined by the 'PushStrategy'
   m r
 pushSingleStorePath pushParams storePath = retryAll $ \retrystatus -> do
-  storeHash <- liftIO $ Store.getStorePathHash storePath
+  storeHash <- liftIO $ encodeUtf8 . System.Nix.Base32.encode <$> Store.storePathHash storePath
   let strategy = pushParamsStrategy pushParams storePath
   res <- liftIO $ narinfoExists pushParams storeHash
   case res of
@@ -212,7 +211,7 @@ uploadStorePath pushParams storePath retrystatus = do
   let store = pushParamsStore pushParams
       strategy = pushParamsStrategy pushParams storePath
 
-  storePathText <- liftIO $ Store.storePathToPath store storePath
+  storePathText <- liftIO $ Store.storeRealPath store storePath
   let path = toS storePathText
 
   -- Validate the path is still valid (may have been GC'd since queued)
@@ -300,26 +299,30 @@ data PathInfo = PathInfo
 -- | Create a 'PathInfo' for a store path by querying the Nix store.
 newPathInfoFromStorePath :: (MonadIO m) => Store -> StorePath -> m PathInfo
 newPathInfoFromStorePath store storePath = liftIO $ do
-  pathInfo <- Store.queryPathInfo store storePath
+  path <- Store.storeRealPath store storePath
+  info <- Store.queryPathInfoJson store storePath NixPathInfo.PathInfoJsonFormatV2
 
-  path <- Store.storePathToPath store storePath
-  narHash <- Store.validPathInfoNarHash32 pathInfo
-  let narSize = fromIntegral $ Store.validPathInfoNarSize pathInfo
-  deriver <-
-    Store.validPathInfoDeriver store pathInfo
-      >>= mapM Store.getStorePathBaseName
-  references <-
-    Store.validPathInfoReferences store pathInfo
-      >>= mapM Store.getStorePathBaseName
+  let narHash = case NixPathInfo.pathInfoNarHash info of
+        NixPathInfo.HashStructured algo val -> hashAlgoText algo <> ":" <> val
+        NixPathInfo.HashSRI t -> t
+      narSize = fromIntegral $ NixPathInfo.pathInfoNarSize info
 
   return $
     PathInfo
       { piPath = toS path,
-        piNarHash = decodeUtf8 narHash,
+        piNarHash = narHash,
         piNarSize = narSize,
-        piDeriver = fmap toS deriver,
-        piReferences = Set.fromList (fmap toS references)
+        piDeriver = NixPathInfo.pathInfoDeriver info,
+        piReferences = Set.fromList (fmap toS (NixPathInfo.pathInfoReferences info))
       }
+
+hashAlgoText :: NixPathInfo.HashAlgo -> Text
+hashAlgoText NixPathInfo.MD5 = "md5"
+hashAlgoText NixPathInfo.SHA1 = "sha1"
+hashAlgoText NixPathInfo.SHA256 = "sha256"
+hashAlgoText NixPathInfo.SHA512 = "sha512"
+hashAlgoText NixPathInfo.BLAKE3 = "blake3"
+hashAlgoText (NixPathInfo.HashAlgoUnknown t) = t
 
 -- | Create a 'PathInfo' for a store path from an existing NarInfo.
 newPathInfoFromNarInfo :: (Applicative m) => NarInfo.SimpleNarInfo -> m PathInfo
@@ -447,8 +450,8 @@ newNarInfoCreate ::
 newNarInfoCreate pushParams storePath pathInfo UploadNarDetails {..} = do
   let store = pushParamsStore pushParams
   let strategy = pushParamsStrategy pushParams storePath
-  storeDir <- Store.storeDir store
-  storePathText <- liftIO $ toS <$> Store.storePathToPath store storePath
+  storeDir <- liftIO $ Store.storeDir store
+  storePathText <- liftIO $ toS <$> Store.storeRealPath store storePath
 
   when (undNarHash /= piNarHash pathInfo) $
     throwM $
@@ -508,9 +511,8 @@ getMissingPathsForClosure pushParams inputPaths = do
 computeClosure :: (MonadIO m) => Store -> [StorePath] -> m [StorePath]
 computeClosure store inputPaths =
   liftIO $ do
-    inputSet <- Std.Set.fromListFP inputPaths
-    closure <- Store.computeFSClosure store Store.defaultClosureParams inputSet
-    Std.Set.toListFP closure
+    closureLists <- mapM (Store.computeFSClosure store) inputPaths
+    pure $ Set.toList $ Set.fromList $ concat closureLists
 
 queryNarInfoBulk :: (MonadIO m, MonadMask m) => PushParams n r -> [StorePath] -> m ([StorePath], [StorePath])
 queryNarInfoBulk pushParams paths = do
@@ -518,7 +520,7 @@ queryNarInfoBulk pushParams paths = do
 
   pathsAndHashes <- liftIO $
     for paths $ \path -> do
-      hash' <- decodeUtf8With lenientDecode <$> Store.getStorePathHash path
+      hash' <- System.Nix.Base32.encode <$> Store.storePathHash path
       pure (hash', path)
   let hashes = fmap fst pathsAndHashes
   let processBatch hashesChunk = retryHttp $ liftIO $ do

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -73,10 +73,10 @@ import Data.List.Extra (chunksOf)
 import Data.Set qualified as Set
 import Data.String.Here (iTrim)
 import Data.Text qualified as T
-import Nix.Unsafe.Store (Store, StorePath)
-import Nix.Unsafe.Store qualified as Store
-import Nix.Store.PathInfo qualified as NixPathInfo
 import Network.HTTP.Types (status401, status404)
+import Nix.C.Store.PathInfo qualified as NixPathInfo
+import Nix.C.Unsafe.Store (Store, StorePath)
+import Nix.C.Unsafe.Store qualified as Store
 import Nix.NarInfo qualified as NarInfo
 import Protolude hiding (toS)
 import Protolude.Conv
@@ -87,6 +87,7 @@ import Servant.Client.Streaming
 import Servant.Conduit ()
 import System.Nix.Base32 qualified
 import System.Nix.Nar
+import System.OsPath qualified as OsPath
 
 -- | A secret for authenticating with a cache.
 data PushSecret
@@ -211,8 +212,8 @@ uploadStorePath pushParams storePath retrystatus = do
   let store = pushParamsStore pushParams
       strategy = pushParamsStrategy pushParams storePath
 
-  storePathText <- liftIO $ Store.storeRealPath store storePath
-  let path = toS storePathText
+  storePathOS <- liftIO $ Store.storeRealPath store storePath
+  path <- liftIO $ OsPath.decodeFS storePathOS
 
   -- Validate the path is still valid (may have been GC'd since queued)
   liftIO (validateStorePath store storePath) >>= \case
@@ -225,7 +226,7 @@ uploadStorePath pushParams storePath retrystatus = do
 
   eresult <-
     runConduitRes $
-      streamNarIO narEffectsIO (toS storePathText) Data.Conduit.yield
+      streamNarIO narEffectsIO path Data.Conduit.yield
         .| streamUploadNar pushParams storePath narSize retrystatus
 
   case eresult of
@@ -299,7 +300,8 @@ data PathInfo = PathInfo
 -- | Create a 'PathInfo' for a store path by querying the Nix store.
 newPathInfoFromStorePath :: (MonadIO m) => Store -> StorePath -> m PathInfo
 newPathInfoFromStorePath store storePath = liftIO $ do
-  path <- Store.storeRealPath store storePath
+  osPath <- Store.storeRealPath store storePath
+  path <- OsPath.decodeFS osPath
   info <- Store.queryPathInfoJson store storePath NixPathInfo.PathInfoJsonFormatV2
 
   let NixPathInfo.Hash algo digest = NixPathInfo.pathInfoNarHash info
@@ -308,7 +310,7 @@ newPathInfoFromStorePath store storePath = liftIO $ do
 
   return $
     PathInfo
-      { piPath = toS path,
+      { piPath = path,
         piNarHash = narHash,
         piNarSize = narSize,
         piDeriver = NixPathInfo.pathInfoDeriver info,
@@ -441,8 +443,10 @@ newNarInfoCreate ::
 newNarInfoCreate pushParams storePath pathInfo UploadNarDetails {..} = do
   let store = pushParamsStore pushParams
   let strategy = pushParamsStrategy pushParams storePath
-  storeDir <- liftIO $ Store.storeDir store
-  storePathText <- liftIO $ toS <$> Store.storeRealPath store storePath
+  storeDirOS <- liftIO $ Store.storeDir store
+  storeDir <- liftIO $ OsPath.decodeFS storeDirOS
+  storePathOS <- liftIO $ Store.storeRealPath store storePath
+  storePathText <- liftIO $ toS <$> OsPath.decodeFS storePathOS
 
   when (undNarHash /= piNarHash pathInfo) $
     throwM $

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -71,7 +71,6 @@ import Data.Conduit.Lzma qualified as Lzma (compress)
 import Data.Conduit.Zstd qualified as Zstd (compress)
 import Data.IORef
 import Data.List.Extra (chunksOf)
-import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.String.Here (iTrim)
 import Data.Text qualified as T
@@ -239,7 +238,7 @@ uploadStorePath pushParams storePath retrystatus = do
     Right (uploadResult, uploadNarDetails) -> do
       nic <- newNarInfoCreate pushParams storePath pathInfo uploadNarDetails
       completeNarUpload pushParams uploadResult nic
-      pushRealisations pushParams pathInfo
+      pushBuildTraces pushParams pathInfo
       onDone strategy
 
 -- | Push an entire closure
@@ -283,18 +282,18 @@ completeNarUpload pushParams Push.S3.UploadMultipartResult {..} nic = do
 
   liftIO $ void $ retryHttp $ withClientM completeMultipartUploadRequest clientEnv escalate
 
--- | Push realisations for content-addressed paths.
+-- | Push build traces for content-addressed paths.
 -- This is a no-op for non-CA paths (when 'piCa' is Nothing) or when
 -- the deriver is unavailable. Walks the derivation graph via the
 -- C API: for each output of the deriver and each output of each
 -- (statically-known) input derivation, query the local store for a
 -- realisation and push the collected list in one batch.
-pushRealisations ::
+pushBuildTraces ::
   (MonadUnliftIO m) =>
   PushParams n r ->
   PathInfo ->
   m ()
-pushRealisations pushParams pathInfo =
+pushBuildTraces pushParams pathInfo =
   case (piCa pathInfo, piDeriver pathInfo) of
     (Just _, Just deriver) | deriver /= unknownDeriver -> liftIO $ do
       let store = pushParamsStore pushParams
@@ -311,23 +310,21 @@ pushRealisations pushParams pathInfo =
         Right drvSp -> do
           visitedDrvsRef <- newIORef Set.empty
           visitedIdsRef <- newIORef Set.empty
-          realisations <- collectRealisations visitedDrvsRef visitedIdsRef store drvSp
-          unless (null realisations) $ do
-            let request = API.putRealisations cachixClient authToken cacheName realisations
+          buildTraces <- collectBuildTraces visitedDrvsRef visitedIdsRef store drvSp
+          unless (null buildTraces) $ do
+            let request = API.putBuildTraces cachixClient authToken cacheName buildTraces
             void $ retryHttp $ withClientM request clientEnv escalate
     _ -> pure ()
 
 -- | Walk the derivation input graph collecting any locally-recorded
--- realisations. Each drv is parsed once (cycle detection). We do not
--- populate 'rDependentRealisations'; the server tracks the graph
--- separately when each path is pushed.
-collectRealisations ::
+-- realisations. Each drv is parsed once (cycle detection).
+collectBuildTraces ::
   IORef (Set FilePath) -> -- visited drv full paths
   IORef (Set ByteString) -> -- visited drv_output_ids
   Store ->
   StorePath ->
   IO [Realisation.Realisation]
-collectRealisations visitedDrvsRef visitedIdsRef store drvSp = do
+collectBuildTraces visitedDrvsRef visitedIdsRef store drvSp = do
   drvFP <- OsPath.decodeFS =<< Store.storeRealPath store drvSp
   alreadySeen <- Set.member drvFP <$> readIORef visitedDrvsRef
   if alreadySeen
@@ -347,7 +344,7 @@ collectRealisations visitedDrvsRef visitedIdsRef store drvSp = do
                 modifyIORef' visitedIdsRef (Set.insert drvOutputId)
                 NixRealisation.queryRealisation store drvOutputId >>= \case
                   Nothing -> pure Nothing
-                  Just r -> Just <$> mkRealisation store drvOutputId r
+                  Just r -> Just <$> mkBuildTrace store drvOutputId r
           -- Recurse into static input derivations. Dynamic inputs are
           -- not surfaced by the C API, so we skip the input walk for
           -- those cases (the realisations of statically-resolvable
@@ -365,26 +362,39 @@ collectRealisations visitedDrvsRef visitedIdsRef store drvSp = do
                   case inputSpE of
                     Left (_ :: SomeException) -> pure []
                     Right inputSp ->
-                      collectRealisations visitedDrvsRef visitedIdsRef store inputSp
+                      collectBuildTraces visitedDrvsRef visitedIdsRef store inputSp
           pure (here ++ deps)
   where
-    mkRealisation ::
+    -- \| The C binding emits ids of the form @\<storeDir\>/\<drvName\>^\<outputName\>@.
+    -- Split on the last @^@ then take the basename of the LHS to get @\<drvName\>@.
+    mkBuildTrace ::
       Store ->
       ByteString ->
       NixRealisation.Realisation ->
       IO Realisation.Realisation
-    mkRealisation s drvOutputId r = do
+    mkBuildTrace s drvOutputId r = do
       outSp <- NixRealisation.realisationOutPath r
       outBaseFP <-
         OsPath.decodeFS . OsPath.takeFileName =<< Store.storeRealPath s outSp
       sigs <- NixRealisation.realisationSignatures r
       let decode = decodeUtf8With lenientDecode
+          (drvFullPathT, outputNameT) =
+            case T.breakOnEnd "^" (decode drvOutputId) of
+              (left, right) | not (T.null left) -> (T.dropEnd 1 left, right)
+              _ -> ("", "")
+          drvNameT = T.takeWhileEnd (/= '/') drvFullPathT
       pure
         Realisation.Realisation
-          { Realisation.rId = decode drvOutputId,
-            Realisation.rOutPath = T.pack outBaseFP,
-            Realisation.rSignatures = fmap decode sigs,
-            Realisation.rDependentRealisations = mempty
+          { Realisation.key =
+              Realisation.DrvOutput
+                { Realisation.drvPath = drvNameT,
+                  Realisation.outputName = outputNameT
+                },
+            Realisation.value =
+              Realisation.UnkeyedRealisation
+                { Realisation.outPath = T.pack outBaseFP,
+                  Realisation.signatures = fmap decode sigs
+                }
           }
 
 unknownDeriver :: Text

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -76,10 +76,9 @@ import Data.Set qualified as Set
 import Data.String.Here (iTrim)
 import Data.Text qualified as T
 import Network.HTTP.Types (status401, status404)
-import Nix.C.Hash qualified as NixHash
 import Nix.C.Hash.Nix32 qualified as Nix32
 import Nix.C.Store.Derivation qualified as NixDrv
-import Nix.C.Store.PathInfo (ContentAddress (..))
+import Nix.C.Store.PathInfo (ContentAddress (..), PathInfoJsonFormat (..))
 import Nix.C.Store.PathInfo qualified as NixPathInfo
 import Nix.C.Store.Realisation qualified as NixRealisation
 import Nix.C.Unsafe.Store (Derivation, Store, StorePath)
@@ -368,25 +367,25 @@ collectRealisations visitedDrvsRef visitedIdsRef store drvSp = do
                     Right inputSp ->
                       collectRealisations visitedDrvsRef visitedIdsRef store inputSp
           pure (here ++ deps)
- where
-  mkRealisation
-    :: Store
-    -> ByteString
-    -> NixRealisation.Realisation
-    -> IO Realisation.Realisation
-  mkRealisation s drvOutputId r = do
-    outSp <- NixRealisation.realisationOutPath r
-    outBaseFP <-
-      OsPath.decodeFS . OsPath.takeFileName =<< Store.storeRealPath s outSp
-    sigs <- NixRealisation.realisationSignatures r
-    let decode = decodeUtf8With lenientDecode
-    pure
-      Realisation.Realisation
-        { Realisation.rId = decode drvOutputId,
-          Realisation.rOutPath = T.pack outBaseFP,
-          Realisation.rSignatures = fmap decode sigs,
-          Realisation.rDependentRealisations = mempty
-        }
+  where
+    mkRealisation ::
+      Store ->
+      ByteString ->
+      NixRealisation.Realisation ->
+      IO Realisation.Realisation
+    mkRealisation s drvOutputId r = do
+      outSp <- NixRealisation.realisationOutPath r
+      outBaseFP <-
+        OsPath.decodeFS . OsPath.takeFileName =<< Store.storeRealPath s outSp
+      sigs <- NixRealisation.realisationSignatures r
+      let decode = decodeUtf8With lenientDecode
+      pure
+        Realisation.Realisation
+          { Realisation.rId = decode drvOutputId,
+            Realisation.rOutPath = T.pack outBaseFP,
+            Realisation.rSignatures = fmap decode sigs,
+            Realisation.rDependentRealisations = mempty
+          }
 
 unknownDeriver :: Text
 unknownDeriver = "unknown-deriver"
@@ -425,21 +424,14 @@ newPathInfoFromStorePath :: (MonadIO m) => Store -> StorePath -> m PathInfo
 newPathInfoFromStorePath store storePath = liftIO $ do
   osPath <- Store.storeRealPath store storePath
   path <- OsPath.decodeFS osPath
-  info <- Store.queryPathInfo store storePath
+  -- V3 returns basenames for references and deriver, which is what we want.
+  info <- Store.queryPathInfoJson store storePath PathInfoJsonFormatV3
 
-  let narHash = NixHash.hashToNix32 (NixPathInfo.pathInfoNarHash info)
+  let narHash = NixPathInfo.hashToNix32 (NixPathInfo.pathInfoNarHash info)
       narSize = fromIntegral $ NixPathInfo.pathInfoNarSize info
       ca = caToText <$> NixPathInfo.pathInfoCa info
-
-  let getStorePathBaseName =
-        (OsPath.decodeFS . OsPath.takeFileName)
-          <=< Store.storeRealPath store
-
-  -- Convert StorePath references to basenames
-  refPaths <- for (NixPathInfo.pathInfoReferences info) getStorePathBaseName
-
-  -- Convert deriver StorePath to basename
-  deriver <- for (NixPathInfo.pathInfoDeriver info) (fmap toS . getStorePathBaseName)
+      refPaths = fmap (toS :: Text -> FilePath) (NixPathInfo.pathInfoReferences info)
+      deriver = NixPathInfo.pathInfoDeriver info
 
   return $
     PathInfo

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -56,6 +56,7 @@ import Cachix.Types.BinaryCache qualified as BinaryCache
 import Cachix.Types.MultipartUpload qualified as Multipart
 import Cachix.Types.NarInfoCreate qualified as Api
 import Cachix.Types.NarInfoHash qualified as NarInfoHash
+import Cachix.Types.Realisation qualified as Realisation
 import Conduit (MonadUnliftIO)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.QSem qualified as QSem
@@ -70,14 +71,18 @@ import Data.Conduit.Lzma qualified as Lzma (compress)
 import Data.Conduit.Zstd qualified as Zstd (compress)
 import Data.IORef
 import Data.List.Extra (chunksOf)
+import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.String.Here (iTrim)
 import Data.Text qualified as T
 import Network.HTTP.Types (status401, status404)
 import Nix.C.Hash qualified as NixHash
 import Nix.C.Hash.Nix32 qualified as Nix32
+import Nix.C.Store.Derivation qualified as NixDrv
+import Nix.C.Store.PathInfo (ContentAddress (..))
 import Nix.C.Store.PathInfo qualified as NixPathInfo
-import Nix.C.Unsafe.Store (Store, StorePath)
+import Nix.C.Store.Realisation qualified as NixRealisation
+import Nix.C.Unsafe.Store (Derivation, Store, StorePath)
 import Nix.C.Unsafe.Store qualified as Store
 import Nix.NarInfo qualified as NarInfo
 import Protolude hiding (toS)
@@ -235,6 +240,7 @@ uploadStorePath pushParams storePath retrystatus = do
     Right (uploadResult, uploadNarDetails) -> do
       nic <- newNarInfoCreate pushParams storePath pathInfo uploadNarDetails
       completeNarUpload pushParams uploadResult nic
+      pushRealisations pushParams pathInfo
       onDone strategy
 
 -- | Push an entire closure
@@ -278,6 +284,121 @@ completeNarUpload pushParams Push.S3.UploadMultipartResult {..} nic = do
 
   liftIO $ void $ retryHttp $ withClientM completeMultipartUploadRequest clientEnv escalate
 
+-- | Push realisations for content-addressed paths.
+-- This is a no-op for non-CA paths (when 'piCa' is Nothing) or when
+-- the deriver is unavailable. Walks the derivation graph via the
+-- C API: for each output of the deriver and each output of each
+-- (statically-known) input derivation, query the local store for a
+-- realisation and push the collected list in one batch.
+pushRealisations ::
+  (MonadUnliftIO m) =>
+  PushParams n r ->
+  PathInfo ->
+  m ()
+pushRealisations pushParams pathInfo =
+  case (piCa pathInfo, piDeriver pathInfo) of
+    (Just _, Just deriver) | deriver /= unknownDeriver -> liftIO $ do
+      let store = pushParamsStore pushParams
+          cacheName = pushParamsName pushParams
+          authToken = getCacheAuthToken (pushParamsSecret pushParams)
+          clientEnv = pushParamsClientEnv pushParams
+      -- Build the full drv store path from store-dir + deriver basename.
+      storeDirFP <- OsPath.decodeFS =<< Store.storeDir store
+      let drvFullFP = storeDirFP <> "/" <> toS deriver
+      drvFullOs <- OsPath.encodeFS drvFullFP
+      eDrvSp <- try (Store.parseStorePath' store drvFullOs)
+      case eDrvSp of
+        Left (_ :: SomeException) -> pure () -- drv missing or unparseable
+        Right drvSp -> do
+          visitedDrvsRef <- newIORef Set.empty
+          visitedIdsRef <- newIORef Set.empty
+          realisations <- collectRealisations visitedDrvsRef visitedIdsRef store drvSp
+          unless (null realisations) $ do
+            let request = API.putRealisations cachixClient authToken cacheName realisations
+            void $ retryHttp $ withClientM request clientEnv escalate
+    _ -> pure ()
+
+-- | Walk the derivation input graph collecting any locally-recorded
+-- realisations. Each drv is parsed once (cycle detection). We do not
+-- populate 'rDependentRealisations'; the server tracks the graph
+-- separately when each path is pushed.
+collectRealisations ::
+  IORef (Set FilePath) -> -- visited drv full paths
+  IORef (Set ByteString) -> -- visited drv_output_ids
+  Store ->
+  StorePath ->
+  IO [Realisation.Realisation]
+collectRealisations visitedDrvsRef visitedIdsRef store drvSp = do
+  drvFP <- OsPath.decodeFS =<< Store.storeRealPath store drvSp
+  alreadySeen <- Set.member drvFP <$> readIORef visitedDrvsRef
+  if alreadySeen
+    then pure []
+    else do
+      modifyIORef' visitedDrvsRef (Set.insert drvFP)
+      eDrv <- try (Store.drvFromStorePath store drvSp)
+      case eDrv of
+        Left (_ :: SomeException) -> pure []
+        Right drv -> do
+          outputs <- NixDrv.derivationOutputs store drv drvSp
+          here <- fmap catMaybes $ forM outputs $ \(_outName, drvOutputId) -> do
+            already <- Set.member drvOutputId <$> readIORef visitedIdsRef
+            if already
+              then pure Nothing
+              else do
+                modifyIORef' visitedIdsRef (Set.insert drvOutputId)
+                NixRealisation.queryRealisation store drvOutputId >>= \case
+                  Nothing -> pure Nothing
+                  Just r -> Just <$> mkRealisation store drvOutputId r
+          -- Recurse into static input derivations. Dynamic inputs are
+          -- not surfaced by the C API, so we skip the input walk for
+          -- those cases (the realisations of statically-resolvable
+          -- inputs are still collected above for the current drv).
+          hasDynamic <- NixDrv.derivationHasDynamicInputs drv
+          deps <-
+            if hasDynamic
+              then pure []
+              else do
+                pairs <- NixDrv.derivationInputDrvOutputs store drv
+                let uniqueDrvPaths = Set.toList $ Set.fromList $ fmap fst pairs
+                fmap concat $ forM uniqueDrvPaths $ \drvPathBS -> do
+                  inputOs <- OsPath.encodeFS (toS drvPathBS :: FilePath)
+                  inputSpE <- try (Store.parseStorePath' store inputOs)
+                  case inputSpE of
+                    Left (_ :: SomeException) -> pure []
+                    Right inputSp ->
+                      collectRealisations visitedDrvsRef visitedIdsRef store inputSp
+          pure (here ++ deps)
+ where
+  mkRealisation
+    :: Store
+    -> ByteString
+    -> NixRealisation.Realisation
+    -> IO Realisation.Realisation
+  mkRealisation s drvOutputId r = do
+    outSp <- NixRealisation.realisationOutPath r
+    outBaseFP <-
+      OsPath.decodeFS . OsPath.takeFileName =<< Store.storeRealPath s outSp
+    sigs <- NixRealisation.realisationSignatures r
+    let decode = decodeUtf8With lenientDecode
+    pure
+      Realisation.Realisation
+        { Realisation.rId = decode drvOutputId,
+          Realisation.rOutPath = T.pack outBaseFP,
+          Realisation.rSignatures = fmap decode sigs,
+          Realisation.rDependentRealisations = mempty
+        }
+
+unknownDeriver :: Text
+unknownDeriver = "unknown-deriver"
+
+-- | Render the C-API 'ContentAddress' back to its textual narinfo form
+-- (e.g. @"text:sha256:..."@ or @"fixed:r:sha256:..."@).
+caToText :: ContentAddress -> Text
+caToText = \case
+  ContentAddressText t -> t
+  ContentAddressStructured method hash ->
+    method <> ":" <> NixPathInfo.hashToSRI hash
+
 data UploadNarDetails = UploadNarDetails
   { undNarSize :: Integer,
     undNarHash :: Text,
@@ -294,7 +415,8 @@ data PathInfo = PathInfo
     piNarHash :: Text,
     piNarSize :: Integer,
     piDeriver :: Maybe Text,
-    piReferences :: Set FilePath
+    piReferences :: Set FilePath,
+    piCa :: Maybe Text
   }
   deriving stock (Eq, Show)
 
@@ -307,6 +429,7 @@ newPathInfoFromStorePath store storePath = liftIO $ do
 
   let narHash = NixHash.hashToNix32 (NixPathInfo.pathInfoNarHash info)
       narSize = fromIntegral $ NixPathInfo.pathInfoNarSize info
+      ca = caToText <$> NixPathInfo.pathInfoCa info
 
   let getStorePathBaseName =
         (OsPath.decodeFS . OsPath.takeFileName)
@@ -324,7 +447,8 @@ newPathInfoFromStorePath store storePath = liftIO $ do
         piNarHash = narHash,
         piNarSize = narSize,
         piDeriver = deriver,
-        piReferences = Set.fromList refPaths
+        piReferences = Set.fromList refPaths,
+        piCa = ca
       }
 
 -- | Create a 'PathInfo' for a store path from an existing NarInfo.
@@ -336,7 +460,8 @@ newPathInfoFromNarInfo narInfo =
         piNarHash = NarInfo.narHash narInfo,
         piNarSize = NarInfo.narSize narInfo,
         piDeriver = NarInfo.deriver narInfo,
-        piReferences = NarInfo.references narInfo
+        piReferences = NarInfo.references narInfo,
+        piCa = NarInfo.ca narInfo
       }
 
 -- | A conduit that compresses and streams a NAR to a cache.
@@ -475,7 +600,7 @@ Got:      ${piNarHash pathInfo}
         |]
 
   let deriver =
-        fromMaybe "unknown-deriver" $
+        fromMaybe unknownDeriver $
           if omitDeriver strategy
             then Nothing
             else piDeriver pathInfo
@@ -499,7 +624,8 @@ Got:      ${piNarHash pathInfo}
             Api.cFileHash = undFileHash,
             Api.cReferences = references,
             Api.cDeriver = deriver,
-            Api.cSig = sig
+            Api.cSig = sig,
+            Api.cCa = piCa pathInfo
           }
 
   escalate $ Api.isNarInfoCreateValid nic

--- a/cachix/src/Cachix/Client/Push.hs
+++ b/cachix/src/Cachix/Client/Push.hs
@@ -402,11 +402,28 @@ unknownDeriver = "unknown-deriver"
 
 -- | Render the C-API 'ContentAddress' back to its textual narinfo form
 -- (e.g. @"text:sha256:..."@ or @"fixed:r:sha256:..."@).
+--
+-- This reproduces Nix's @ContentAddress::render()@
+-- (@renderPrefixModern(method) + hash.to_string(Nix32, true)@): the narinfo
+-- @CA:@ grammar only accepts @text:@ and @fixed:@ prefixes with a
+-- @<algo>:<base32>@ hash, not the structured path-info method name (@nar@ /
+-- @flat@) or an SRI hash. 'NixPathInfo.hashToNix32' already renders
+-- @"<algo>:<base32>"@; we only need to map the method to its narinfo prefix.
 caToText :: ContentAddress -> Text
 caToText = \case
   ContentAddressText t -> t
   ContentAddressStructured method hash ->
-    method <> ":" <> NixPathInfo.hashToSRI hash
+    narInfoMethodPrefix method <> NixPathInfo.hashToNix32 hash
+  where
+    -- Mirrors Nix's renderPrefixModern: Text -> "text:", and the fixed-output
+    -- ingestion methods nest under "fixed:" (flat -> "", nar -> "r:", git ->
+    -- "git:").
+    narInfoMethodPrefix = \case
+      "text" -> "text:"
+      "flat" -> "fixed:"
+      "nar" -> "fixed:r:"
+      "git" -> "fixed:git:"
+      other -> "fixed:" <> other <> ":"
 
 data UploadNarDetails = UploadNarDetails
   { undNarSize :: Integer,

--- a/cachix/src/Cachix/Client/PushQueue.hs
+++ b/cachix/src/Cachix/Client/PushQueue.hs
@@ -22,7 +22,7 @@ import Control.Concurrent.STM (TVar, modifyTVar', newTVarIO, readTVar)
 import Control.Concurrent.STM.Lock qualified as Lock
 import Control.Concurrent.STM.TBQueue qualified as TBQueue
 import Data.Set qualified as S
-import Nix.Unsafe.Store (StorePath)
+import Nix.C.Unsafe.Store (StorePath)
 import Protolude
 import System.Posix.Signals qualified as Signals
 import System.Systemd.Daemon qualified as Systemd

--- a/cachix/src/Cachix/Client/PushQueue.hs
+++ b/cachix/src/Cachix/Client/PushQueue.hs
@@ -22,7 +22,7 @@ import Control.Concurrent.STM (TVar, modifyTVar', newTVarIO, readTVar)
 import Control.Concurrent.STM.Lock qualified as Lock
 import Control.Concurrent.STM.TBQueue qualified as TBQueue
 import Data.Set qualified as S
-import Hercules.CNix.Store (StorePath)
+import Nix.Unsafe.Store (StorePath)
 import Protolude
 import System.Posix.Signals qualified as Signals
 import System.Systemd.Daemon qualified as Systemd

--- a/cachix/src/Cachix/Client/WatchStore.hs
+++ b/cachix/src/Cachix/Client/WatchStore.hs
@@ -7,7 +7,7 @@ import Cachix.Client.CNix (logStorePathWarning, resolveStorePath)
 import Cachix.Client.Push
 import Cachix.Client.PushQueue qualified as PushQueue
 import Control.Concurrent.STM.TBQueue qualified as TBQueue
-import Nix.Unsafe.Store (Store)
+import Nix.C.Unsafe.Store (Store)
 import Protolude
 import System.FSNotify
 import System.Systemd.Daemon qualified as Systemd

--- a/cachix/src/Cachix/Client/WatchStore.hs
+++ b/cachix/src/Cachix/Client/WatchStore.hs
@@ -7,7 +7,7 @@ import Cachix.Client.CNix (logStorePathWarning, resolveStorePath)
 import Cachix.Client.Push
 import Cachix.Client.PushQueue qualified as PushQueue
 import Control.Concurrent.STM.TBQueue qualified as TBQueue
-import Hercules.CNix.Store (Store)
+import Nix.Unsafe.Store (Store)
 import Protolude
 import System.FSNotify
 import System.Systemd.Daemon qualified as Systemd

--- a/cachix/src/Cachix/Daemon.hs
+++ b/cachix/src/Cachix/Daemon.hs
@@ -39,10 +39,10 @@ import Control.Concurrent.STM.TMChan
 import Control.Exception.Safe (catchAny)
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Text qualified as T
-import Nix.Unsafe.Store (Store, withStore)
 import Katip qualified
 import Network.Socket qualified as Socket
 import Network.Socket.ByteString qualified as Socket.BS
+import Nix.C.Unsafe.Store (Store, withStore)
 import Protolude hiding (bracket)
 import Servant.Client.Streaming (runClientM)
 import System.Environment (lookupEnv)

--- a/cachix/src/Cachix/Daemon.hs
+++ b/cachix/src/Cachix/Daemon.hs
@@ -39,8 +39,7 @@ import Control.Concurrent.STM.TMChan
 import Control.Exception.Safe (catchAny)
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Text qualified as T
-import Hercules.CNix.Store (Store, withStore)
-import Hercules.CNix.Util qualified as CNix.Util
+import Nix.Unsafe.Store (Store, withStore)
 import Katip qualified
 import Network.Socket qualified as Socket
 import Network.Socket.ByteString qualified as Socket.BS
@@ -110,7 +109,7 @@ new daemonEnv nixStore daemonOptions daemonLogHandle daemonPushOptions daemonCac
 -- Equivalent to running 'withStore', new', and 'run', together with some signal handling.
 start :: Env -> DaemonOptions -> PushOptions -> BinaryCacheName -> IO ()
 start daemonEnv daemonOptions daemonPushOptions daemonCacheName =
-  withStore $ \store -> do
+  withStore "auto" $ \store -> do
     daemon <- new daemonEnv store daemonOptions Nothing daemonPushOptions daemonCacheName
     void $ runDaemon daemon installSignalHandlers
     result <- run daemon
@@ -238,7 +237,6 @@ installSignalHandlers = do
     termHandler mainThreadId = do
       Katip.logFM Katip.InfoS "sigTERM received. Exiting immediately..."
       startExitTimer mainThreadId
-      liftIO CNix.Util.triggerInterrupt
       eventLoop <- asks daemonEventLoop
       -- Signal directly to the event loop to ensure exit even if queue is full
       EventLoop.exitLoopWithFailure EventLoopClosed eventLoop
@@ -250,7 +248,6 @@ installSignalHandlers = do
 
     handleInterrupt :: ThreadId -> IORef Bool -> Daemon ()
     handleInterrupt mainThreadId interruptRef = do
-      liftIO CNix.Util.triggerInterrupt
       isSecondInterrupt <- liftIO $ atomicModifyIORef' interruptRef (True,)
       eventLoop <- asks daemonEventLoop
 

--- a/cachix/src/Cachix/Daemon/Client.hs
+++ b/cachix/src/Cachix/Daemon/Client.hs
@@ -19,7 +19,7 @@ import Data.ByteString.Char8 qualified as BS8
 import Data.IORef
 import Data.Text qualified as T
 import Data.Time.Clock
-import Hercules.CNix.Store qualified as Store
+import Nix.Unsafe.Store qualified as Store
 import Network.Socket qualified as Socket
 import Network.Socket.ByteString qualified as Socket.BS
 import Network.Socket.ByteString.Lazy qualified as Socket.LBS
@@ -132,10 +132,10 @@ push _env daemonOptions daemonPushOptions cliPaths = do
       -- This avoids hangs in cases where stdin is non-interactive but unused by caller.
       (_, paths) -> return paths
 
-  storePaths <- Store.withStore $ \store -> do
+  storePaths <- Store.withStore "auto" $ \store -> do
     (errors, validPaths) <- resolveStorePaths store inputStorePaths
     for_ errors $ uncurry logStorePathWarning
-    mapM (fmap (toS . BS8.unpack) . Store.storePathToPath store) validPaths
+    mapM (fmap (toS . BS8.unpack) . Store.storeRealPath store) validPaths
 
   withDaemonConn (daemonSocketPath daemonOptions) $ \sock -> do
     let shouldWait = Options.shouldWait daemonPushOptions

--- a/cachix/src/Cachix/Daemon/Client.hs
+++ b/cachix/src/Cachix/Daemon/Client.hs
@@ -15,18 +15,18 @@ import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM.TBMQueue
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as BS
-import Data.ByteString.Char8 qualified as BS8
 import Data.IORef
 import Data.Text qualified as T
 import Data.Time.Clock
-import Nix.Unsafe.Store qualified as Store
 import Network.Socket qualified as Socket
 import Network.Socket.ByteString qualified as Socket.BS
 import Network.Socket.ByteString.Lazy qualified as Socket.LBS
+import Nix.C.Unsafe.Store qualified as Store
 import Protolude
 import System.Environment (lookupEnv)
 import System.IO (hIsTerminalDevice)
 import System.IO.Error (isResourceVanishedError)
+import System.OsPath qualified as OsPath
 
 data SocketError
   = -- | The socket has been closed
@@ -135,7 +135,7 @@ push _env daemonOptions daemonPushOptions cliPaths = do
   storePaths <- Store.withStore "auto" $ \store -> do
     (errors, validPaths) <- resolveStorePaths store inputStorePaths
     for_ errors $ uncurry logStorePathWarning
-    mapM (fmap (toS . BS8.unpack) . Store.storeRealPath store) validPaths
+    mapM (OsPath.decodeFS <=< Store.storeRealPath store) validPaths
 
   withDaemonConn (daemonSocketPath daemonOptions) $ \sock -> do
     let shouldWait = Options.shouldWait daemonPushOptions

--- a/cachix/src/Cachix/Daemon/NarinfoQuery.hs
+++ b/cachix/src/Cachix/Daemon/NarinfoQuery.hs
@@ -30,8 +30,8 @@ import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
 import Data.Time (NominalDiffTime, UTCTime, addUTCTime, diffUTCTime, getCurrentTime)
-import Nix.Unsafe.Store (StorePath, storePathHash)
 import Katip qualified
+import Nix.C.Unsafe.Store (StorePath, storePathHash)
 import Protolude
 import UnliftIO.Async qualified as Async
 

--- a/cachix/src/Cachix/Daemon/NarinfoQuery.hs
+++ b/cachix/src/Cachix/Daemon/NarinfoQuery.hs
@@ -30,7 +30,7 @@ import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
 import Data.Time (NominalDiffTime, UTCTime, addUTCTime, diffUTCTime, getCurrentTime)
-import Hercules.CNix.Store (StorePath, getStorePathHash)
+import Nix.Unsafe.Store (StorePath, storePathHash)
 import Katip qualified
 import Protolude
 import UnliftIO.Async qualified as Async
@@ -140,7 +140,7 @@ new nqmConfig nqmCallback = liftIO $ do
 -- | Check if a path exists in the cache and is not stale
 lookupCache :: (MonadIO m) => NarinfoQueryManager requestId -> StorePath -> m Bool
 lookupCache NarinfoQueryManager {nqmCache, nqmCachedTime} path = liftIO $ do
-  pathHash <- getStorePathHash path
+  pathHash <- storePathHash path
   now <- readTVarIO nqmCachedTime
   cache <- readTVarIO nqmCache
   return $ TTLCache.lookup now pathHash cache
@@ -149,7 +149,7 @@ lookupCache NarinfoQueryManager {nqmCache, nqmCachedTime} path = liftIO $ do
 updateCache :: (MonadIO m) => NarinfoQueryManager requestId -> Set StorePath -> m ()
 updateCache NarinfoQueryManager {nqmCache, nqmConfig, nqmCachedTime} paths = liftIO $ do
   -- Convert paths to hashes
-  pathHashes <- mapM getStorePathHash (Set.toList paths)
+  pathHashes <- mapM storePathHash (Set.toList paths)
   now <- readTVarIO nqmCachedTime
   let ttl = nqoCacheTTL nqmConfig
   when (ttl > 0) $ do

--- a/cachix/src/Cachix/Daemon/Push.hs
+++ b/cachix/src/Cachix/Daemon/Push.hs
@@ -19,7 +19,7 @@ import Cachix.Daemon.Types (PushManager)
 import Cachix.Types.BinaryCache (BinaryCache, BinaryCacheName)
 import Cachix.Types.BinaryCache qualified as BinaryCache
 import Data.Set qualified as Set
-import Hercules.CNix.Store (Store)
+import Nix.Unsafe.Store (Store)
 import Protolude hiding (toS)
 import Servant.Auth ()
 import Servant.Auth.Client

--- a/cachix/src/Cachix/Daemon/Push.hs
+++ b/cachix/src/Cachix/Daemon/Push.hs
@@ -19,7 +19,7 @@ import Cachix.Daemon.Types (PushManager)
 import Cachix.Types.BinaryCache (BinaryCache, BinaryCacheName)
 import Cachix.Types.BinaryCache qualified as BinaryCache
 import Data.Set qualified as Set
-import Nix.Unsafe.Store (Store)
+import Nix.C.Unsafe.Store (Store)
 import Protolude hiding (toS)
 import Servant.Auth ()
 import Servant.Auth.Client

--- a/cachix/src/Cachix/Daemon/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/PushManager.hs
@@ -77,8 +77,7 @@ import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Time (UTCTime, diffUTCTime, getCurrentTime, secondsToNominalDiffTime)
 import GHC.Clock (getMonotonicTimeNSec)
-import Hercules.CNix (StorePath)
-import Hercules.CNix.Store (Store, parseStorePath, storePathToPath)
+import Nix.Unsafe.Store (Store, StorePath, parseStorePath', storeRealPath)
 import Katip qualified
 import Protolude hiding (toS)
 import Protolude.Conv (toS)
@@ -413,7 +412,7 @@ runPushPathTask pushParams filePath = do
         Katip.logLocM Katip.DebugS $ Katip.ls $ "Pushing store path " <> filePath
 
         let store = pushParamsStore pushParams
-        storePath <- liftIO $ parseStorePath store (toS filePath)
+        storePath <- liftIO $ parseStorePath' store (toS filePath)
 
         retryAll $ uploadStorePath pushParams storePath
 
@@ -426,20 +425,20 @@ newPushStrategy ::
   (StorePath -> PushStrategy PushManager ())
 newPushStrategy store authToken opts cacheName compressionMethod storePath =
   let onAlreadyPresent = do
-        sp <- liftIO $ storePathToPath store storePath
+        sp <- liftIO $ storeRealPath store storePath
         Katip.logFM Katip.InfoS $ Katip.ls $ "Skipping " <> (toS sp :: Text)
         -- TODO: needs another event type here
         pushStorePathDone (toS sp)
 
       onError err = do
         let errText = toS (displayException err)
-        sp <- liftIO $ storePathToPath store storePath
+        sp <- liftIO $ storeRealPath store storePath
         Katip.katipAddContext (Katip.sl "error" errText) $
           Katip.logFM Katip.InfoS (Katip.ls $ "Failed to push " <> (toS sp :: Text))
         pushStorePathFailed (toS sp) errText
 
       onAttempt retryStatus size = do
-        sp <- liftIO $ storePathToPath store storePath
+        sp <- liftIO $ storeRealPath store storePath
         let retryContext =
               if rsIterNumber retryStatus > 0
                 then Katip.katipAddContext (Katip.sl "retry" (rsIterNumber retryStatus))
@@ -451,7 +450,7 @@ newPushStrategy store authToken opts cacheName compressionMethod storePath =
         pushStorePathAttempt (toS sp) size retryStatus
 
       onUncompressedNARStream _ size = do
-        sp <- liftIO $ storePathToPath store storePath
+        sp <- liftIO $ storeRealPath store storePath
         progressEmitIntervalNs <- asks pmProgressEmitIntervalNs
         lastEmitNsRef <- liftIO $ newIORef =<< getMonotonicTimeNSec
         currentBytesRef <- liftIO $ newIORef (0 :: Int64)
@@ -475,7 +474,7 @@ newPushStrategy store authToken opts cacheName compressionMethod storePath =
           C.yield chunk
 
       onDone = do
-        sp <- liftIO $ storePathToPath store storePath
+        sp <- liftIO $ storeRealPath store storePath
         Katip.logFM Katip.InfoS $ Katip.ls $ "Pushed " <> (toS sp :: Text)
         pushStorePathDone (toS sp)
    in PushStrategy
@@ -573,7 +572,7 @@ pushStorePathFailed storePath errMsg = do
 
 storeToFilePath :: (MonadIO m) => Store -> StorePath -> m FilePath
 storeToFilePath store storePath = do
-  fp <- liftIO $ storePathToPath store storePath
+  fp <- liftIO $ storeRealPath store storePath
   pure $ toS fp
 
 withException :: (E.MonadCatch m) => m a -> (SomeException -> m a) -> m a

--- a/cachix/src/Cachix/Daemon/PushManager.hs
+++ b/cachix/src/Cachix/Daemon/PushManager.hs
@@ -77,13 +77,14 @@ import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Time (UTCTime, diffUTCTime, getCurrentTime, secondsToNominalDiffTime)
 import GHC.Clock (getMonotonicTimeNSec)
-import Nix.Unsafe.Store (Store, StorePath, parseStorePath', storeRealPath)
 import Katip qualified
+import Nix.C.Unsafe.Store (Store, StorePath, parseStorePath', storeRealPath)
 import Protolude hiding (toS)
 import Protolude.Conv (toS)
 import Servant.Auth ()
 import Servant.Auth.Client
 import Servant.Conduit ()
+import System.OsPath qualified as OsPath
 import UnliftIO.QSem qualified as QSem
 
 newPushManagerEnv :: (MonadIO m) => PushOptions -> NarinfoQuery.NarinfoQueryOptions -> PushParams PushManager () -> OnPushEvent -> Logger -> m PushManagerEnv
@@ -412,7 +413,8 @@ runPushPathTask pushParams filePath = do
         Katip.logLocM Katip.DebugS $ Katip.ls $ "Pushing store path " <> filePath
 
         let store = pushParamsStore pushParams
-        storePath <- liftIO $ parseStorePath' store (toS filePath)
+        osPath <- liftIO $ OsPath.encodeFS filePath
+        storePath <- liftIO $ parseStorePath' store osPath
 
         retryAll $ uploadStorePath pushParams storePath
 
@@ -425,20 +427,20 @@ newPushStrategy ::
   (StorePath -> PushStrategy PushManager ())
 newPushStrategy store authToken opts cacheName compressionMethod storePath =
   let onAlreadyPresent = do
-        sp <- liftIO $ storeRealPath store storePath
+        sp <- liftIO $ OsPath.decodeFS =<< storeRealPath store storePath
         Katip.logFM Katip.InfoS $ Katip.ls $ "Skipping " <> (toS sp :: Text)
         -- TODO: needs another event type here
         pushStorePathDone (toS sp)
 
       onError err = do
         let errText = toS (displayException err)
-        sp <- liftIO $ storeRealPath store storePath
+        sp <- liftIO $ OsPath.decodeFS =<< storeRealPath store storePath
         Katip.katipAddContext (Katip.sl "error" errText) $
           Katip.logFM Katip.InfoS (Katip.ls $ "Failed to push " <> (toS sp :: Text))
         pushStorePathFailed (toS sp) errText
 
       onAttempt retryStatus size = do
-        sp <- liftIO $ storeRealPath store storePath
+        sp <- liftIO $ OsPath.decodeFS =<< storeRealPath store storePath
         let retryContext =
               if rsIterNumber retryStatus > 0
                 then Katip.katipAddContext (Katip.sl "retry" (rsIterNumber retryStatus))
@@ -450,7 +452,7 @@ newPushStrategy store authToken opts cacheName compressionMethod storePath =
         pushStorePathAttempt (toS sp) size retryStatus
 
       onUncompressedNARStream _ size = do
-        sp <- liftIO $ storeRealPath store storePath
+        sp <- liftIO $ OsPath.decodeFS =<< storeRealPath store storePath
         progressEmitIntervalNs <- asks pmProgressEmitIntervalNs
         lastEmitNsRef <- liftIO $ newIORef =<< getMonotonicTimeNSec
         currentBytesRef <- liftIO $ newIORef (0 :: Int64)
@@ -474,7 +476,7 @@ newPushStrategy store authToken opts cacheName compressionMethod storePath =
           C.yield chunk
 
       onDone = do
-        sp <- liftIO $ storeRealPath store storePath
+        sp <- liftIO $ OsPath.decodeFS =<< storeRealPath store storePath
         Katip.logFM Katip.InfoS $ Katip.ls $ "Pushed " <> (toS sp :: Text)
         pushStorePathDone (toS sp)
    in PushStrategy
@@ -571,9 +573,8 @@ pushStorePathFailed storePath errMsg = do
 -- Helpers
 
 storeToFilePath :: (MonadIO m) => Store -> StorePath -> m FilePath
-storeToFilePath store storePath = do
-  fp <- liftIO $ storeRealPath store storePath
-  pure $ toS fp
+storeToFilePath store storePath =
+  liftIO $ OsPath.decodeFS =<< storeRealPath store storePath
 
 withException :: (E.MonadCatch m) => m a -> (SomeException -> m a) -> m a
 withException action handler = action `E.catchAll` (\e -> handler e >> E.throwM e)

--- a/cachix/test/Daemon/NarinfoQuerySpec.hs
+++ b/cachix/test/Daemon/NarinfoQuerySpec.hs
@@ -8,11 +8,12 @@ import Cachix.Daemon.NarinfoQuery qualified as NarinfoQuery
 import Control.Concurrent.STM
 import Data.Set qualified as Set
 import Data.Time (UTCTime, getCurrentTime)
-import Nix.Unsafe.Init qualified as NixInit
-import Nix.Unsafe.Store (Store, StorePath, withStore)
-import Nix.Unsafe.Store qualified as Store
 import Katip qualified
+import Nix.C.Unsafe.Init qualified as NixInit
+import Nix.C.Unsafe.Store (Store, StorePath, withStore)
+import Nix.C.Unsafe.Store qualified as Store
 import Protolude
+import System.OsPath qualified as OsPath
 import Test.Hspec
 import UnliftIO.Async qualified as Async
 import UnliftIO.Timeout (timeout)
@@ -20,8 +21,9 @@ import UnliftIO.Timeout (timeout)
 -- Create a mock StorePath for testing
 mockStorePath :: Store -> Int -> IO StorePath
 mockStorePath store i = do
-  let pathText = "/nix/store/" <> show i <> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-mock"
-  Store.parseStorePath' store (encodeUtf8 pathText)
+  let pathText = "/nix/store/" <> show i <> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-mock" :: [Char]
+  osPath <- OsPath.encodeFS pathText
+  Store.parseStorePath' store osPath
 
 -- Test data structure to track batch processor calls
 data BatchCall = BatchCall

--- a/cachix/test/Daemon/NarinfoQuerySpec.hs
+++ b/cachix/test/Daemon/NarinfoQuerySpec.hs
@@ -8,8 +8,9 @@ import Cachix.Daemon.NarinfoQuery qualified as NarinfoQuery
 import Control.Concurrent.STM
 import Data.Set qualified as Set
 import Data.Time (UTCTime, getCurrentTime)
-import Hercules.CNix qualified as CNix
-import Hercules.CNix.Store (Store, StorePath, withStoreFromURI)
+import Nix.Unsafe.Init qualified as NixInit
+import Nix.Unsafe.Store (Store, StorePath, withStore)
+import Nix.Unsafe.Store qualified as Store
 import Katip qualified
 import Protolude
 import Test.Hspec
@@ -20,7 +21,7 @@ import UnliftIO.Timeout (timeout)
 mockStorePath :: Store -> Int -> IO StorePath
 mockStorePath store i = do
   let pathText = "/nix/store/" <> show i <> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-mock"
-  CNix.parseStorePath store (encodeUtf8 pathText)
+  Store.parseStorePath' store (encodeUtf8 pathText)
 
 -- Test data structure to track batch processor calls
 data BatchCall = BatchCall
@@ -134,10 +135,10 @@ waitForCallbacks callsVar n =
 spec :: Spec
 spec = do
   -- Initialize the CNix library
-  runIO CNix.init
+  runIO NixInit.initNix
 
   describe "Batching" $ do
-    it "triggers batch when size threshold is reached" $ withStoreFromURI "dummy://" $ \store -> do
+    it "triggers batch when size threshold is reached" $ withStore "dummy://" $ \store -> do
       path1 <- mockStorePath store 1
       path2 <- mockStorePath store 2
       path3 <- mockStorePath store 3
@@ -160,7 +161,7 @@ spec = do
               Nothing -> panic "Expected batch call"
         Set.fromList batchPaths `shouldBe` Set.fromList [path1, path2]
 
-    it "triggers batch when timeout is reached" $ withStoreFromURI "dummy://" $ \store -> do
+    it "triggers batch when timeout is reached" $ withStore "dummy://" $ \store -> do
       path1 <- mockStorePath store 1
       let config = defaultNarinfoQueryOptions {nqoMaxBatchSize = 100, nqoMaxWaitTime = 0.05} -- Small timeout, large batch
       withTestManager config $ \TestContext {..} -> do
@@ -174,7 +175,7 @@ spec = do
 
         calls <- readTVarIO tcBatchCalls
         length calls `shouldBe` 1 -- Batch triggered by timeout
-    it "processes immediately when timeout is zero" $ withStoreFromURI "dummy://" $ \store -> do
+    it "processes immediately when timeout is zero" $ withStore "dummy://" $ \store -> do
       path1 <- mockStorePath store 1
       let config = defaultNarinfoQueryOptions {nqoMaxBatchSize = 100, nqoMaxWaitTime = 0} -- Immediate mode
       withTestManager config $ \TestContext {..} -> do
@@ -186,7 +187,7 @@ spec = do
 
         calls <- readTVarIO tcBatchCalls
         length calls `shouldBe` 1 -- Processed immediately
-    it "only caches existing paths, not missing ones" $ withStoreFromURI "dummy://" $ \store -> do
+    it "only caches existing paths, not missing ones" $ withStore "dummy://" $ \store -> do
       path1 <- mockStorePath store 1
       path2 <- mockStorePath store 2
       path3 <- mockStorePath store 3
@@ -209,7 +210,7 @@ spec = do
         cached1 `shouldBe` True -- Existing path cached
         cached2 `shouldBe` True -- Existing path cached
         cached3 `shouldBe` False -- Missing path not cached
-    it "bypasses batch processor for cached paths" $ withStoreFromURI "dummy://" $ \store -> do
+    it "bypasses batch processor for cached paths" $ withStore "dummy://" $ \store -> do
       path1 <- mockStorePath store 1
       path2 <- mockStorePath store 2
       let config = defaultNarinfoQueryOptions {nqoMaxWaitTime = 0}
@@ -243,7 +244,7 @@ spec = do
               Nothing -> panic "Expected callback call"
         NarinfoQuery.nrAllPaths secondResponse `shouldBe` Set.fromList [path1, path2]
 
-    it "distributes correct paths to each request" $ withStoreFromURI "dummy://" $ \store -> do
+    it "distributes correct paths to each request" $ withStore "dummy://" $ \store -> do
       path1 <- mockStorePath store 1
       path2 <- mockStorePath store 2
       path3 <- mockStorePath store 3
@@ -282,7 +283,7 @@ spec = do
         NarinfoQuery.nrAllPaths response2 `shouldBe` Set.fromList [path3, path4, path5]
         NarinfoQuery.nrMissingPaths response2 `shouldBe` Set.fromList [path4]
 
-    it "deduplicates paths across requests in same batch" $ withStoreFromURI "dummy://" $ \store -> do
+    it "deduplicates paths across requests in same batch" $ withStore "dummy://" $ \store -> do
       path1 <- mockStorePath store 1
       path2 <- mockStorePath store 2
       let config = defaultNarinfoQueryOptions {nqoMaxBatchSize = 3, nqoMaxWaitTime = 0.1}

--- a/cachix/test/Daemon/PushManagerSpec.hs
+++ b/cachix/test/Daemon/PushManagerSpec.hs
@@ -18,7 +18,8 @@ import Control.Monad (fail)
 import Control.Retry (defaultRetryStatus)
 import Data.Set qualified as Set
 import Data.Time (diffUTCTime, getCurrentTime)
-import Hercules.CNix qualified as CNix
+import Nix.Unsafe.Init qualified as NixInit
+import Nix.Unsafe.Store (Store, withStore)
 import Protolude
 import Servant.Auth.Client (Token (Token))
 import System.IO.Temp (withSystemTempDirectory)
@@ -193,7 +194,7 @@ spec = do
 
 withPushManager :: (PushManagerEnv -> IO a) -> IO a
 withPushManager f = do
-  CNix.init
+  NixInit.initNix
   withTempStore $ \store -> do
     logger <- liftIO $ Log.new "daemon" Nothing Log.Debug
     cachixOptions <- Env.defaultCachixOptions
@@ -208,10 +209,10 @@ withPushManager f = do
 inPushManager :: PushManager a -> IO a
 inPushManager f = withPushManager (`runPushManager` f)
 
-withTempStore :: (CNix.Store -> IO a) -> IO a
+withTempStore :: (Store -> IO a) -> IO a
 withTempStore f =
   withSystemTempDirectory "cnix-test-store" $ \d ->
-    CNix.withStoreFromURI (toS d) f
+    withStore (encodeUtf8 (toS d :: Text)) f
 
 newBinaryCache :: BinaryCache.BinaryCacheName -> BinaryCache.BinaryCache
 newBinaryCache name =

--- a/cachix/test/Daemon/PushManagerSpec.hs
+++ b/cachix/test/Daemon/PushManagerSpec.hs
@@ -18,8 +18,8 @@ import Control.Monad (fail)
 import Control.Retry (defaultRetryStatus)
 import Data.Set qualified as Set
 import Data.Time (diffUTCTime, getCurrentTime)
-import Nix.Unsafe.Init qualified as NixInit
-import Nix.Unsafe.Store (Store, withStore)
+import Nix.C.Unsafe.Init qualified as NixInit
+import Nix.C.Unsafe.Store (Store, withStore)
 import Protolude
 import Servant.Auth.Client (Token (Token))
 import System.IO.Temp (withSystemTempDirectory)

--- a/devenv.nix
+++ b/devenv.nix
@@ -2,7 +2,7 @@
   pkgs,
   lib,
   ghcVersion,
-  getNix,
+  nixCApiPkgs,
   ...
 }:
 
@@ -17,7 +17,6 @@
     pkgs.zlib
     pkgs.boost
     pkgs.libsodium
-    (getNix { inherit pkgs; })
 
     # Required by nix-util
     pkgs.libblake3
@@ -28,6 +27,7 @@
     pkgs.libgit2
     pkgs.pcre2
   ]
+  ++ nixCApiPkgs
   ++ lib.optional pkgs.stdenv.hostPlatform.isx86 pkgs.libcpuid
   ++ [
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -26,6 +26,7 @@
     pkgs.sqlite.dev
     pkgs.libgit2
     pkgs.pcre2
+
   ]
   ++ nixCApiPkgs
   ++ lib.optional pkgs.stdenv.hostPlatform.isx86 pkgs.libcpuid

--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037660,
-        "narHash": "sha256-GYKwHpJwlv3i+SYaOWqjBiD5Re/IgsunjjSqtd8Y+os=",
+        "lastModified": 1775604664,
+        "narHash": "sha256-OGdllLqWyWfR91tK+Kt1ndmVg2P/Q6EDvePHB7gvmxE=",
         "owner": "cachix",
         "repo": "nix-bindings-haskell",
-        "rev": "bb622e49d00115afcf7d82774cd60c0e5d9a385d",
+        "rev": "5c7ff694e8bce836eecf6679e0d19c481520dd06",
         "type": "github"
       },
       "original": {
@@ -382,16 +382,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1774493711,
-        "narHash": "sha256-xQqNVk6qjWrsG8KnKH/O7Dl5leYSucnZtxRihKz0aGw=",
+        "lastModified": 1775584026,
+        "narHash": "sha256-mNMlEs5VpSy14fZBepBKyK9E+9Pdxgod9zVr0n7wgHQ=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "029becbe2fc65eb252facd2322610f8ac5b1dd15",
+        "rev": "528fc271dc73d550b3899d4ce8651b3c8ab5970c",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "feat-query-path-info-json",
+        "ref": "feat-query-path-info",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -155,7 +155,7 @@
     "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
-          "hs-nix-c-api",
+          "nix-bindings-haskell",
           "nix",
           "nixpkgs"
         ]
@@ -216,20 +216,20 @@
     "git-hooks-nix": {
       "inputs": {
         "flake-compat": [
-          "hs-nix-c-api",
+          "nix-bindings-haskell",
           "nix"
         ],
         "gitignore": [
-          "hs-nix-c-api",
+          "nix-bindings-haskell",
           "nix"
         ],
         "nixpkgs": [
-          "hs-nix-c-api",
+          "nix-bindings-haskell",
           "nix",
           "nixpkgs"
         ],
         "nixpkgs-stable": [
-          "hs-nix-c-api",
+          "nix-bindings-haskell",
           "nix",
           "nixpkgs"
         ]
@@ -274,7 +274,7 @@
         "flake-parts": "flake-parts_3",
         "libclang-bindings-src": "libclang-bindings-src",
         "nixpkgs": [
-          "hs-nix-c-api",
+          "nix-bindings-haskell",
           "nixpkgs"
         ]
       },
@@ -289,29 +289,6 @@
       "original": {
         "owner": "well-typed",
         "repo": "hs-bindgen",
-        "type": "github"
-      }
-    },
-    "hs-nix-c-api": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "hs-bindgen": "hs-bindgen",
-        "nix": "nix_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774560645,
-        "narHash": "sha256-2Oc2pdJZtAJT3uRyWCDtTcJF0O60eiVi9NGinBCxPOQ=",
-        "owner": "cachix",
-        "repo": "hs-nix-c-api",
-        "rev": "1ecd76534b3d2db0938b994710a09ef5d81176dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "hs-nix-c-api",
         "type": "github"
       }
     },
@@ -369,6 +346,29 @@
         "owner": "cachix",
         "ref": "devenv-2.32",
         "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-bindings-haskell": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "hs-bindgen": "hs-bindgen",
+        "nix": "nix_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775037660,
+        "narHash": "sha256-GYKwHpJwlv3i+SYaOWqjBiD5Re/IgsunjjSqtd8Y+os=",
+        "owner": "cachix",
+        "repo": "nix-bindings-haskell",
+        "rev": "bb622e49d00115afcf7d82774cd60c0e5d9a385d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nix-bindings-haskell",
         "type": "github"
       }
     },
@@ -519,7 +519,7 @@
         "devenv": "devenv",
         "flake-compat": "flake-compat",
         "git-hooks": "git-hooks",
-        "hs-nix-c-api": "hs-nix-c-api",
+        "nix-bindings-haskell": "nix-bindings-haskell",
         "nixpkgs": "nixpkgs_2"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -302,11 +302,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774551687,
-        "narHash": "sha256-Q0x21f72bOO+66tM69peHYUJr8bsiCgR0w7Xb8NZcyI=",
+        "lastModified": 1774560645,
+        "narHash": "sha256-2Oc2pdJZtAJT3uRyWCDtTcJF0O60eiVi9NGinBCxPOQ=",
         "owner": "cachix",
         "repo": "hs-nix-c-api",
-        "rev": "1e7ada5e34a1886eea101eff40890cd8cf1cb607",
+        "rev": "1ecd76534b3d2db0938b994710a09ef5d81176dd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -79,6 +79,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -92,6 +108,64 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "hs-nix-c-api",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -139,6 +213,41 @@
         "type": "github"
       }
     },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "hs-nix-c-api",
+          "nix"
+        ],
+        "gitignore": [
+          "hs-nix-c-api",
+          "nix"
+        ],
+        "nixpkgs": [
+          "hs-nix-c-api",
+          "nix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "hs-nix-c-api",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -157,6 +266,69 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hs-bindgen": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "libclang-bindings-src": "libclang-bindings-src",
+        "nixpkgs": [
+          "hs-nix-c-api",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774379170,
+        "narHash": "sha256-lZV6IdCBf8uCt21qB5mfgLaP9CNgho/HsqjvkulDR2Q=",
+        "owner": "well-typed",
+        "repo": "hs-bindgen",
+        "rev": "4b6febb5cc6196835bd2890a3ab27a88dab1806b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "well-typed",
+        "repo": "hs-bindgen",
+        "type": "github"
+      }
+    },
+    "hs-nix-c-api": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "hs-bindgen": "hs-bindgen",
+        "nix": "nix_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774505671,
+        "narHash": "sha256-zv52RyDsSSYwXC7Edv7BxZ+DMzKdW+/RsZhaztTtyDM=",
+        "owner": "cachix",
+        "repo": "hs-nix-c-api",
+        "rev": "32f0713f6c71d28bb1df417ff9bf2a77ebdf3102",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "hs-nix-c-api",
+        "type": "github"
+      }
+    },
+    "libclang-bindings-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774015466,
+        "narHash": "sha256-tYPETZy3OXLe6IMLajXxmHyCn9Pzwp8rQ5mpldL4vfY=",
+        "owner": "well-typed",
+        "repo": "libclang",
+        "rev": "607cdbcbcfeb2b1e2f49cb75076213051cb80e97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "well-typed",
+        "repo": "libclang",
+        "rev": "607cdbcbcfeb2b1e2f49cb75076213051cb80e97",
         "type": "github"
       }
     },
@@ -200,6 +372,30 @@
         "type": "github"
       }
     },
+    "nix_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts_4",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1774493711,
+        "narHash": "sha256-xQqNVk6qjWrsG8KnKH/O7Dl5leYSucnZtxRihKz0aGw=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "029becbe2fc65eb252facd2322610f8ac5b1dd15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "feat-query-path-info-json",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixd": {
       "inputs": {
         "flake-parts": [
@@ -229,6 +425,81 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1771903837,
+        "narHash": "sha256-jEA8WggGKtMFeNeCKq3NK8cLEjJmG6/RLUElYYbBZ0E=",
+        "rev": "e764fc9a405871f1f6ca3d1394fb422e0a0c3951",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/25.11/nixos-25.11.6495.e764fc9a4058/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs-23-11": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1772624091,
         "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "NixOS",
@@ -248,7 +519,8 @@
         "devenv": "devenv",
         "flake-compat": "flake-compat",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs"
+        "hs-nix-c-api": "hs-nix-c-api",
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "treefmt-nix": {

--- a/flake.lock
+++ b/flake.lock
@@ -302,11 +302,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774505671,
-        "narHash": "sha256-zv52RyDsSSYwXC7Edv7BxZ+DMzKdW+/RsZhaztTtyDM=",
+        "lastModified": 1774551687,
+        "narHash": "sha256-Q0x21f72bOO+66tM69peHYUJr8bsiCgR0w7Xb8NZcyI=",
         "owner": "cachix",
         "repo": "hs-nix-c-api",
-        "rev": "32f0713f6c71d28bb1df417ff9bf2a77ebdf3102",
+        "rev": "1e7ada5e34a1886eea101eff40890cd8cf1cb607",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -227,19 +227,14 @@
           "nix-bindings-haskell",
           "nix",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nix-bindings-haskell",
-          "nix",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1734279981,
-        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -359,15 +354,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1775604664,
-        "narHash": "sha256-OGdllLqWyWfR91tK+Kt1ndmVg2P/Q6EDvePHB7gvmxE=",
+        "lastModified": 1778088650,
+        "narHash": "sha256-Ctw/xEQ+8QaIbzruWCO9cN9sVs5AWhSt85+baZTI3YA=",
         "owner": "cachix",
         "repo": "nix-bindings-haskell",
-        "rev": "5c7ff694e8bce836eecf6679e0d19c481520dd06",
+        "rev": "316baf1ac87d90f4de8c4db29ed66b21cab792ec",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "ca-derivations",
         "repo": "nix-bindings-haskell",
         "type": "github"
       }
@@ -382,16 +378,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1775584026,
-        "narHash": "sha256-mNMlEs5VpSy14fZBepBKyK9E+9Pdxgod9zVr0n7wgHQ=",
+        "lastModified": 1778079741,
+        "narHash": "sha256-qAj6qezumCDIAD2T6LUDWBQDsBCoMZ9y92FBjRKgV6c=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "528fc271dc73d550b3899d4ce8651b3c8ab5970c",
+        "rev": "03c770ab058ffd70184f2539fe49bc70fbf9b763",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "feat-query-path-info",
+        "ref": "cachix",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hs-nix-c-api = {
+      url = "github:cachix/hs-nix-c-api";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -45,18 +49,22 @@
       # Keep in sync with stack.yaml
       ghcVersion = "910";
 
-      # Try to use the same Nix version as cnix-store, if available.
-      getNix =
-        {
-          pkgs,
-          haskellPackages ? pkgs.haskellPackages,
-        }:
-        haskellPackages.hercules-ci-cnix-store.nixPackage or pkgs.nix;
+      # Nix C API packages from hs-nix-c-api's Nix fork.
+      getNixCApiPkgs = system:
+        with inputs.hs-nix-c-api.inputs.nix.packages.${system}; [
+          nix-util-c
+          nix-store-c
+          nix-expr-c
+          nix-fetchers-c
+          nix-flake-c
+          nix-main-c
+        ];
 
       customHaskellPackages =
         {
           pkgs,
           haskellPackages ? pkgs.haskellPackages,
+          hs-nix-c-api ? inputs.hs-nix-c-api.packages.${pkgs.system}.hs-nix-c-api,
         }@args:
         let
           hlib = pkgs.haskell.lib;
@@ -64,14 +72,14 @@
           cachix =
             hlib.overrideCabal
               (haskellPackages.callCabal2nix "cachix" ./cachix {
-                inherit cachix-api;
+                inherit cachix-api hs-nix-c-api;
                 hnix-store-core = haskellPackages.hnix-store-core_0_8_0_0 or haskellPackages.hnix-store-core;
-                nix = getNix args;
               })
-              # Apply a fix for a bug in GHC 9.10.3 that fails to load libraries using weak references on macOS 26.
-              # https://github.com/NixOS/nixpkgs/pull/469906
               (
                 old: {
+                  pkg-configDepends = getNixCApiPkgs pkgs.system;
+                  # Apply a fix for a bug in GHC 9.10.3 that fails to load libraries using weak references on macOS 26.
+                  # https://github.com/NixOS/nixpkgs/pull/469906
                   preBuild = ''
                     DYLD_INSERT_LIBRARIES="''${DYLD_INSERT_LIBRARIES:+$DYLD_INSERT_LIBRARIES:}$(pkg-config --variable=libdir nix-store)/libnixstore.dylib:$(pkg-config --variable=libdir nix-util)/libnixutil.dylib"
                     export DYLD_INSERT_LIBRARIES
@@ -129,7 +137,7 @@
           default = inputs.devenv.lib.mkShell {
             inherit inputs pkgs;
             modules = [
-              ({ _module.args = { inherit ghcVersion getNix; }; })
+              ({ _module.args = { inherit ghcVersion; nixCApiPkgs = getNixCApiPkgs system; }; })
               ./devenv.nix
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,8 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    hs-nix-c-api = {
-      url = "github:cachix/hs-nix-c-api";
+    nix-bindings-haskell = {
+      url = "github:cachix/nix-bindings-haskell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     git-hooks = {
@@ -49,9 +49,9 @@
       # Keep in sync with stack.yaml
       ghcVersion = "910";
 
-      # Nix C API packages from hs-nix-c-api's Nix fork.
-      getNixCApiPkgs = system:
-        with inputs.hs-nix-c-api.inputs.nix.packages.${system}; [
+      # Nix C API packages from nix-bindings-haskell's Nix fork.
+      getNixCApiPkgs =
+        system: with inputs.nix-bindings-haskell.inputs.nix.packages.${system}; [
           nix-util-c
           nix-store-c
           nix-expr-c
@@ -65,7 +65,7 @@
           pkgs,
           system,
           haskellPackages ? pkgs.haskellPackages,
-          hs-nix-c-api ? inputs.hs-nix-c-api.packages.${system}.hs-nix-c-api,
+          nix-bindings ? inputs.nix-bindings-haskell.packages.${system}.nix-bindings,
         }@args:
         let
           hlib = pkgs.haskell.lib;
@@ -73,22 +73,20 @@
           cachix =
             hlib.overrideCabal
               (haskellPackages.callCabal2nix "cachix" ./cachix {
-                inherit cachix-api hs-nix-c-api;
+                inherit cachix-api nix-bindings;
                 hnix-store-core = haskellPackages.hnix-store-core_0_8_0_0 or haskellPackages.hnix-store-core;
               })
-              (
-                old: {
-                  pkg-configDepends = getNixCApiPkgs system;
-                  # Apply a fix for a bug in GHC 9.10.3 that fails to load libraries using weak references on macOS 26.
-                  # https://github.com/NixOS/nixpkgs/pull/469906
-                  preBuild = ''
-                    DYLD_INSERT_LIBRARIES="''${DYLD_INSERT_LIBRARIES:+$DYLD_INSERT_LIBRARIES:}$(pkg-config --variable=libdir nix-store)/libnixstore.dylib:$(pkg-config --variable=libdir nix-util)/libnixutil.dylib"
-                    export DYLD_INSERT_LIBRARIES
-                    echo "DYLD_INSERT_LIBRARIES=$DYLD_INSERT_LIBRARIES"
-                  ''
-                  + (old.preBuild or "");
-                }
-              );
+              (old: {
+                pkg-configDepends = getNixCApiPkgs system;
+                # Apply a fix for a bug in GHC 9.10.3 that fails to load libraries using weak references on macOS 26.
+                # https://github.com/NixOS/nixpkgs/pull/469906
+                preBuild = ''
+                  DYLD_INSERT_LIBRARIES="''${DYLD_INSERT_LIBRARIES:+$DYLD_INSERT_LIBRARIES:}$(pkg-config --variable=libdir nix-store)/libnixstore.dylib:$(pkg-config --variable=libdir nix-util)/libnixutil.dylib"
+                  export DYLD_INSERT_LIBRARIES
+                  echo "DYLD_INSERT_LIBRARIES=$DYLD_INSERT_LIBRARIES"
+                ''
+                + (old.preBuild or "");
+              });
         in
         {
           inherit cachix cachix-api;
@@ -138,7 +136,12 @@
           default = inputs.devenv.lib.mkShell {
             inherit inputs pkgs;
             modules = [
-              ({ _module.args = { inherit ghcVersion; nixCApiPkgs = getNixCApiPkgs system; }; })
+              ({
+                _module.args = {
+                  inherit ghcVersion;
+                  nixCApiPkgs = getNixCApiPkgs system;
+                };
+              })
               ./devenv.nix
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -63,8 +63,9 @@
       customHaskellPackages =
         {
           pkgs,
+          system,
           haskellPackages ? pkgs.haskellPackages,
-          hs-nix-c-api ? inputs.hs-nix-c-api.packages.${pkgs.system}.hs-nix-c-api,
+          hs-nix-c-api ? inputs.hs-nix-c-api.packages.${system}.hs-nix-c-api,
         }@args:
         let
           hlib = pkgs.haskell.lib;
@@ -77,7 +78,7 @@
               })
               (
                 old: {
-                  pkg-configDepends = getNixCApiPkgs pkgs.system;
+                  pkg-configDepends = getNixCApiPkgs system;
                   # Apply a fix for a bug in GHC 9.10.3 that fails to load libraries using weak references on macOS 26.
                   # https://github.com/NixOS/nixpkgs/pull/469906
                   preBuild = ''
@@ -99,7 +100,7 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           hlib = pkgs.haskell.lib;
-          inherit (customHaskellPackages { inherit pkgs; })
+          inherit (customHaskellPackages { inherit pkgs system; })
             cachix
             cachix-api
             ;

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nix-bindings-haskell = {
-      url = "github:cachix/nix-bindings-haskell";
+      url = "github:cachix/nix-bindings-haskell/ca-derivations";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     git-hooks = {

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,39 @@
         }@args:
         let
           hlib = pkgs.haskell.lib;
+          # CA derivation FFI bindings (hercules-ci/hercules-ci-agent#670)
+          hercules-ci-cnix-store-src =
+            let
+              src =
+                builtins.fetchGit {
+                  url = "https://github.com/hercules-ci/hercules-ci-agent";
+                  rev = "a8a8acd6c77179963da9814f82ca10e61425a0a0";
+                }
+                + "/hercules-ci-cnix-store";
+            in
+            pkgs.runCommand "hercules-ci-cnix-store-src" { } ''
+              cp -r ${src} $out
+              chmod -R u+w $out
+              cat > $out/include/hercules-ci-cnix/store.hxx << 'HEADER'
+              #pragma once
+
+              #include <nix/store/path-info.hh>
+              #include <nix/store/derived-path-map.hh>
+
+              typedef nix::ref<nix::Store> refStore;
+
+              typedef nix::Strings::iterator StringsIterator;
+              typedef nix::DerivationOutputs::iterator DerivationOutputsIterator;
+              typedef nix::StringPairs::iterator StringPairsIterator;
+              typedef nix::PathSet::iterator PathSetIterator;
+              typedef nix::ref<const nix::ValidPathInfo> refValidPathInfo;
+
+              typedef nix::DerivedPathMap<std::set<nix::OutputName, std::less<>>>::Map::iterator DerivationInputsIterator;
+              HEADER
+            '';
+          hercules-ci-cnix-store =
+            haskellPackages.callCabal2nix "hercules-ci-cnix-store" hercules-ci-cnix-store-src
+              { nix = pkgs.nix; };
           cachix-api = haskellPackages.callCabal2nix "cachix-api" ./cachix-api { };
           cachix =
             hlib.overrideCabal


### PR DESCRIPTION
## Summary

Rebased on top of #725 (`feat-nix-bindings-haskell`). Implements CA derivation realisation push using the new bindings from cachix/nix-bindings-haskell#2 instead of `Hercules.CNix.Store`.

- New \`pushRealisations\` walks the drv input graph via \`derivationInputDrvOutputs\` (the new C API does not expose \`dependentRealisations\`, so we recurse on input derivations to collect the same set).
- Skips recursion when \`nix_derivation_has_dynamic_inputs\` is true.
- Adds \`piCa\` to \`PathInfo\`, populated from \`pathInfoCa\` on the JSON path-info; uses \`PathInfoJsonFormatV3\` so references and deriver come back as basenames.
- \`Cachix.Types.Realisation\` + \`API.putRealisations\` already in cachix-api from the prior commit.

## Depends on

- cachix/nix#cachix (already merged into the bindings flake input via #2)
- cachix/nix-bindings-haskell#2

## Test plan

- [x] cachix builds + tests pass via \`nix build .#cachix\`
- [x] cachix-server's NixOS \`ca-derivations-latest\` test exercises the full push/pull path including realisations endpoint roundtrip and auth enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)