### PR TITLE
docs: fix broken CI status badge (Test -> Build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## [Cachix](https://cachix.org) - Nix binary cache hosting: Never build software twice.
 
-[![Test](https://github.com/cachix/cachix/workflows/Test/badge.svg)](https://github.com/cachix/cachix/actions)
+[![Build](https://github.com/cachix/cachix/actions/workflows/build.yml/badge.svg)](https://github.com/cachix/cachix/actions)
 [![Hackage](https://img.shields.io/hackage/v/cachix.svg)](https://hackage.haskell.org/package/cachix)
 
 ```


### PR DESCRIPTION
The "Test" badge referenced a no-longer-existing workflow, which rendered as a broken image on GitHub. Rename the badge to "Build" and point it to the workflow described by `actions/workflows/build.yml`.
