### PR TITLE
narinfo: add If-None-Match request header and ETag response header

### DIFF
--- a/cachix-api/src/Cachix/API.hs
+++ b/cachix-api/src/Cachix/API.hs
@@ -47,7 +47,8 @@ data BinaryCacheAPI route = BinaryCacheAPI
           :> "cache"
           :> Capture "name" Text
           :> Capture "narinfohash" NarInfoHash.NarInfoHash
-          :> Get '[XNixNarInfo, JSON] (Headers '[Header "Cache-Control" Text] NarInfo.CachixNarInfo),
+          :> Header "If-None-Match" Text
+          :> Get '[XNixNarInfo, JSON] (Headers '[Header "ETag" Text, Header "Cache-Control" Text] NarInfo.CachixNarInfo),
     narinfoHead ::
       route
         :- CachixAuth


### PR DESCRIPTION
Adds an `If-None-Match` request header and an `ETag` response header to the `narinfo` route.

This lets caching proxies (e.g. nginx with `proxy_cache_revalidate on`) revalidate a narinfo with a conditional GET and receive a `304 Not Modified` instead of re-downloading the body and rewriting the cache file. The server-side handler computes a strong SHA256 ETag over the serialized narinfo bytes and honors `If-None-Match`.

Purely additive to the API type: the request header is optional and the response gains a header, so existing clients are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)