### PR TITLE
nixconf: manage caches via an !include fragment (#413)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: cachix/install-nix-action@v31
 
     - name: Setup read-only Cachix cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       created: ${{ steps.autotag.outputs.created }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     # Assume that the versions for cachix and cachix-api are kept in sync.
     - uses: sol/haskell-autotag@v1
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: cachix/install-nix-action@v31
     - uses: cachix/cachix-action@v17
       with:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Config commands:
 
 Cache commands:
   generate-keypair         Generate a signing key pair for a binary cache
-  use                      Configure a binary cache in nix.conf
-  remove                   Remove a binary cache from nix.conf
+  use                      Configure a binary cache in the cachix.conf fragment
+                           included by nix.conf
+  remove                   Remove a binary cache from the cachix.conf fragment
+                           included by nix.conf
 
 Push commands:
   push                     Upload Nix store paths to a binary cache

--- a/cachix-api/CHANGELOG.md
+++ b/cachix-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- narinfo: accept an `If-None-Match` request header and return an `ETag` response header, for conditional GETs
+
 ## [0.7.0] - 2022-01-12
 
 - Support Cachix Deploy

--- a/cachix-api/src/Cachix/API.hs
+++ b/cachix-api/src/Cachix/API.hs
@@ -47,7 +47,8 @@ data BinaryCacheAPI route = BinaryCacheAPI
           :> "cache"
           :> Capture "name" Text
           :> Capture "narinfohash" NarInfoHash.NarInfoHash
-          :> Get '[XNixNarInfo, JSON] (Headers '[Header "Cache-Control" Text] NarInfo.CachixNarInfo),
+          :> Header "If-None-Match" Text
+          :> Get '[XNixNarInfo, JSON] (Headers '[Header "ETag" Text, Header "Cache-Control" Text] NarInfo.CachixNarInfo),
     narinfoHead ::
       route
         :- CachixAuth

--- a/cachix/CHANGELOG.md
+++ b/cachix/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- client: require Nix 2.4 or newer, for both `cachix use` and `cachix remove`
+- `cachix use` now writes caches to a dedicated `cachix.conf` fragment, pulled into `nix.conf` with `!include`, so cachix manages only its own file and no longer rewrites your Nix settings. Caches use `extra-substituters` / `extra-trusted-public-keys`, and inline settings written by older versions are migrated into the fragment (with a notice).
+- `cachix use --output-directory` keeps writing a self-contained `nix.conf`, with no fragment involved, so shipping that single file keeps working
+
+### Fixed
+
+- #413: `cachix use` no longer drops or overrides substituters and public keys configured elsewhere, and now leaves substituters/public keys it didn't write untouched instead of sweeping them into the fragment
+- migration only claims inline lines whose first value is the `cache.nixos.org` default, the exact shape older versions wrote, so user-authored lines that merely mention the default stay put; the default is restated in the fragment so setups overriding `substituters` at another level keep `cache.nixos.org` reachable
+- `cachix remove` also removes a leftover trusted public key when the substituter is already gone, names the file it actually changed, and points out a matching substituter it does not manage instead of claiming no cache was found
+- a stale `netrc-file` line older versions wrote into `nix.conf` is moved into the fragment on the next `cachix use`, including for public caches
+- lines with inline `#` comments and Nix 1.0 alias keys (`binary-caches`, `binary-cache-public-keys`) are preserved byte for byte instead of being reparsed and rewritten
+- `cachix use` and `cachix remove` abort when an existing config file cannot be read, instead of treating it as empty and overwriting it on the next write
+- when `nix.conf` is not writable (for example managed by home-manager or nix-darwin), `cachix use` explains how to add the `!include` line manually instead of failing with a bare IO error
+
 ## [1.11.1] - 2026-04-29
 
 ### Added

--- a/cachix/CHANGELOG.md
+++ b/cachix/CHANGELOG.md
@@ -9,19 +9,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- client: require Nix 2.4 or newer, for both `cachix use` and `cachix remove`
-- `cachix use` now writes caches to a dedicated `cachix.conf` fragment, pulled into `nix.conf` with `!include`, so cachix manages only its own file and no longer rewrites your Nix settings. Caches use `extra-substituters` / `extra-trusted-public-keys`, and inline settings written by older versions are migrated into the fragment (with a notice).
+- client: require Nix 2.4 or newer, for both `cachix use` and `cachix remove`. Pre-release builds of exactly 2.4 (nixUnstable snapshots from 2019 to 2021) count as older than 2.4 and are rejected.
+- `cachix use` now writes caches to a dedicated `cachix.conf` fragment, pulled into `nix.conf` with `!include`, so cachix manages only its own file and no longer rewrites your Nix settings. Caches use `extra-substituters` / `extra-trusted-public-keys`, and inline settings written by older versions are migrated into the fragment (with a notice listing the migrated values).
 - `cachix use --output-directory` keeps writing a self-contained `nix.conf`, with no fragment involved, so shipping that single file keeps working
+- `cachix remove` accepts the same `--mode` and `--output-directory` options as `cachix use`, so caches can be removed from a self-contained `nix.conf` as well
 
 ### Fixed
 
 - #413: `cachix use` no longer drops or overrides substituters and public keys configured elsewhere, and now leaves substituters/public keys it didn't write untouched instead of sweeping them into the fragment
-- migration only claims inline lines whose first value is the `cache.nixos.org` default, the exact shape older versions wrote, so user-authored lines that merely mention the default stay put; the default is restated in the fragment so setups overriding `substituters` at another level keep `cache.nixos.org` reachable
-- `cachix remove` also removes a leftover trusted public key when the substituter is already gone, names the file it actually changed, and points out a matching substituter it does not manage instead of claiming no cache was found
+- migration only claims inline lines that match the exact shape older versions wrote: both the `substituters` and `trusted-public-keys` lines present, each led by the `cache.nixos.org` default. A lone marker-led line (a shape users write by hand to override defaults) and lines that merely mention the default stay put. The default is restated in the fragment so setups overriding `substituters` at another level keep `cache.nixos.org` reachable.
+- migration only runs when `nix.conf` is writable: on a read-only `nix.conf` (for example managed by home-manager or nix-darwin) legacy lines are left in place with a notice, so `cachix use` succeeds once the `!include` line is present instead of failing on every run
+- `cachix remove` also removes a leftover trusted public key when the substituter is already gone, names the file it actually changed, and points out a matching substituter it does not manage (also modulo a trailing slash, on commented lines, and on Nix 1.0 alias lines) instead of claiming no cache was found, including when a managed entry was removed but an unmanaged copy remains
+- `cachix remove` no longer adds the `!include cachix.conf` line to a `nix.conf` that lacked it, so a removal cannot re-activate the remaining caches in the fragment
 - a stale `netrc-file` line older versions wrote into `nix.conf` is moved into the fragment on the next `cachix use`, including for public caches
-- lines with inline `#` comments and Nix 1.0 alias keys (`binary-caches`, `binary-cache-public-keys`) are preserved byte for byte instead of being reparsed and rewritten
-- `cachix use` and `cachix remove` abort when an existing config file cannot be read, instead of treating it as empty and overwriting it on the next write
-- when `nix.conf` is not writable (for example managed by home-manager or nix-darwin), `cachix use` explains how to add the `!include` line manually instead of failing with a bare IO error
+- lines with inline `#` comments and Nix 1.0 alias keys (`binary-caches`, `binary-cache-public-keys`) are preserved byte for byte instead of being reparsed and rewritten, and their values are still honored when detecting trusted users and configured substituters
+- `extra-trusted-users` is now recognized when detecting trusted users
+- values in a `netrc-file` path with spaces are no longer mangled on a rewrite, blank lines after assignments are preserved, and stray empty values from trailing whitespace are dropped
+- `cachix use` and `cachix remove` abort with a clean error when an existing config file cannot be read, instead of treating it as empty and overwriting it on the next write
+- all config writes (`nix.conf`, the fragment, and `--output-directory` files) explain what to do when the file is not writable instead of failing with a bare IO error; the `!include` hint recognizes an existing include spelled with an absolute path
+- `cachix use` and `cachix remove` print a clean error when `nix-env` is not on the PATH instead of crashing with a raw IO exception
 
 ## [1.11.1] - 2026-04-29
 

--- a/cachix/CHANGELOG.md
+++ b/cachix/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `cachix use` and `cachix remove` abort with a clean error when an existing config file cannot be read, instead of treating it as empty and overwriting it on the next write
 - all config writes (`nix.conf`, the fragment, and `--output-directory` files) explain what to do when the file is not writable instead of failing with a bare IO error; the `!include` hint recognizes an existing include spelled with an absolute path
 - `cachix use` and `cachix remove` print a clean error when `nix-env` is not on the PATH instead of crashing with a raw IO exception
+- the netrc file for private caches is only rewritten (and its notice only printed) when its contents actually change, so repeated `cachix use` runs are fully idempotent; a rotated auth token still updates it
 
 ## [1.11.1] - 2026-04-29
 

--- a/cachix/src/Cachix/Client.hs
+++ b/cachix/src/Cachix/Client.hs
@@ -51,7 +51,7 @@ main = displayConsoleRegions $ do
     Push (PushPaths opts name cliPaths) -> Command.push env opts name cliPaths
     Push (PushWatchStore _ _) ->
       throwIO $ DeprecatedCommand "DEPRECATED: cachix watch-store has replaced cachix push --watch-store."
-    Remove name -> Command.remove env name
+    Remove name useOptions -> Command.remove env name useOptions
     Use name useOptions -> Command.use env name useOptions
     Version -> putText cachixVersion
     WatchExec watchExecMode pushArgs batchOptions name cmd args ->

--- a/cachix/src/Cachix/Client/Command/Cache.hs
+++ b/cachix/src/Cachix/Client/Command/Cache.hs
@@ -23,8 +23,8 @@ use env name useOptions = do
       InstallationMode.addBinaryCache (config env) binaryCache useOptions $
         InstallationMode.getInstallationMode nixEnv useOptions
 
-remove :: Env -> Text -> IO ()
-remove env name = do
+remove :: Env -> Text -> InstallationMode.UseOptions -> IO ()
+remove env name useOptions = do
   nixEnv <- InstallationMode.requireNixEnv
   InstallationMode.removeBinaryCache (Config.hostname $ config env) name $
-    InstallationMode.getInstallationMode nixEnv InstallationMode.defaultUseOptions
+    InstallationMode.getInstallationMode nixEnv useOptions

--- a/cachix/src/Cachix/Client/Command/Cache.hs
+++ b/cachix/src/Cachix/Client/Command/Cache.hs
@@ -1,13 +1,10 @@
 module Cachix.Client.Command.Cache (use, remove) where
 
 import Cachix.API qualified as API
-import Cachix.API.Error
 import Cachix.Client.Command.Push qualified as Push
 import Cachix.Client.Config qualified as Config
 import Cachix.Client.Env (Env (..))
-import Cachix.Client.Exception (CachixException (..))
 import Cachix.Client.InstallationMode qualified as InstallationMode
-import Cachix.Client.NixVersion (assertNixVersion)
 import Cachix.Client.Retry (retryClientM)
 import Cachix.Client.Servant
 import Protolude hiding (toS)
@@ -22,13 +19,12 @@ use env name useOptions = do
   case res of
     Left err -> Push.handleCacheResponse name optionalAuthToken err
     Right binaryCache -> do
-      () <- escalateAs UnsupportedNixVersion =<< assertNixVersion
-      nixEnv <- InstallationMode.getNixEnv
+      nixEnv <- InstallationMode.requireNixEnv
       InstallationMode.addBinaryCache (config env) binaryCache useOptions $
         InstallationMode.getInstallationMode nixEnv useOptions
 
 remove :: Env -> Text -> IO ()
 remove env name = do
-  nixEnv <- InstallationMode.getNixEnv
+  nixEnv <- InstallationMode.requireNixEnv
   InstallationMode.removeBinaryCache (Config.hostname $ config env) name $
     InstallationMode.getInstallationMode nixEnv InstallationMode.defaultUseOptions

--- a/cachix/src/Cachix/Client/Exception.hs
+++ b/cachix/src/Cachix/Client/Exception.hs
@@ -23,6 +23,8 @@ data CachixException
   | ImportUnsupportedHash Text
   | RemoveCacheUnsupported Text
   | InvalidStorePath Text
+  | NixConfParseError Text
+  | NixConfWriteFailed Text
   deriving (Show, Typeable)
 
 instance Exception CachixException where
@@ -46,3 +48,5 @@ instance Exception CachixException where
   displayException (ImportUnsupportedHash s) = toS s
   displayException (RemoveCacheUnsupported s) = toS s
   displayException (InvalidStorePath s) = toS s
+  displayException (NixConfParseError s) = toS s
+  displayException (NixConfWriteFailed s) = toS s

--- a/cachix/src/Cachix/Client/Exception.hs
+++ b/cachix/src/Cachix/Client/Exception.hs
@@ -24,6 +24,7 @@ data CachixException
   | RemoveCacheUnsupported Text
   | InvalidStorePath Text
   | NixConfParseError Text
+  | NixConfReadFailed Text
   | NixConfWriteFailed Text
   deriving (Show, Typeable)
 
@@ -49,4 +50,5 @@ instance Exception CachixException where
   displayException (RemoveCacheUnsupported s) = toS s
   displayException (InvalidStorePath s) = toS s
   displayException (NixConfParseError s) = toS s
+  displayException (NixConfReadFailed s) = toS s
   displayException (NixConfWriteFailed s) = toS s

--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -4,6 +4,7 @@ module Cachix.Client.InstallationMode
   ( InstallationMode (..),
     NixEnv (..),
     getNixEnv,
+    requireNixEnv,
     getInstallationMode,
     addBinaryCache,
     removeBinaryCache,
@@ -16,11 +17,13 @@ module Cachix.Client.InstallationMode
   )
 where
 
+import Cachix.API.Error (escalateAs)
 import Cachix.Client.Config (Config)
 import Cachix.Client.Config qualified as Config
 import Cachix.Client.Exception (CachixException (..))
 import Cachix.Client.NetRc qualified as NetRc
 import Cachix.Client.NixConf qualified as NixConf
+import Cachix.Client.NixVersion (assertNixVersion)
 import Cachix.Client.URI qualified as URI
 import Cachix.Types.BinaryCache qualified as BinaryCache
 import Data.Maybe qualified
@@ -81,7 +84,12 @@ toString UntrustedNixOS = "untrusted-nixos"
 getNixEnv :: IO NixEnv
 getNixEnv = do
   user <- getUser
-  ncs <- NixConf.resolveIncludes =<< NixConf.readWithDefault NixConf.Global
+  -- The global nix.conf is only inspected for trusted users here, never
+  -- written back, so an unreadable file can safely degrade to an empty one.
+  globalConf <-
+    NixConf.read NixConf.Global
+      >>= maybe (NixConf.new <$> NixConf.getFilename NixConf.Global) pure
+  ncs <- NixConf.resolveIncludes globalConf
   isTrusted <- isTrustedUser $ concatMap (NixConf.readLines NixConf.isTrustedUsers) ncs
   isNixOS <- doesFileExist "/run/current-system/nixos-version"
   return $
@@ -90,6 +98,13 @@ getNixEnv = do
         isTrusted = isTrusted,
         isNixOS = isNixOS
       }
+
+-- | Assert the installed Nix is new enough, then resolve the environment
+-- both `cachix use` and `cachix remove` need before touching nix.conf.
+requireNixEnv :: IO NixEnv
+requireNixEnv = do
+  () <- escalateAs UnsupportedNixVersion =<< assertNixVersion
+  getNixEnv
 
 getInstallationMode :: NixEnv -> UseOptions -> InstallationMode
 getInstallationMode nixenv useOptions
@@ -136,72 +151,163 @@ b) Run the following command to add your user as trusted
 |]
 addBinaryCache config bc useOptions WriteNixOS =
   nixosBinaryCache config bc useOptions
+-- A custom output directory (--output-directory) is a fully cachix-generated
+-- artifact meant to be shipped elsewhere, so its nix.conf stays
+-- self-contained instead of splitting the caches into a fragment.
+addBinaryCache config bc _ (Install ncl@(NixConf.Custom _)) = do
+  nixConf <- NixConf.readWithDefault ncl
+  unless (BinaryCache.isPublic bc) $ void $ addPrivateBinaryCacheNetRC config bc ncl
+  _ <- writeIfChanged nixConf (nixConf {NixConf.nixConfLines = NixConf.addCacheStandalone bc (NixConf.nixConfLines nixConf)})
+  putStrLn $ "Configured " <> BinaryCache.uri bc <> " binary cache in " <> toS (NixConf.nixConfPath nixConf)
 addBinaryCache config bc _ (Install ncl) = do
-  (input, output) <- prepareNixConf ncl
+  (nixConf, fragment) <- resolveNixConfAndFragment ncl
   netrcLocMaybe <- forM (guard $ not (BinaryCache.isPublic bc)) $ const $ addPrivateBinaryCacheNetRC config bc ncl
-  let addNetRCLine :: NixConf.NixConfSource -> NixConf.NixConfSource
-      addNetRCLine = fromMaybe identity $ do
-        netrcLoc <- netrcLocMaybe :: Maybe FilePath
-        -- We only add the netrc line for local user configs for now.
-        -- On NixOS we assume it will be picked up from the default location.
-        guard (ncl == NixConf.Local)
-        pure $ setNetRC (toS netrcLoc)
-  NixConf.write $ addNetRCLine $ NixConf.add bc input output
-  filename <- NixConf.getFilename ncl
-  putStrLn $ "Configured " <> BinaryCache.uri bc <> " binary cache in " <> toS filename
-
--- | Resolve and read the nix.conf.
---
--- Returns a set of "input" confs and the "output" conf.
---
--- The output is the parsed conf file at the location specified by the NixConfLoc.
---
--- Inputs are any confs included by the output conf, plus any additional external resolutions.
--- For example, for the local Nix conf, we also return the global one.
-prepareNixConf :: NixConf.NixConfLoc -> IO ([NixConf.NixConfSource], NixConf.NixConfSource)
-prepareNixConf ncl = do
-  outputPath <- NixConf.getFilename ncl
-  -- TODO: might need locking one day
-  gnc <- NixConf.read NixConf.Global
-  gncInputs <- traverse NixConf.resolveIncludes gnc
-
-  (input, output) <-
-    case ncl of
-      NixConf.Global -> do
-        return (gncInputs, gnc)
-      NixConf.Local -> do
-        lnc <- NixConf.read NixConf.Local
-        lncInputs <- traverse NixConf.resolveIncludes lnc
-        return (gncInputs <> lncInputs, lnc)
-      NixConf.Custom _ -> do
-        lnc <- NixConf.read ncl
-        lncInputs <- traverse NixConf.resolveIncludes lnc
-        return (lncInputs, lnc)
-
-  return
-    ( fromMaybe [] input,
-      fromMaybe (NixConf.new outputPath) output
-    )
+  let managedNetRC = toS (replaceFileName (NixConf.nixConfPath nixConf) "netrc") :: Text
+      NixConf.NixConf nixConfLs = NixConf.nixConfLines nixConf
+      -- Older cachix wrote the netrc-file line straight into nix.conf.
+      hasLegacyNetRC = NixConf.NetRcFile managedNetRC `elem` nixConfLs
+      -- We only manage the netrc line for local user configs for now.
+      -- On NixOS we assume it will be picked up from the default location.
+      addNetRCLine :: NixConf.NixConfSource -> NixConf.NixConfSource
+      addNetRCLine
+        | ncl /= NixConf.Local = identity
+        | Just netrcLoc <- netrcLocMaybe = setNetRC (toS netrcLoc)
+        -- Keep a legacy netrc line working by moving it into the fragment.
+        | hasLegacyNetRC = setNetRC managedNetRC
+        | otherwise = identity
+      -- Drop the stale copy from nix.conf once the fragment carries it. Only
+      -- the exact path cachix manages is matched, so a netrc-file setting the
+      -- user authored themselves is left alone.
+      clearStaleNetRCLine :: NixConf.NixConfSource -> NixConf.NixConfSource
+      clearStaleNetRCLine
+        | ncl == NixConf.Local = clearNetRC managedNetRC
+        | otherwise = identity
+      (nixConf', fragment') = NixConf.addCache bc (NixConf.nixConfLines nixConf) (NixConf.nixConfLines fragment)
+  printMigrationNotice nixConf fragment
+  _ <- writeIfChanged fragment (addNetRCLine (fragment {NixConf.nixConfLines = fragment'}))
+  writeNixConfWithHint fragment nixConf (clearStaleNetRCLine (nixConf {NixConf.nixConfLines = nixConf'}))
+  putStrLn $ "Configured " <> BinaryCache.uri bc <> " binary cache in " <> toS (NixConf.nixConfPath fragment)
 
 removeBinaryCache :: URI.URI -> Text -> InstallationMode -> IO ()
-removeBinaryCache uri name (Install ncl) = do
-  contents <- NixConf.readWithDefault ncl
-  let (final, removed) = NixConf.remove uri name [contents] contents
-  NixConf.write final
-  filename <- NixConf.getFilename ncl
+removeBinaryCache uri name (Install ncl@(NixConf.Custom _)) = do
+  nixConf <- NixConf.readWithDefault ncl
+  let (nixConf', removed) = NixConf.removeCacheStandalone uri name (NixConf.nixConfLines nixConf)
   if removed
-    then putStrLn $ "Removed " <> host <> " binary cache in " <> toS filename
-    else putStrLn $ "No " <> host <> " binary cache found in " <> toS filename
-  where
-    host = URI.toByteString (URI.appendSubdomain name uri)
+    then do
+      _ <- writeIfChanged nixConf (nixConf {NixConf.nixConfLines = nixConf'})
+      putStrLn $ "Removed " <> host uri name <> " binary cache from " <> (toS (NixConf.nixConfPath nixConf) :: Text)
+    else putStrLn $ "No " <> host uri name <> " binary cache found in " <> (toS (NixConf.nixConfPath nixConf) :: Text)
+removeBinaryCache uri name (Install ncl) = do
+  (nixConf, fragment) <- resolveNixConfAndFragment ncl
+  let ((nixConf', fragment'), removed) =
+        NixConf.removeCache uri name (NixConf.nixConfLines nixConf) (NixConf.nixConfLines fragment)
+      unmanaged = host uri name `elem` NixConf.readLines NixConf.isSubstituter (NixConf.nixConfLines nixConf)
+  if removed
+    then do
+      printMigrationNotice nixConf fragment
+      fragmentWritten <- writeIfChanged fragment (fragment {NixConf.nixConfLines = fragment'})
+      nixConfWritten <- writeIfChanged nixConf (nixConf {NixConf.nixConfLines = nixConf'})
+      let changed =
+            [toS (NixConf.nixConfPath fragment) | fragmentWritten]
+              <> [toS (NixConf.nixConfPath nixConf) | nixConfWritten]
+      putStrLn $
+        "Removed "
+          <> host uri name
+          <> " binary cache"
+          <> (if null changed then "" else " from " <> T.intercalate " and " changed)
+    else
+      if unmanaged
+        then
+          putStrLn $
+            "Found "
+              <> host uri name
+              <> " in "
+              <> (toS (NixConf.nixConfPath nixConf) :: Text)
+              <> ", but cachix does not manage that entry. Remove it manually."
+        else
+          putStrLn $
+            "No "
+              <> host uri name
+              <> " binary cache found in "
+              <> (toS (NixConf.nixConfPath nixConf) :: Text)
+              <> " or "
+              <> toS (NixConf.nixConfPath fragment)
 removeBinaryCache _ _ _ = do
   throwIO $ RemoveCacheUnsupported "Removing binary caches is only supported for nix.conf"
 
+-- | The full substituter URI of the given cache, as it appears in nix.conf.
+host :: URI.URI -> Text -> Text
+host uri name = toS $ URI.toByteString (URI.appendSubdomain name uri)
+
+-- | Resolve the nix.conf at the given location and the cachix.conf fragment
+-- it includes, reading both from disk.
+resolveNixConfAndFragment :: NixConf.NixConfLoc -> IO (NixConf.NixConfSource, NixConf.NixConfSource)
+resolveNixConfAndFragment ncl = do
+  nixConfPath <- NixConf.getFilename ncl
+  let fragmentPath = replaceFileName nixConfPath (toS NixConf.cachixConf)
+  nixConf <- NixConf.readPathWithDefault nixConfPath
+  -- The fragment is expected to not exist yet on a first run; read it
+  -- quietly rather than printing a "no config" error for that.
+  fragment <- NixConf.readPathQuiet fragmentPath
+  return (nixConf, fragment)
+
+-- | Write the new NixConfSource only if its lines differ from the old one.
+-- Returns whether a write happened.
+writeIfChanged :: NixConf.NixConfSource -> NixConf.NixConfSource -> IO Bool
+writeIfChanged old new
+  | NixConf.nixConfLines old /= NixConf.nixConfLines new = NixConf.write new $> True
+  | otherwise = pure False
+
+-- | Tell the user when settings an older cachix wrote inline into nix.conf
+-- are about to move into the cachix.conf fragment.
+printMigrationNotice :: NixConf.NixConfSource -> NixConf.NixConfSource -> IO ()
+printMigrationNotice nixConf fragment =
+  when (NixConf.legacyCaches (NixConf.nixConfLines nixConf) /= ([], [])) $
+    putErrText $
+      "Migrating cache settings written by an older cachix from "
+        <> toS (NixConf.nixConfPath nixConf)
+        <> " to "
+        <> toS (NixConf.nixConfPath fragment)
+
+-- | Write the nix.conf, and when that fails (commonly a read-only nix.conf
+-- managed by home-manager or nix-darwin) explain how to finish the setup
+-- manually instead of dying with a bare IO error.
+writeNixConfWithHint :: NixConf.NixConfSource -> NixConf.NixConfSource -> NixConf.NixConfSource -> IO ()
+writeNixConfWithHint fragment old new = do
+  result <- try (void (writeIfChanged old new)) :: IO (Either IOException ())
+  case result of
+    Right () -> pure ()
+    Left err -> do
+      let nixConfPath = toS (NixConf.nixConfPath old) :: Text
+          fragmentPath = toS (NixConf.nixConfPath fragment) :: Text
+          errText = toS (displayException err) :: Text
+      throwIO $
+        NixConfWriteFailed
+          [iTrim|
+Could not write to ${nixConfPath}:
+
+  ${errText}
+
+The caches are configured in ${fragmentPath}, but ${nixConfPath} could not be updated to include that file.
+If your nix.conf is managed by home-manager or nix-darwin, add the following line to it and re-run this command:
+
+  !include ${NixConf.cachixConf}
+|]
+
 setNetRC :: Text -> NixConf.NixConfSource -> NixConf.NixConfSource
-setNetRC netrc conf = (fmap . fmap) (\ls -> filter noNetRc ls ++ [NixConf.NetRcFile netrc]) conf
+setNetRC netrc = (fmap . fmap) (\ls -> filter noNetRc ls ++ [NixConf.NetRcFile netrc])
   where
     noNetRc (NixConf.NetRcFile _) = False
     noNetRc _ = True
+
+-- | Drop a stale netrc-file line an older cachix wrote into nix.conf,
+-- matching the exact path cachix manages so a netrc-file setting the user
+-- authored themselves is left alone.
+clearNetRC :: Text -> NixConf.NixConfSource -> NixConf.NixConfSource
+clearNetRC netrc = (fmap . fmap) (filter keep)
+  where
+    keep (NixConf.NetRcFile path) = path /= netrc
+    keep _ = True
 
 nixosBinaryCache :: Config -> BinaryCache.BinaryCache -> UseOptions -> IO ()
 nixosBinaryCache config bc UseOptions {useNixOSFolder = baseDirectory} = do

--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -458,8 +458,10 @@ addPrivateBinaryCacheNetRC config bc nixconf = do
   filename <- (`replaceFileName` "netrc") <$> NixConf.getFilename nixconf
   authToken <- Config.getAuthTokenRequired config
   let netrcfile = fromMaybe filename Nothing -- TODO: get netrc from nixconf
-  NetRc.add authToken [bc] netrcfile
-  putErrText $ "Configured private read access credentials in " <> toS filename
+  written <- NetRc.add authToken [bc] netrcfile
+  when written $
+    putErrText $
+      "Configured private read access credentials in " <> toS filename
   pure filename
 
 isTrustedUser :: [Text] -> IO Bool

--- a/cachix/src/Cachix/Client/InstallationMode.hs
+++ b/cachix/src/Cachix/Client/InstallationMode.hs
@@ -157,10 +157,11 @@ addBinaryCache config bc useOptions WriteNixOS =
 addBinaryCache config bc _ (Install ncl@(NixConf.Custom _)) = do
   nixConf <- NixConf.readWithDefault ncl
   unless (BinaryCache.isPublic bc) $ void $ addPrivateBinaryCacheNetRC config bc ncl
-  _ <- writeIfChanged nixConf (nixConf {NixConf.nixConfLines = NixConf.addCacheStandalone bc (NixConf.nixConfLines nixConf)})
+  _ <- writeWithHint outputDirHint nixConf (nixConf {NixConf.nixConfLines = NixConf.addCacheStandalone bc (NixConf.nixConfLines nixConf)})
   putStrLn $ "Configured " <> BinaryCache.uri bc <> " binary cache in " <> toS (NixConf.nixConfPath nixConf)
 addBinaryCache config bc _ (Install ncl) = do
   (nixConf, fragment) <- resolveNixConfAndFragment ncl
+  migrate <- migrateLegacyMode nixConf
   netrcLocMaybe <- forM (guard $ not (BinaryCache.isPublic bc)) $ const $ addPrivateBinaryCacheNetRC config bc ncl
   let managedNetRC = toS (replaceFileName (NixConf.nixConfPath nixConf) "netrc") :: Text
       NixConf.NixConf nixConfLs = NixConf.nixConfLines nixConf
@@ -172,21 +173,32 @@ addBinaryCache config bc _ (Install ncl) = do
       addNetRCLine
         | ncl /= NixConf.Local = identity
         | Just netrcLoc <- netrcLocMaybe = setNetRC (toS netrcLoc)
-        -- Keep a legacy netrc line working by moving it into the fragment.
-        | hasLegacyNetRC = setNetRC managedNetRC
+        -- Keep a legacy netrc line working by moving it into the fragment,
+        -- but only when nix.conf is writable so the stale copy can also be
+        -- dropped; otherwise the line simply keeps working where it is.
+        | hasLegacyNetRC, NixConf.MigrateLegacy <- migrate = setNetRC managedNetRC
         | otherwise = identity
       -- Drop the stale copy from nix.conf once the fragment carries it. Only
       -- the exact path cachix manages is matched, so a netrc-file setting the
       -- user authored themselves is left alone.
       clearStaleNetRCLine :: NixConf.NixConfSource -> NixConf.NixConfSource
       clearStaleNetRCLine
-        | ncl == NixConf.Local = clearNetRC managedNetRC
+        | ncl == NixConf.Local, NixConf.MigrateLegacy <- migrate = clearNetRC managedNetRC
         | otherwise = identity
-      (nixConf', fragment') = NixConf.addCache bc (NixConf.nixConfLines nixConf) (NixConf.nixConfLines fragment)
-  printMigrationNotice nixConf fragment
-  _ <- writeIfChanged fragment (addNetRCLine (fragment {NixConf.nixConfLines = fragment'}))
-  writeNixConfWithHint fragment nixConf (clearStaleNetRCLine (nixConf {NixConf.nixConfLines = nixConf'}))
-  putStrLn $ "Configured " <> BinaryCache.uri bc <> " binary cache in " <> toS (NixConf.nixConfPath fragment)
+      (nixConf', fragment') = NixConf.addCache bc migrate (NixConf.nixConfPath nixConf) (NixConf.nixConfLines nixConf) (NixConf.nixConfLines fragment)
+      nixConfPathT = toS (NixConf.nixConfPath nixConf) :: Text
+      fragmentPathT = toS (NixConf.nixConfPath fragment) :: Text
+      includeHint =
+        [iTrim|
+The caches are configured in ${fragmentPathT}, but ${nixConfPathT} could not be updated to include that file.
+If your nix.conf is managed by home-manager or nix-darwin, add the following line to it and re-run this command:
+
+  !include ${NixConf.cachixConf}
+|]
+  printMigrationNotice migrate nixConf fragment
+  _ <- writeWithHint fragmentWriteHint fragment (addNetRCLine (fragment {NixConf.nixConfLines = fragment'}))
+  _ <- writeWithHint includeHint nixConf (clearStaleNetRCLine (nixConf {NixConf.nixConfLines = nixConf'}))
+  putStrLn $ "Configured " <> BinaryCache.uri bc <> " binary cache in " <> fragmentPathT
 
 removeBinaryCache :: URI.URI -> Text -> InstallationMode -> IO ()
 removeBinaryCache uri name (Install ncl@(NixConf.Custom _)) = do
@@ -194,50 +206,67 @@ removeBinaryCache uri name (Install ncl@(NixConf.Custom _)) = do
   let (nixConf', removed) = NixConf.removeCacheStandalone uri name (NixConf.nixConfLines nixConf)
   if removed
     then do
-      _ <- writeIfChanged nixConf (nixConf {NixConf.nixConfLines = nixConf'})
+      _ <- writeWithHint outputDirHint nixConf (nixConf {NixConf.nixConfLines = nixConf'})
       putStrLn $ "Removed " <> host uri name <> " binary cache from " <> (toS (NixConf.nixConfPath nixConf) :: Text)
     else putStrLn $ "No " <> host uri name <> " binary cache found in " <> (toS (NixConf.nixConfPath nixConf) :: Text)
 removeBinaryCache uri name (Install ncl) = do
   (nixConf, fragment) <- resolveNixConfAndFragment ncl
-  let ((nixConf', fragment'), removed) =
-        NixConf.removeCache uri name (NixConf.nixConfLines nixConf) (NixConf.nixConfLines fragment)
-      unmanaged = host uri name `elem` NixConf.readLines NixConf.isSubstituter (NixConf.nixConfLines nixConf)
+  migrate <- migrateLegacyMode nixConf
+  let cacheUri = host uri name
+      ((nixConf', fragment'), removed) =
+        NixConf.removeCache uri name migrate (NixConf.nixConfPath nixConf) (NixConf.nixConfLines nixConf) (NixConf.nixConfLines fragment)
+      nixConfPathT = toS (NixConf.nixConfPath nixConf) :: Text
+      fragmentPathT = toS (NixConf.nixConfPath fragment) :: Text
   if removed
     then do
-      printMigrationNotice nixConf fragment
-      fragmentWritten <- writeIfChanged fragment (fragment {NixConf.nixConfLines = fragment'})
-      nixConfWritten <- writeIfChanged nixConf (nixConf {NixConf.nixConfLines = nixConf'})
+      printMigrationNotice migrate nixConf fragment
+      fragmentWritten <- writeWithHint fragmentWriteHint fragment (fragment {NixConf.nixConfLines = fragment'})
+      nixConfWritten <- writeWithHint (removeNixConfHint fragmentPathT) nixConf (nixConf {NixConf.nixConfLines = nixConf'})
       let changed =
-            [toS (NixConf.nixConfPath fragment) | fragmentWritten]
-              <> [toS (NixConf.nixConfPath nixConf) | nixConfWritten]
+            [fragmentPathT | fragmentWritten]
+              <> [nixConfPathT | nixConfWritten]
       putStrLn $
         "Removed "
-          <> host uri name
+          <> cacheUri
           <> " binary cache"
           <> (if null changed then "" else " from " <> T.intercalate " and " changed)
+      -- The cache may also sit in a line cachix does not manage; removing
+      -- the managed entry alone would leave it silently active.
+      when (stillConfigured cacheUri nixConf') $
+        putStrLn $
+          "Note: " <> cacheUri <> " is still configured in " <> nixConfPathT <> " by a line cachix does not manage. Remove it manually."
     else
-      if unmanaged
+      if stillConfigured cacheUri (NixConf.nixConfLines nixConf)
         then
           putStrLn $
             "Found "
-              <> host uri name
+              <> cacheUri
               <> " in "
-              <> (toS (NixConf.nixConfPath nixConf) :: Text)
+              <> nixConfPathT
               <> ", but cachix does not manage that entry. Remove it manually."
         else
           putStrLn $
             "No "
-              <> host uri name
+              <> cacheUri
               <> " binary cache found in "
-              <> (toS (NixConf.nixConfPath nixConf) :: Text)
+              <> nixConfPathT
               <> " or "
-              <> toS (NixConf.nixConfPath fragment)
+              <> fragmentPathT
 removeBinaryCache _ _ _ = do
   throwIO $ RemoveCacheUnsupported "Removing binary caches is only supported for nix.conf"
 
 -- | The full substituter URI of the given cache, as it appears in nix.conf.
 host :: URI.URI -> Text -> Text
-host uri name = toS $ URI.toByteString (URI.appendSubdomain name uri)
+host uri name = URI.serialize (URI.appendSubdomain name uri)
+
+-- | Whether the substituter appears (modulo a trailing slash) among the
+-- substituter lines of the given config, including lines cachix does not
+-- manage such as ones with inline comments or Nix 1.0 alias keys.
+stillConfigured :: Text -> NixConf.NixConf -> Bool
+stillConfigured cacheUri conf =
+  stripSlash cacheUri `elem` fmap stripSlash (NixConf.readLines NixConf.isSubstituter conf)
+  where
+    stripSlash = T.dropWhileEnd (== '/')
 
 -- | Resolve the nix.conf at the given location and the cachix.conf fragment
 -- it includes, reading both from disk.
@@ -258,41 +287,76 @@ writeIfChanged old new
   | NixConf.nixConfLines old /= NixConf.nixConfLines new = NixConf.write new $> True
   | otherwise = pure False
 
--- | Tell the user when settings an older cachix wrote inline into nix.conf
--- are about to move into the cachix.conf fragment.
-printMigrationNotice :: NixConf.NixConfSource -> NixConf.NixConfSource -> IO ()
-printMigrationNotice nixConf fragment =
-  when (NixConf.legacyCaches (NixConf.nixConfLines nixConf) /= ([], [])) $
-    putErrText $
-      "Migrating cache settings written by an older cachix from "
-        <> toS (NixConf.nixConfPath nixConf)
-        <> " to "
-        <> toS (NixConf.nixConfPath fragment)
+-- | Whether legacy inline settings may be migrated out of the nix.conf:
+-- only when the file can actually be rewritten. A read-only nix.conf (e.g.
+-- a home-manager or nix-darwin managed symlink) keeps its legacy lines, so
+-- the command does not fail on every run trying to strip them.
+migrateLegacyMode :: NixConf.NixConfSource -> IO NixConf.MigrateLegacy
+migrateLegacyMode nixConf = do
+  isWritable <- isWritablePath (NixConf.nixConfPath nixConf)
+  pure $ if isWritable then NixConf.MigrateLegacy else NixConf.LeaveLegacy
 
--- | Write the nix.conf, and when that fails (commonly a read-only nix.conf
--- managed by home-manager or nix-darwin) explain how to finish the setup
--- manually instead of dying with a bare IO error.
-writeNixConfWithHint :: NixConf.NixConfSource -> NixConf.NixConfSource -> NixConf.NixConfSource -> IO ()
-writeNixConfWithHint fragment old new = do
-  result <- try (void (writeIfChanged old new)) :: IO (Either IOException ())
+isWritablePath :: FilePath -> IO Bool
+isWritablePath path = do
+  exists <- doesFileExist path
+  if exists
+    then writable <$> getPermissions path
+    else pure True
+
+-- | Tell the user what happens to cache settings an older cachix wrote
+-- inline into nix.conf: migrated into the cachix.conf fragment when nix.conf
+-- is writable, left in place when it is not.
+printMigrationNotice :: NixConf.MigrateLegacy -> NixConf.NixConfSource -> NixConf.NixConfSource -> IO ()
+printMigrationNotice migrate nixConf fragment =
+  case NixConf.legacyCaches (NixConf.nixConfLines nixConf) of
+    ([], []) -> pure ()
+    (substituters, publicKeys) ->
+      case migrate of
+        NixConf.MigrateLegacy -> do
+          putErrText $
+            "Migrating cache settings written by an older cachix from "
+              <> toS (NixConf.nixConfPath nixConf)
+              <> " to "
+              <> toS (NixConf.nixConfPath fragment)
+              <> ":"
+          putErrText $ "  substituters: " <> T.unwords substituters
+          putErrText $ "  trusted-public-keys: " <> T.unwords publicKeys
+        NixConf.LeaveLegacy ->
+          putErrText $
+            toS (NixConf.nixConfPath nixConf)
+              <> " is not writable; leaving cache settings written by an older cachix in place."
+
+-- | Write the conf if it changed, and when the write fails (commonly a
+-- read-only or root-owned file) rethrow as a CachixException carrying the
+-- given hint instead of dying with a bare IO error.
+writeWithHint :: Text -> NixConf.NixConfSource -> NixConf.NixConfSource -> IO Bool
+writeWithHint hint old new = do
+  result <- try (writeIfChanged old new) :: IO (Either IOException Bool)
   case result of
-    Right () -> pure ()
-    Left err -> do
-      let nixConfPath = toS (NixConf.nixConfPath old) :: Text
-          fragmentPath = toS (NixConf.nixConfPath fragment) :: Text
-          errText = toS (displayException err) :: Text
+    Right written -> pure written
+    Left err ->
       throwIO $
-        NixConfWriteFailed
-          [iTrim|
-Could not write to ${nixConfPath}:
+        NixConfWriteFailed $
+          T.intercalate
+            "\n"
+            [ "Could not write to " <> toS (NixConf.nixConfPath old) <> ":",
+              "",
+              "  " <> toS (displayException err),
+              "",
+              hint
+            ]
 
-  ${errText}
+fragmentWriteHint :: Text
+fragmentWriteHint = "Check that you have write access to the file. To configure the system-wide nix.conf, re-run the command with sudo."
 
-The caches are configured in ${fragmentPath}, but ${nixConfPath} could not be updated to include that file.
-If your nix.conf is managed by home-manager or nix-darwin, add the following line to it and re-run this command:
+outputDirHint :: Text
+outputDirHint = "Check that you have write access to the --output-directory path."
 
-  !include ${NixConf.cachixConf}
-|]
+removeNixConfHint :: Text -> Text
+removeNixConfHint fragmentPath =
+  "The cache settings in "
+    <> fragmentPath
+    <> " were updated, but nix.conf could not be. If your nix.conf is managed by home-manager or nix-darwin, apply the remaining change there manually."
 
 setNetRC :: Text -> NixConf.NixConfSource -> NixConf.NixConfSource
 setNetRC netrc = (fmap . fmap) (\ls -> filter noNetRc ls ++ [NixConf.NetRcFile netrc])

--- a/cachix/src/Cachix/Client/NetRc.hs
+++ b/cachix/src/Cachix/Client/NetRc.hs
@@ -20,19 +20,29 @@ import System.FilePath (takeDirectory)
 -- | Add a list of binary caches to netrc under `filename`.
 --   Makes sure there are no duplicate entries (using domain as a key).
 --   If file under filename doesn't exist it's created.
+--   The write is skipped when the rendered contents already match the
+--   file byte for byte, so repeated runs leave the credentials file
+--   untouched while a changed auth token still rewrites it.
+--   Returns whether a write happened.
 add ::
   Token ->
   [BinaryCache.BinaryCache] ->
   FilePath ->
-  IO ()
+  IO Bool
 add cachixAuthToken binarycaches filename = do
   doesExist <- doesFileExist filename
-  netrc <-
+  existing <-
     if doesExist
-      then BS.readFile filename >>= parse
-      else return $ NetRc [] []
-  createDirectoryIfMissing True (takeDirectory filename)
-  BS.writeFile filename $ netRcToByteString $ uniqueAppend netrc
+      then Just <$> BS.readFile filename
+      else return Nothing
+  netrc <- maybe (return $ NetRc [] []) parse existing
+  let rendered = netRcToByteString $ uniqueAppend netrc
+  if Just rendered == existing
+    then return False
+    else do
+      createDirectoryIfMissing True (takeDirectory filename)
+      BS.writeFile filename rendered
+      return True
   where
     parse :: ByteString -> IO NetRc
     parse contents = escalateAs (NetRcParseError . show) $ parseNetRc filename contents

--- a/cachix/src/Cachix/Client/NixConf.hs
+++ b/cachix/src/Cachix/Client/NixConf.hs
@@ -2,11 +2,10 @@
 
 {- (Very limited) parser, renderer and modifier of nix.conf
 
-Supports subset of nix.conf given Nix 2.0 or Nix 1.0
-
-When reading config files, it normalizes Nix 1.0/2.0 names to unified naming,
-then when it writes the config back, it uses naming depending what given Nix
-version considers as recommended.
+Only the settings cachix manages are interpreted. Everything else, including
+Nix 1.0 alias keys (binary-caches, binary-cache-public-keys) and lines with
+inline comments, is preserved verbatim so a rewrite never alters lines cachix
+does not own.
 
 -}
 module Cachix.Client.NixConf
@@ -19,10 +18,17 @@ module Cachix.Client.NixConf
     IncludeType (..),
     new,
     render,
-    add,
-    remove,
+    addCache,
+    removeCache,
+    addCacheStandalone,
+    removeCacheStandalone,
+    legacyCaches,
+    isSubstituter,
+    cachixConf,
     read,
     readWithDefault,
+    readPathWithDefault,
+    readPathQuiet,
     resolveIncludes,
     write,
     getFilename,
@@ -64,8 +70,10 @@ defaultSigningKey = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDSh
 
 data NixConfLine
   = Substituters [Text]
+  | ExtraSubstituters [Text]
   | TrustedUsers [Text]
   | TrustedPublicKeys [Text]
+  | ExtraTrustedPublicKeys [Text]
   | NetRcFile Text
   | Include IncludeType
   | Other Text
@@ -107,12 +115,6 @@ class NixConfOps a where
   -- | Write the given lines to the nix.conf
   writeLines :: (NixConfLine -> Maybe [Text]) -> NixConfLine -> a -> a
 
-  -- | Add the given binary cache to the nix.conf
-  add :: BinaryCache.BinaryCache -> [a] -> a -> a
-
-  -- | Remove the given binary cache from the nix.conf
-  remove :: URI.URI -> Text -> [a] -> a -> (a, Bool)
-
   -- | Render the nix.conf to a Text
   render :: a -> Text
 
@@ -126,32 +128,14 @@ instance NixConfOps NixConf where
     where
       f x = filter (isNothing . predicate) x <> [addition]
 
-  add bc toRead toWrite =
-    writeLines isPublicKey (TrustedPublicKeys $ nub publicKeys) $
-      writeLines isSubstituter (Substituters $ nub substituters) toWrite
-    where
-      -- Note: some defaults are always appended since overriding some setttings in nix.conf overrides defaults otherwise
-      substituters = (defaultPublicURI : concatMap (readLines isSubstituter) toRead) <> [BinaryCache.uri bc]
-      publicKeys = (defaultSigningKey : concatMap (readLines isPublicKey) toRead) <> BinaryCache.publicSigningKeys bc
-
-  remove uri name toRead toWrite =
-    (newconf, oldsubstituters /= substituters)
-    where
-      newconf =
-        writeLines isPublicKey (TrustedPublicKeys $ nub publicKeys) $
-          writeLines isSubstituter (Substituters $ nub substituters) toWrite
-      oldsubstituters = concatMap (readLines isSubstituter) toRead
-      substituters = filter (toS (URI.toByteString fulluri) /=) oldsubstituters
-      oldpublicKeys = concatMap (readLines isPublicKey) toRead
-      publicKeys = filter (not . T.isPrefixOf (toS $ URI.hostBS $ URI.getHostname fulluri)) oldpublicKeys
-      fulluri = URI.appendSubdomain name uri
-
   render (NixConf ls) = T.unlines $ fmap go ls
     where
       go :: NixConfLine -> Text
       go (Substituters xs) = "substituters" <> " = " <> T.unwords xs
+      go (ExtraSubstituters xs) = "extra-substituters" <> " = " <> T.unwords xs
       go (TrustedUsers xs) = "trusted-users = " <> T.unwords xs
       go (TrustedPublicKeys xs) = "trusted-public-keys" <> " = " <> T.unwords xs
+      go (ExtraTrustedPublicKeys xs) = "extra-trusted-public-keys" <> " = " <> T.unwords xs
       go (NetRcFile filename) = "netrc-file = " <> filename
       go (Include (RequiredInclude path)) = "include " <> path
       go (Include (OptionalInclude path)) = "!include " <> path
@@ -160,19 +144,175 @@ instance NixConfOps NixConf where
 instance NixConfOps NixConfSource where
   readLines f = readLines f . nixConfLines
   writeLines f = fmap . writeLines f
-  add bc toRead toWrite = toWrite {nixConfLines = add bc (fmap nixConfLines toRead) (nixConfLines toWrite)}
-  remove uri name toRead toWrite =
-    let (newLines, changed) = remove uri name (fmap nixConfLines toRead) (nixConfLines toWrite)
-     in (toWrite {nixConfLines = newLines}, changed)
   render = render . nixConfLines
 
 isSubstituter :: NixConfLine -> Maybe [Text]
 isSubstituter (Substituters xs) = Just xs
+isSubstituter (ExtraSubstituters xs) = Just xs
 isSubstituter _ = Nothing
 
 isPublicKey :: NixConfLine -> Maybe [Text]
 isPublicKey (TrustedPublicKeys xs) = Just xs
+isPublicKey (ExtraTrustedPublicKeys xs) = Just xs
 isPublicKey _ = Nothing
+
+-- | Replace matching assignments, omitting the replacement when it has no values.
+writeNonEmptyLines :: (NixConfLine -> Maybe [Text]) -> NixConfLine -> NixConf -> NixConf
+writeNonEmptyLines predicate addition =
+  case predicate addition of
+    Just [] -> fmap $ filter (isNothing . predicate)
+    _ -> writeLines predicate addition
+
+-- | Write the given substituters and public keys as extra-* assignments,
+-- leaving any other existing settings untouched.
+writeExtraCaches :: [Text] -> [Text] -> NixConf -> NixConf
+writeExtraCaches substituters publicKeys =
+  writeNonEmptyLines isPublicKey (ExtraTrustedPublicKeys $ nub publicKeys)
+    . writeNonEmptyLines isSubstituter (ExtraSubstituters $ nub substituters)
+
+-- | The caches cachix manages in the fragment it owns: every substituter and
+-- public key written there. The whole fragment belongs to cachix, so every
+-- entry counts regardless of value, including a restated Nix default carried
+-- over from migrated legacy settings.
+fragmentCaches :: NixConf -> ([Text], [Text])
+fragmentCaches conf =
+  ( readLines isSubstituter conf,
+    readLines isPublicKey conf
+  )
+
+-- | Substituter values in a line an OLDER cachix wrote inline into nix.conf.
+-- Old versions always wrote @defaultPublicURI@ as the FIRST value of the
+-- plain @substituters =@ line they produced (to work around the line
+-- overriding Nix's defaults), so a leading default acts as a per line
+-- provenance marker. The default is kept in the migrated values: the old
+-- line overrode substituters set at other config levels, so restating the
+-- default in the additive extra-* settings is the only way to guarantee it
+-- stays reachable afterwards. Lines whose first value is not the default
+-- (however common the default is in user-authored lines), and extra-* lines
+-- (which old cachix never wrote), are left alone.
+legacySubstituters :: NixConfLine -> Maybe [Text]
+legacySubstituters (Substituters xs@(marker : _))
+  | marker == defaultPublicURI = Just xs
+legacySubstituters _ = Nothing
+
+-- | Same as `legacySubstituters` for the trusted-public-keys line, marked by
+-- a leading @defaultSigningKey@.
+legacyPublicKeys :: NixConfLine -> Maybe [Text]
+legacyPublicKeys (TrustedPublicKeys xs@(marker : _))
+  | marker == defaultSigningKey = Just xs
+legacyPublicKeys _ = Nothing
+
+-- | The caches an older cachix wrote inline into the nix.conf.
+legacyCaches :: NixConf -> ([Text], [Text])
+legacyCaches conf =
+  ( readLines legacySubstituters conf,
+    readLines legacyPublicKeys conf
+  )
+
+-- | The name of the config fragment cachix owns. It lives next to the nix.conf
+-- it configures and is pulled in with an @!include@, so cachix only ever writes
+-- its own file and never rewrites the user's settings.
+cachixConf :: Text
+cachixConf = "cachix.conf"
+
+-- | Add a binary cache. Given the nix.conf and the cachix fragment it includes,
+-- returns the updated @(nix.conf, fragment)@. The cache's substituter and public
+-- keys are written to the fragment as extra-* settings, the nix.conf gains an
+-- @!include@ of the fragment, and any cache settings older versions wrote inline
+-- in the nix.conf are migrated into the fragment.
+addCache :: BinaryCache.BinaryCache -> NixConf -> NixConf -> (NixConf, NixConf)
+addCache bc nixconf fragment = (migrateNixConf nixconf, fragment')
+  where
+    (substituters, publicKeys) = collectCaches nixconf fragment
+    fragment' =
+      writeExtraCaches
+        (substituters <> [BinaryCache.uri bc])
+        (publicKeys <> BinaryCache.publicSigningKeys bc)
+        fragment
+
+-- | Remove a binary cache from the nix.conf and its fragment. Returns the
+-- updated configs and whether the cache was present. When it is absent both
+-- configs are returned untouched.
+removeCache :: URI.URI -> Text -> NixConf -> NixConf -> ((NixConf, NixConf), Bool)
+removeCache uri name nixconf fragment
+  | removed = ((nixconf', fragment'), True)
+  | otherwise = ((nixconf, fragment), False)
+  where
+    ((substituters, publicKeys), removed) = filterCache uri name (collectCaches nixconf fragment)
+    fragment' = writeExtraCaches substituters publicKeys fragment
+    -- Only reference the fragment when it has content, so a removal that
+    -- empties it does not leave an include pointing at a file never written.
+    nixconf'
+      | fragment' == NixConf [] = stripCaches nixconf
+      | otherwise = migrateNixConf nixconf
+
+-- | Drop the given cache's substituter and public keys from the collected
+-- values, reporting whether either matched. Public keys count on their own:
+-- a leftover key must stay removable even when its substituter is already
+-- gone, since a stale key keeps the cache's signatures trusted.
+filterCache :: URI.URI -> Text -> ([Text], [Text]) -> (([Text], [Text]), Bool)
+filterCache uri name (oldSubstituters, oldPublicKeys) =
+  ((substituters, publicKeys), removed)
+  where
+    substituters = filter (toS (URI.toByteString fulluri) /=) oldSubstituters
+    publicKeys = filter (not . T.isPrefixOf (toS $ URI.hostBS $ URI.getHostname fulluri)) oldPublicKeys
+    removed = substituters /= oldSubstituters || publicKeys /= oldPublicKeys
+    fulluri = URI.appendSubdomain name uri
+
+-- | Add a binary cache to a self-contained nix.conf, e.g. one generated with
+-- @--output-directory@. The whole file is cachix-generated, so its cache
+-- lines (including plain assignments written by older versions) are collected
+-- and rewritten as extra-* settings in place; no fragment or include is
+-- involved, keeping the file usable on its own.
+addCacheStandalone :: BinaryCache.BinaryCache -> NixConf -> NixConf
+addCacheStandalone bc conf =
+  writeExtraCaches
+    (substituters <> [BinaryCache.uri bc])
+    (publicKeys <> BinaryCache.publicSigningKeys bc)
+    conf
+  where
+    (substituters, publicKeys) = fragmentCaches conf
+
+-- | Remove a binary cache from a self-contained nix.conf.
+-- See `addCacheStandalone`.
+removeCacheStandalone :: URI.URI -> Text -> NixConf -> (NixConf, Bool)
+removeCacheStandalone uri name conf
+  | removed = (writeExtraCaches substituters publicKeys conf, True)
+  | otherwise = (conf, False)
+  where
+    ((substituters, publicKeys), removed) = filterCache uri name (fragmentCaches conf)
+
+-- | The caches cachix manages across the nix.conf and its fragment: legacy
+-- inline settings recognized in the nix.conf, plus everything in the
+-- fragment.
+collectCaches :: NixConf -> NixConf -> ([Text], [Text])
+collectCaches nixconf fragment =
+  let (s1, k1) = legacyCaches nixconf
+      (s2, k2) = fragmentCaches fragment
+   in (s1 <> s2, k1 <> k2)
+
+-- | Strip the legacy cache settings cachix wrote inline from the nix.conf and
+-- ensure it includes the fragment.
+migrateNixConf :: NixConf -> NixConf
+migrateNixConf = ensureOptionalInclude cachixConf . stripCaches
+
+-- | Remove exactly the lines `legacyCaches` collects: assignments an older
+-- cachix wrote inline. Everything else stays in nix.conf untouched.
+stripCaches :: NixConf -> NixConf
+stripCaches = fmap (filter (\l -> isNothing (legacySubstituters l) && isNothing (legacyPublicKeys l)))
+
+-- | Ensure the config optionally includes the given path, appending the
+-- directive when it is not already present. An existing include also counts
+-- when spelled with a leading @./@, which resolves to the same file.
+ensureOptionalInclude :: Text -> NixConf -> NixConf
+ensureOptionalInclude path conf@(NixConf ls)
+  | any isIncludeOf ls = conf
+  | otherwise = NixConf (ls <> [Include (OptionalInclude path)])
+  where
+    isIncludeOf (Include (OptionalInclude q)) = matches q
+    isIncludeOf (Include (RequiredInclude q)) = matches q
+    isIncludeOf _ = False
+    matches q = q == path || q == "./" <> path
 
 isTrustedUsers :: NixConfLine -> Maybe [Text]
 isTrustedUsers (TrustedUsers xs) = Just xs
@@ -260,13 +400,41 @@ read ncl = do
 -- Return an empty NixConfSource if the file does not exist or cannot be read.
 -- Prints errors to stderr.
 readWithDefault :: NixConfLoc -> IO NixConfSource
-readWithDefault ncl = do
-  filename <- getFilename ncl
+readWithDefault ncl = readPathWithDefault =<< getFilename ncl
+
+-- | Safely read a nix.conf file from the given file path.
+-- Return an empty NixConfSource (with that path) if the file does not exist,
+-- printing a note. Any other failure reading an EXISTING file is fatal:
+-- falling back to an empty config would let the next write silently replace
+-- the file's contents.
+readPathWithDefault :: FilePath -> IO NixConfSource
+readPathWithDefault filename =
   read' filename >>= \case
-    Left err -> do
+    Left err@(IOError _ ioerr) | isDoesNotExistError ioerr -> do
       printNixConfError err
       return $ new filename
+    Left err -> do
+      printNixConfError err
+      throwNixConfError err
     Right conf -> return conf
+
+-- | Like `readPathWithDefault`, but silent when the file simply doesn't
+-- exist. Meant for files cachix exclusively manages, such as the cachix.conf
+-- fragment, which is expected to be missing until the first `cachix use`,
+-- so printing a "no config" error for it would just be noise.
+readPathQuiet :: FilePath -> IO NixConfSource
+readPathQuiet filename =
+  read' filename >>= \case
+    Left (IOError _ ioerr) | isDoesNotExistError ioerr -> return $ new filename
+    Left err -> do
+      printNixConfError err
+      throwNixConfError err
+    Right conf -> return conf
+
+throwNixConfError :: NixConfError -> IO a
+throwNixConfError (IOError _ ioerr) = throwIO ioerr
+throwNixConfError (ParseError path err) =
+  throwIO $ NixConfParseError ("Failed to parse " <> toS path <> ":\n" <> err)
 
 -- | Safely read a nix.conf file from the given file path.
 read' :: FilePath -> IO (Either NixConfError NixConfSource)
@@ -314,7 +482,9 @@ printNixConfError (ParseError path err) = do
 -- nix.conf Parser
 type Parser = Mega.Parsec Void Text
 
--- TODO: handle comments
+-- NB: lines with an inline '#' comment are deliberately left unparsed so they
+-- round-trip verbatim as Other: Nix strips '#' to the end of the line, so
+-- treating the comment tokens as values would corrupt any rewrite.
 parseLine :: ([Text] -> NixConfLine) -> Text -> Parser NixConfLine
 parseLine constr name = Mega.try $ do
   _ <- optional (some (char ' '))
@@ -323,6 +493,7 @@ parseLine constr name = Mega.try $ do
   _ <- char '='
   _ <- many (char ' ')
   values <- Mega.sepBy1 (many (Mega.satisfy (not . isSpace))) (some (char ' '))
+  guard $ not (any ('#' `elem`) values)
   _ <- many spaceChar
   return $ constr (fmap toS values)
 
@@ -341,11 +512,14 @@ parseOther = Mega.try $ Other . toS <$> Mega.someTill Mega.anySingle (void eol <
 parseAltLine :: Parser NixConfLine
 parseAltLine =
   (Other "" <$ eol)
+    <|> parseLine ExtraSubstituters "extra-substituters"
     <|> parseLine Substituters "substituters"
+    <|> parseLine ExtraTrustedPublicKeys "extra-trusted-public-keys"
     <|> parseLine TrustedPublicKeys "trusted-public-keys"
     <|> parseLine TrustedUsers "trusted-users"
-    <|> parseLine TrustedPublicKeys "binary-cache-public-keys"
-    <|> parseLine Substituters "binary-caches"
+    -- Nix 1.0 alias keys (binary-caches, binary-cache-public-keys) are
+    -- deliberately NOT interpreted: cachix never wrote them, and parsing them
+    -- would rename user-authored lines to the canonical keys on a rewrite.
     -- NB: assume that space in this option means space in filename
     <|> parseLine (NetRcFile . T.concat) "netrc-file"
     <|> parseInclude RequiredInclude "include"

--- a/cachix/src/Cachix/Client/NixConf.hs
+++ b/cachix/src/Cachix/Client/NixConf.hs
@@ -2,10 +2,12 @@
 
 {- (Very limited) parser, renderer and modifier of nix.conf
 
-Only the settings cachix manages are interpreted. Everything else, including
-Nix 1.0 alias keys (binary-caches, binary-cache-public-keys) and lines with
-inline comments, is preserved verbatim so a rewrite never alters lines cachix
-does not own.
+Only the settings cachix manages are rewritten. Lines with inline '#' comments
+and Nix 1.0 alias keys (binary-caches, binary-cache-public-keys) are parsed
+for READING only: their values (as Nix sees them, with everything from '#' to
+the end of the line stripped) are visible to the trust and substituter checks,
+but the lines carry their raw text and render back unchanged, so a rewrite
+never alters lines cachix does not own.
 
 -}
 module Cachix.Client.NixConf
@@ -16,6 +18,7 @@ module Cachix.Client.NixConf
     NixConfSourceG (..),
     NixConfLoc (..),
     IncludeType (..),
+    MigrateLegacy (..),
     new,
     render,
     addCache,
@@ -23,6 +26,7 @@ module Cachix.Client.NixConf
     addCacheStandalone,
     removeCacheStandalone,
     legacyCaches,
+    ensureOptionalInclude,
     isSubstituter,
     cachixConf,
     read,
@@ -72,16 +76,29 @@ data NixConfLine
   = Substituters [Text]
   | ExtraSubstituters [Text]
   | TrustedUsers [Text]
+  | ExtraTrustedUsers [Text]
   | TrustedPublicKeys [Text]
   | ExtraTrustedPublicKeys [Text]
   | NetRcFile Text
   | Include IncludeType
+  | -- | A line whose meaning is known but whose raw text must be preserved:
+    -- assignments with inline '#' comments and Nix 1.0 alias keys. The parsed
+    -- meaning is visible to reads (trust detection, substituter checks), but
+    -- the line renders back byte for byte and is never rewritten or migrated.
+    Verbatim NixConfLine Text
   | Other Text
   deriving (Show, Eq)
 
 data IncludeType
   = RequiredInclude Text -- for "include"
   | OptionalInclude Text -- for "!include"
+  deriving (Show, Eq)
+
+-- | Whether legacy cache settings an older cachix wrote inline into nix.conf
+-- may be migrated into the fragment. Migration rewrites nix.conf, so it must
+-- be off when the file cannot be written (e.g. managed by home-manager or
+-- nix-darwin), or every run would fail trying to strip the same lines.
+data MigrateLegacy = MigrateLegacy | LeaveLegacy
   deriving (Show, Eq)
 
 -- | A list of conf lines
@@ -134,11 +151,13 @@ instance NixConfOps NixConf where
       go (Substituters xs) = "substituters" <> " = " <> T.unwords xs
       go (ExtraSubstituters xs) = "extra-substituters" <> " = " <> T.unwords xs
       go (TrustedUsers xs) = "trusted-users = " <> T.unwords xs
+      go (ExtraTrustedUsers xs) = "extra-trusted-users = " <> T.unwords xs
       go (TrustedPublicKeys xs) = "trusted-public-keys" <> " = " <> T.unwords xs
       go (ExtraTrustedPublicKeys xs) = "extra-trusted-public-keys" <> " = " <> T.unwords xs
       go (NetRcFile filename) = "netrc-file = " <> filename
       go (Include (RequiredInclude path)) = "include " <> path
       go (Include (OptionalInclude path)) = "!include " <> path
+      go (Verbatim _ raw) = raw
       go (Other line) = line
 
 instance NixConfOps NixConfSource where
@@ -149,12 +168,27 @@ instance NixConfOps NixConfSource where
 isSubstituter :: NixConfLine -> Maybe [Text]
 isSubstituter (Substituters xs) = Just xs
 isSubstituter (ExtraSubstituters xs) = Just xs
+isSubstituter (Verbatim line _) = isSubstituter line
 isSubstituter _ = Nothing
 
 isPublicKey :: NixConfLine -> Maybe [Text]
 isPublicKey (TrustedPublicKeys xs) = Just xs
 isPublicKey (ExtraTrustedPublicKeys xs) = Just xs
+isPublicKey (Verbatim line _) = isPublicKey line
 isPublicKey _ = Nothing
+
+isTrustedUsers :: NixConfLine -> Maybe [Text]
+isTrustedUsers (TrustedUsers xs) = Just xs
+isTrustedUsers (ExtraTrustedUsers xs) = Just xs
+isTrustedUsers (Verbatim line _) = isTrustedUsers line
+isTrustedUsers _ = Nothing
+
+-- | Restrict a predicate to lines cachix may rewrite: lines preserved
+-- verbatim (inline comments, alias keys) are never collected into the
+-- fragment or replaced by it.
+owned :: (NixConfLine -> Maybe [Text]) -> NixConfLine -> Maybe [Text]
+owned _ (Verbatim _ _) = Nothing
+owned predicate line = predicate line
 
 -- | Replace matching assignments, omitting the replacement when it has no values.
 writeNonEmptyLines :: (NixConfLine -> Maybe [Text]) -> NixConfLine -> NixConf -> NixConf
@@ -167,8 +201,8 @@ writeNonEmptyLines predicate addition =
 -- leaving any other existing settings untouched.
 writeExtraCaches :: [Text] -> [Text] -> NixConf -> NixConf
 writeExtraCaches substituters publicKeys =
-  writeNonEmptyLines isPublicKey (ExtraTrustedPublicKeys $ nub publicKeys)
-    . writeNonEmptyLines isSubstituter (ExtraSubstituters $ nub substituters)
+  writeNonEmptyLines (owned isPublicKey) (ExtraTrustedPublicKeys $ nub publicKeys)
+    . writeNonEmptyLines (owned isSubstituter) (ExtraSubstituters $ nub substituters)
 
 -- | The caches cachix manages in the fragment it owns: every substituter and
 -- public key written there. The whole fragment belongs to cachix, so every
@@ -176,8 +210,8 @@ writeExtraCaches substituters publicKeys =
 -- over from migrated legacy settings.
 fragmentCaches :: NixConf -> ([Text], [Text])
 fragmentCaches conf =
-  ( readLines isSubstituter conf,
-    readLines isPublicKey conf
+  ( readLines (owned isSubstituter) conf,
+    readLines (owned isPublicKey) conf
   )
 
 -- | Substituter values in a line an OLDER cachix wrote inline into nix.conf.
@@ -202,12 +236,15 @@ legacyPublicKeys (TrustedPublicKeys xs@(marker : _))
   | marker == defaultSigningKey = Just xs
 legacyPublicKeys _ = Nothing
 
--- | The caches an older cachix wrote inline into the nix.conf.
+-- | The caches an older cachix wrote inline into the nix.conf. Old versions
+-- always wrote BOTH marker-led lines together, so a lone marked line (a shape
+-- users also write by hand, e.g. a substituters override listing the default
+-- first) is not claimed.
 legacyCaches :: NixConf -> ([Text], [Text])
 legacyCaches conf =
-  ( readLines legacySubstituters conf,
-    readLines legacyPublicKeys conf
-  )
+  case (readLines legacySubstituters conf, readLines legacyPublicKeys conf) of
+    (substituters@(_ : _), publicKeys@(_ : _)) -> (substituters, publicKeys)
+    _ -> ([], [])
 
 -- | The name of the config fragment cachix owns. It lives next to the nix.conf
 -- it configures and is pulled in with an @!include@, so cachix only ever writes
@@ -215,36 +252,59 @@ legacyCaches conf =
 cachixConf :: Text
 cachixConf = "cachix.conf"
 
--- | Add a binary cache. Given the nix.conf and the cachix fragment it includes,
--- returns the updated @(nix.conf, fragment)@. The cache's substituter and public
--- keys are written to the fragment as extra-* settings, the nix.conf gains an
--- @!include@ of the fragment, and any cache settings older versions wrote inline
--- in the nix.conf are migrated into the fragment.
-addCache :: BinaryCache.BinaryCache -> NixConf -> NixConf -> (NixConf, NixConf)
-addCache bc nixconf fragment = (migrateNixConf nixconf, fragment')
+-- | Append the cache's substituter and public keys to the collected values
+-- and write them back as extra-* assignments.
+appendCache :: BinaryCache.BinaryCache -> ([Text], [Text]) -> NixConf -> NixConf
+appendCache bc (substituters, publicKeys) =
+  writeExtraCaches
+    (substituters <> [BinaryCache.uri bc])
+    (publicKeys <> BinaryCache.publicSigningKeys bc)
+
+-- | Add a binary cache. Given the nix.conf (at the given path) and the cachix
+-- fragment it includes, returns the updated @(nix.conf, fragment)@. The
+-- cache's substituter and public keys are written to the fragment as extra-*
+-- settings, the nix.conf gains an @!include@ of the fragment, and (when
+-- migration is on) cache settings older versions wrote inline in the nix.conf
+-- are moved into the fragment.
+addCache :: BinaryCache.BinaryCache -> MigrateLegacy -> FilePath -> NixConf -> NixConf -> (NixConf, NixConf)
+addCache bc migrate nixConfPath nixconf fragment =
+  (nixconf', appendCache bc (collectCaches migrate nixconf fragment) fragment)
   where
-    (substituters, publicKeys) = collectCaches nixconf fragment
-    fragment' =
-      writeExtraCaches
-        (substituters <> [BinaryCache.uri bc])
-        (publicKeys <> BinaryCache.publicSigningKeys bc)
-        fragment
+    nixconf' = ensureOptionalInclude nixConfPath (stripLegacy nixconf)
+    stripLegacy = case migrate of
+      MigrateLegacy -> stripCaches
+      LeaveLegacy -> identity
 
 -- | Remove a binary cache from the nix.conf and its fragment. Returns the
 -- updated configs and whether the cache was present. When it is absent both
 -- configs are returned untouched.
-removeCache :: URI.URI -> Text -> NixConf -> NixConf -> ((NixConf, NixConf), Bool)
-removeCache uri name nixconf fragment
+removeCache :: URI.URI -> Text -> MigrateLegacy -> FilePath -> NixConf -> NixConf -> ((NixConf, NixConf), Bool)
+removeCache uri name migrate nixConfPath nixconf fragment
   | removed = ((nixconf', fragment'), True)
   | otherwise = ((nixconf, fragment), False)
   where
-    ((substituters, publicKeys), removed) = filterCache uri name (collectCaches nixconf fragment)
-    fragment' = writeExtraCaches substituters publicKeys fragment
-    -- Only reference the fragment when it has content, so a removal that
-    -- empties it does not leave an include pointing at a file never written.
+    (fragment', removed) = removeFrom uri name (collectCaches migrate nixconf fragment) fragment
+    migratesLegacy = migrate == MigrateLegacy && legacyCaches nixconf /= ([], [])
+    -- A removal only bookkeeps the nix.conf: legacy lines it migrates are
+    -- stripped, and the include is ensured only when that migration moves
+    -- active inline settings into the fragment (and the fragment has content;
+    -- an emptied fragment must not gain an include pointing at a file never
+    -- written). A plain removal never adds the include, so it cannot
+    -- re-activate remaining fragment caches on a system where the include
+    -- was deliberately absent.
     nixconf'
+      | not migratesLegacy = nixconf
       | fragment' == NixConf [] = stripCaches nixconf
-      | otherwise = migrateNixConf nixconf
+      | otherwise = ensureOptionalInclude nixConfPath (stripCaches nixconf)
+
+-- | Drop the given cache from the collected values and write the remainder
+-- back as extra-* assignments, reporting whether anything matched.
+removeFrom :: URI.URI -> Text -> ([Text], [Text]) -> NixConf -> (NixConf, Bool)
+removeFrom uri name collected conf
+  | removed = (writeExtraCaches substituters publicKeys conf, True)
+  | otherwise = (conf, False)
+  where
+    ((substituters, publicKeys), removed) = filterCache uri name collected
 
 -- | Drop the given cache's substituter and public keys from the collected
 -- values, reporting whether either matched. Public keys count on their own:
@@ -254,7 +314,7 @@ filterCache :: URI.URI -> Text -> ([Text], [Text]) -> (([Text], [Text]), Bool)
 filterCache uri name (oldSubstituters, oldPublicKeys) =
   ((substituters, publicKeys), removed)
   where
-    substituters = filter (toS (URI.toByteString fulluri) /=) oldSubstituters
+    substituters = filter (URI.serialize fulluri /=) oldSubstituters
     publicKeys = filter (not . T.isPrefixOf (toS $ URI.hostBS $ URI.getHostname fulluri)) oldPublicKeys
     removed = substituters /= oldSubstituters || publicKeys /= oldPublicKeys
     fulluri = URI.appendSubdomain name uri
@@ -265,58 +325,49 @@ filterCache uri name (oldSubstituters, oldPublicKeys) =
 -- and rewritten as extra-* settings in place; no fragment or include is
 -- involved, keeping the file usable on its own.
 addCacheStandalone :: BinaryCache.BinaryCache -> NixConf -> NixConf
-addCacheStandalone bc conf =
-  writeExtraCaches
-    (substituters <> [BinaryCache.uri bc])
-    (publicKeys <> BinaryCache.publicSigningKeys bc)
-    conf
-  where
-    (substituters, publicKeys) = fragmentCaches conf
+addCacheStandalone bc conf = appendCache bc (fragmentCaches conf) conf
 
 -- | Remove a binary cache from a self-contained nix.conf.
 -- See `addCacheStandalone`.
 removeCacheStandalone :: URI.URI -> Text -> NixConf -> (NixConf, Bool)
-removeCacheStandalone uri name conf
-  | removed = (writeExtraCaches substituters publicKeys conf, True)
-  | otherwise = (conf, False)
-  where
-    ((substituters, publicKeys), removed) = filterCache uri name (fragmentCaches conf)
+removeCacheStandalone uri name conf = removeFrom uri name (fragmentCaches conf) conf
 
 -- | The caches cachix manages across the nix.conf and its fragment: legacy
--- inline settings recognized in the nix.conf, plus everything in the
--- fragment.
-collectCaches :: NixConf -> NixConf -> ([Text], [Text])
-collectCaches nixconf fragment =
-  let (s1, k1) = legacyCaches nixconf
+-- inline settings recognized in the nix.conf (when migration is on), plus
+-- everything in the fragment.
+collectCaches :: MigrateLegacy -> NixConf -> NixConf -> ([Text], [Text])
+collectCaches migrate nixconf fragment =
+  let (s1, k1) = case migrate of
+        MigrateLegacy -> legacyCaches nixconf
+        LeaveLegacy -> ([], [])
       (s2, k2) = fragmentCaches fragment
    in (s1 <> s2, k1 <> k2)
 
--- | Strip the legacy cache settings cachix wrote inline from the nix.conf and
--- ensure it includes the fragment.
-migrateNixConf :: NixConf -> NixConf
-migrateNixConf = ensureOptionalInclude cachixConf . stripCaches
-
 -- | Remove exactly the lines `legacyCaches` collects: assignments an older
--- cachix wrote inline. Everything else stays in nix.conf untouched.
+-- cachix wrote inline. When nothing is claimed (including when only one of
+-- the two marker lines is present), the nix.conf is left untouched.
 stripCaches :: NixConf -> NixConf
-stripCaches = fmap (filter (\l -> isNothing (legacySubstituters l) && isNothing (legacyPublicKeys l)))
+stripCaches conf
+  | legacyCaches conf == ([], []) = conf
+  | otherwise = fmap (filter (\l -> isNothing (legacySubstituters l) && isNothing (legacyPublicKeys l))) conf
 
--- | Ensure the config optionally includes the given path, appending the
--- directive when it is not already present. An existing include also counts
--- when spelled with a leading @./@, which resolves to the same file.
-ensureOptionalInclude :: Text -> NixConf -> NixConf
-ensureOptionalInclude path conf@(NixConf ls)
+-- | Ensure the nix.conf at the given path optionally includes the cachix
+-- fragment, appending the directive when no existing include already resolves
+-- to it. Includes are resolved relative to the nix.conf's directory, the same
+-- way `resolveIncludesWithStack` does, so relative ("cachix.conf",
+-- "./cachix.conf") and absolute spellings all count.
+ensureOptionalInclude :: FilePath -> NixConf -> NixConf
+ensureOptionalInclude nixConfPath conf@(NixConf ls)
   | any isIncludeOf ls = conf
-  | otherwise = NixConf (ls <> [Include (OptionalInclude path)])
+  | otherwise = NixConf (ls <> [Include (OptionalInclude cachixConf)])
   where
-    isIncludeOf (Include (OptionalInclude q)) = matches q
+    dir = takeDirectory nixConfPath
+    fragmentPath = normalise (dir </> toS cachixConf)
     isIncludeOf (Include (RequiredInclude q)) = matches q
+    isIncludeOf (Include (OptionalInclude q)) = matches q
+    isIncludeOf (Verbatim line _) = isIncludeOf line
     isIncludeOf _ = False
-    matches q = q == path || q == "./" <> path
-
-isTrustedUsers :: NixConfLine -> Maybe [Text]
-isTrustedUsers (TrustedUsers xs) = Just xs
-isTrustedUsers _ = Nothing
+    matches q = normalise (dir </> toS q) == fragmentPath
 
 -- | Create a new, empty NixConfSource with the given path
 new :: FilePath -> NixConfSource
@@ -334,10 +385,15 @@ resolveIncludes conf@NixConfSource {nixConfPath} =
 
 resolveIncludesWithStack :: [FilePath] -> FilePath -> NixConfSource -> IO [NixConfSource]
 resolveIncludesWithStack stack baseFile baseConf@(NixConfSource {nixConfLines = NixConf ls}) = do
-  includedConfigs <- mapM resolveInclude [f | Include f <- ls]
+  includedConfigs <- mapM resolveInclude (mapMaybe includeOf ls)
   return $ baseConf : concat includedConfigs
   where
     dir = takeDirectory baseFile
+
+    -- Includes carrying an inline comment still pull in their file.
+    includeOf (Include f) = Just f
+    includeOf (Verbatim line _) = includeOf line
+    includeOf _ = Nothing
 
     resolveInclude :: IncludeType -> IO [NixConfSource]
     resolveInclude includeType = do
@@ -402,39 +458,36 @@ read ncl = do
 readWithDefault :: NixConfLoc -> IO NixConfSource
 readWithDefault ncl = readPathWithDefault =<< getFilename ncl
 
--- | Safely read a nix.conf file from the given file path.
--- Return an empty NixConfSource (with that path) if the file does not exist,
--- printing a note. Any other failure reading an EXISTING file is fatal:
--- falling back to an empty config would let the next write silently replace
--- the file's contents.
-readPathWithDefault :: FilePath -> IO NixConfSource
-readPathWithDefault filename =
+-- | Read a nix.conf, defaulting to an empty one (with the given path) when
+-- the file does not exist; noisy controls whether that case prints a note.
+-- Any other failure reading an EXISTING file is fatal: falling back to an
+-- empty config would let the next write silently replace the file's contents.
+readPath :: Bool -> FilePath -> IO NixConfSource
+readPath noisy filename =
   read' filename >>= \case
-    Left err@(IOError _ ioerr) | isDoesNotExistError ioerr -> do
-      printNixConfError err
-      return $ new filename
-    Left err -> do
-      printNixConfError err
-      throwNixConfError err
+    Left err@(IOError _ ioerr)
+      | isDoesNotExistError ioerr -> do
+          when noisy $ printNixConfError err
+          return $ new filename
+    Left err -> throwNixConfError err
     Right conf -> return conf
+
+-- | See `readPath`.
+readPathWithDefault :: FilePath -> IO NixConfSource
+readPathWithDefault = readPath True
 
 -- | Like `readPathWithDefault`, but silent when the file simply doesn't
 -- exist. Meant for files cachix exclusively manages, such as the cachix.conf
 -- fragment, which is expected to be missing until the first `cachix use`,
 -- so printing a "no config" error for it would just be noise.
 readPathQuiet :: FilePath -> IO NixConfSource
-readPathQuiet filename =
-  read' filename >>= \case
-    Left (IOError _ ioerr) | isDoesNotExistError ioerr -> return $ new filename
-    Left err -> do
-      printNixConfError err
-      throwNixConfError err
-    Right conf -> return conf
+readPathQuiet = readPath False
 
+-- | Rethrow a read failure as a CachixException, so the top-level handler
+-- prints it exactly once.
 throwNixConfError :: NixConfError -> IO a
-throwNixConfError (IOError _ ioerr) = throwIO ioerr
-throwNixConfError (ParseError path err) =
-  throwIO $ NixConfParseError ("Failed to parse " <> toS path <> ":\n" <> err)
+throwNixConfError err@(IOError _ _) = throwIO $ NixConfReadFailed (formatNixConfError err)
+throwNixConfError err@(ParseError _ _) = throwIO $ NixConfParseError (formatNixConfError err)
 
 -- | Safely read a nix.conf file from the given file path.
 read' :: FilePath -> IO (Either NixConfError NixConfSource)
@@ -456,55 +509,94 @@ getFilename ncl = do
       Custom filepath -> return filepath
   return $ dir <> "/nix.conf"
 
+formatNixConfError :: NixConfError -> Text
+formatNixConfError (IOError path err)
+  | isDoesNotExistError err =
+      unlines
+        [ "No config at " <> toS path <> ":",
+          "",
+          toS (displayException err)
+        ]
+  | otherwise =
+      unlines
+        [ "Failed to read " <> toS path <> ":",
+          "",
+          toS (displayException err)
+        ]
+formatNixConfError (ParseError path err) =
+  unlines
+    [ "Failed to parse " <> toS path <> ":",
+      "",
+      err
+    ]
+
 printNixConfError :: NixConfError -> IO ()
-printNixConfError (IOError path err) | isDoesNotExistError err = do
-  putErrText $
-    unlines
-      [ "No config at " <> toS path <> ":",
-        "",
-        toS (displayException err)
-      ]
-printNixConfError (IOError path err) = do
-  putErrText $
-    unlines
-      [ "Failed to read " <> toS path <> ":",
-        "",
-        toS (displayException err)
-      ]
-printNixConfError (ParseError path err) = do
-  putErrText $
-    unlines
-      [ "Failed to parse " <> toS path <> ":",
-        "",
-        err
-      ]
+printNixConfError = putErrText . formatNixConfError
 
 -- nix.conf Parser
 type Parser = Mega.Parsec Void Text
 
--- NB: lines with an inline '#' comment are deliberately left unparsed so they
--- round-trip verbatim as Other: Nix strips '#' to the end of the line, so
--- treating the comment tokens as values would corrupt any rewrite.
+-- | Parse an assignment cachix may manage. A line carrying an inline '#'
+-- comment is wrapped in Verbatim: its values (up to the '#', as Nix reads
+-- them) stay visible, but the line renders back unchanged.
 parseLine :: ([Text] -> NixConfLine) -> Text -> Parser NixConfLine
-parseLine constr name = Mega.try $ do
-  _ <- optional (some (char ' '))
-  _ <- string name
+parseLine = parseAssignment False
+
+-- | Parse an assignment cachix only ever reads (Nix 1.0 alias keys): the
+-- parsed meaning is always wrapped in Verbatim, so a rewrite reproduces the
+-- user's line instead of renaming it to the canonical key.
+parseReadOnlyLine :: ([Text] -> NixConfLine) -> Text -> Parser NixConfLine
+parseReadOnlyLine = parseAssignment True
+
+parseAssignment :: Bool -> ([Text] -> NixConfLine) -> Text -> Parser NixConfLine
+parseAssignment alwaysVerbatim constr name = Mega.try $ do
+  (raw, values) <- Mega.match $ do
+    _ <- optional (some (char ' '))
+    _ <- string name
+    _ <- many (char ' ')
+    _ <- char '='
+    _ <- many (char ' ')
+    Mega.sepBy1 (many (Mega.satisfy (not . isSpace))) (some (char ' '))
   _ <- many (char ' ')
-  _ <- char '='
-  _ <- many (char ' ')
-  values <- Mega.sepBy1 (many (Mega.satisfy (not . isSpace))) (some (char ' '))
-  guard $ not (any ('#' `elem`) values)
-  _ <- many spaceChar
-  return $ constr (fmap toS values)
+  _ <- void eol <|> Mega.eof
+  let vals = fmap toS values :: [Text]
+      hasComment = any (T.isInfixOf "#") vals
+      semantic = constr (stripInlineComment vals)
+  return $
+    if alwaysVerbatim || hasComment
+      then Verbatim semantic raw
+      else semantic
+
+-- | Values as Nix sees them: everything from the first '#' to the end of the
+-- line is a comment, and empty tokens (from stray spacing) are dropped.
+stripInlineComment :: [Text] -> [Text]
+stripInlineComment = filter (not . T.null) . go
+  where
+    go [] = []
+    go (v : vs)
+      | "#" `T.isInfixOf` v = [T.takeWhile (/= '#') v]
+      | otherwise = v : go vs
 
 parseInclude :: (Text -> IncludeType) -> Text -> Parser NixConfLine
 parseInclude constr name = Mega.try $ do
-  _ <- optional (some (char ' '))
-  _ <- string name
-  _ <- some (char ' ')
-  path <- many (Mega.satisfy (not . isSpace))
-  _ <- many spaceChar
-  return $ Include (constr (toS path))
+  (raw, path) <- Mega.match $ do
+    _ <- optional (some (char ' '))
+    _ <- string name
+    _ <- some (char ' ')
+    many (Mega.satisfy (not . isSpace))
+  trailing <- many (Mega.satisfy (/= '\n'))
+  _ <- void eol <|> Mega.eof
+  let pathT = toS path :: Text
+      include = Include (constr (T.takeWhile (/= '#') pathT))
+      rest = T.strip (toS trailing)
+      rawLine = raw <> toS trailing
+  if T.null rest || "#" `T.isPrefixOf` rest
+    then
+      return $
+        if "#" `T.isInfixOf` pathT || not (T.null rest)
+          then Verbatim include rawLine
+          else include
+    else empty
 
 parseOther :: Parser NixConfLine
 parseOther = Mega.try $ Other . toS <$> Mega.someTill Mega.anySingle (void eol <|> Mega.eof)
@@ -516,12 +608,15 @@ parseAltLine =
     <|> parseLine Substituters "substituters"
     <|> parseLine ExtraTrustedPublicKeys "extra-trusted-public-keys"
     <|> parseLine TrustedPublicKeys "trusted-public-keys"
+    <|> parseLine ExtraTrustedUsers "extra-trusted-users"
     <|> parseLine TrustedUsers "trusted-users"
-    -- Nix 1.0 alias keys (binary-caches, binary-cache-public-keys) are
-    -- deliberately NOT interpreted: cachix never wrote them, and parsing them
-    -- would rename user-authored lines to the canonical keys on a rewrite.
+    -- Nix 1.0 alias keys are still honored by Nix, so they are read (the
+    -- substituter checks must see them), but never rewritten: rendering them
+    -- back as canonical keys would rename user-authored lines.
+    <|> parseReadOnlyLine Substituters "binary-caches"
+    <|> parseReadOnlyLine TrustedPublicKeys "binary-cache-public-keys"
     -- NB: assume that space in this option means space in filename
-    <|> parseLine (NetRcFile . T.concat) "netrc-file"
+    <|> parseLine (NetRcFile . T.unwords) "netrc-file"
     <|> parseInclude RequiredInclude "include"
     <|> parseInclude OptionalInclude "!include"
     <|> parseOther

--- a/cachix/src/Cachix/Client/NixVersion.hs
+++ b/cachix/src/Cachix/Client/NixVersion.hs
@@ -38,11 +38,19 @@ assertNixVersion = do
 
 getRawNixVersion :: IO (Either Text Text)
 getRawNixVersion = do
-  (exitcode, out, err) <- readProcessWithExitCode "nix-env" ["--version"] mempty
-  unless (err == "") $ putStrLn $ "nix-env stderr: " <> err
-  return $ case exitcode of
-    ExitFailure i -> Left $ "'nix-env --version' exited with " <> Protolude.show i
-    ExitSuccess -> Right (toS out)
+  result <- try (readProcessWithExitCode "nix-env" ["--version"] mempty) :: IO (Either IOException (ExitCode, [Char], [Char]))
+  case result of
+    Left ioerr ->
+      return $
+        Left $
+          "Couldn't run 'nix-env --version': "
+            <> toS (displayException ioerr)
+            <> "\nIs Nix installed and on the PATH? https://nixos.org/nix/"
+    Right (exitcode, out, err) -> do
+      unless (err == "") $ putStrLn $ "nix-env stderr: " <> err
+      return $ case exitcode of
+        ExitFailure i -> Left $ "'nix-env --version' exited with " <> Protolude.show i
+        ExitSuccess -> Right (toS out)
 
 parseNixVersion :: Text -> Either Text Versioning
 parseNixVersion input =

--- a/cachix/src/Cachix/Client/NixVersion.hs
+++ b/cachix/src/Cachix/Client/NixVersion.hs
@@ -1,6 +1,7 @@
 -- TODO: we may need to revisit this when the various flavours of Nix start to diverge
 module Cachix.Client.NixVersion
   ( assertNixVersion,
+    isSupportedNixVersion,
     parseNixVersion,
     minimalVersion,
   )
@@ -15,9 +16,16 @@ import Text.Megaparsec (Parsec, anySingle, choice, eof, lookAhead, manyTill, par
 import Text.Megaparsec qualified as P
 import Text.Megaparsec.Char (digitChar)
 
-minimalVersion :: SemVer
+-- | The minimum supported Nix version. Kept as a General (two component)
+-- version so plain "2.4" output compares equal to it; the cross constructor
+-- Ord of the versions package orders SemVer shaped output like "2.4.0"
+-- correctly against it as well.
+minimalVersion :: Versioning
 minimalVersion =
-  semver "2.0.1" & fromRight (panic "Couldn't parse minimalVersion")
+  General (version "2.4" & fromRight (panic "Couldn't parse minimalVersion"))
+
+isSupportedNixVersion :: Versioning -> Bool
+isSupportedNixVersion = (>= minimalVersion)
 
 assertNixVersion :: IO (Either Text ())
 assertNixVersion = do
@@ -25,7 +33,7 @@ assertNixVersion = do
   return $ case nixVersion of
     Left err -> Left err
     Right ver
-      | ver < Ideal minimalVersion -> Left "Nix 2.0.2 or lower is not supported. Please upgrade: https://nixos.org/nix/"
+      | not (isSupportedNixVersion ver) -> Left $ "Nix " <> prettyV minimalVersion <> " or newer is required. Please upgrade: https://nixos.org/nix/"
       | otherwise -> Right ()
 
 getRawNixVersion :: IO (Either Text Text)

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -92,7 +92,7 @@ data CachixCommand
   | WatchStore PushOptions Text
   | WatchExec WatchExecMode PushOptions NarinfoQueryOptions Text Text [Text]
   | Use BinaryCacheName InstallationMode.UseOptions
-  | Remove BinaryCacheName
+  | Remove BinaryCacheName InstallationMode.UseOptions
   | DeployCommand DeployOptions.DeployCommand
   | Version
   deriving (Show)
@@ -711,7 +711,7 @@ watchStoreCommand :: Parser CachixCommand
 watchStoreCommand = WatchStore <$> pushOptionsParser <*> cacheNameParser
 
 removeCommand :: Parser CachixCommand
-removeCommand = Remove <$> cacheNameParser
+removeCommand = Remove <$> cacheNameParser <*> installationMode
 
 useCommand :: Parser CachixCommand
 useCommand = Use <$> cacheNameParser <*> installationMode

--- a/cachix/src/Cachix/Client/OptionsParser.hs
+++ b/cachix/src/Cachix/Client/OptionsParser.hs
@@ -244,8 +244,8 @@ commandParser =
           [ commandGroup "Cache commands:",
             hidden,
             command "generate-keypair" $ infoH generateKeypairCommand $ progDesc "Generate a signing key pair for a binary cache",
-            command "use" $ infoH useCommand $ progDesc "Configure a binary cache in nix.conf",
-            command "remove" $ infoH removeCommand $ progDesc "Remove a binary cache from nix.conf"
+            command "use" $ infoH useCommand $ progDesc "Configure a binary cache in the cachix.conf fragment included by nix.conf",
+            command "remove" $ infoH removeCommand $ progDesc "Remove a binary cache from the cachix.conf fragment included by nix.conf"
           ]
 
     pushCommands =
@@ -739,7 +739,7 @@ installationMode =
       optional . strOption $
         long "output-directory"
           <> short 'O'
-          <> help "Output directory where nix.conf and netrc will be updated."
+          <> help "Output directory where a self-contained nix.conf and netrc will be updated."
 
 versionParser :: Parser CachixCommand
 versionParser =

--- a/cachix/src/Cachix/Deploy/Activate.hs
+++ b/cachix/src/Cachix/Deploy/Activate.hs
@@ -194,7 +194,7 @@ withCacheArgs host agentInfo agentToken m =
                   BinaryCache.permission = Read,
                   BinaryCache.preferredCompressionMethod = BinaryCache.XZ
                 }
-        NetRc.add (Token (toS agentToken)) [bc] filepath
+        _ <- NetRc.add (Token (toS agentToken)) [bc] filepath
         return $ cachesArgs cache <> ["--option", "netrc-file", filepath]
       Nothing ->
         return []

--- a/cachix/test/InstallationModeSpec.hs
+++ b/cachix/test/InstallationModeSpec.hs
@@ -1,8 +1,15 @@
 module InstallationModeSpec where
 
+import Cachix.Client.Config (Config)
 import Cachix.Client.InstallationMode
 import Cachix.Client.NixConf qualified as NixConf
+import Cachix.Types.BinaryCache (BinaryCache (..), CompressionMethod (..))
+import Cachix.Types.Permission (Permission (..))
 import Protolude
+import System.Directory (createDirectoryIfMissing, doesFileExist, getPermissions, setOwnerWritable, setPermissions)
+import System.Environment (setEnv)
+import System.FilePath ((</>))
+import System.IO.Temp (withTempDirectory)
 import Test.Hspec
 
 defautUseOptions :: UseOptions
@@ -13,69 +20,183 @@ defautUseOptions =
       useNixOSFolder = "/etc/nixos"
     }
 
+publicCache :: BinaryCache
+publicCache =
+  BinaryCache
+    { name = "name",
+      uri = "https://name.cachix.org",
+      isPublic = True,
+      permission = Admin,
+      publicSigningKeys = ["name.cachix.org-1:pub"],
+      githubUsername = "foobar",
+      preferredCompressionMethod = ZSTD
+    }
+
+-- | Config is only consulted for private caches (netrc credentials), which
+-- these tests do not exercise.
+unusedConfig :: Config
+unusedConfig = panic "Config is not used for public caches"
+
+-- | Run an action against a temp directory serving as XDG_CONFIG_HOME, so
+-- the Local install mode operates on <tmp>/nix/nix.conf.
+withLocalNixConf :: (FilePath -> IO a) -> IO a
+withLocalNixConf action =
+  withTempDirectory "/tmp" "cachix-install" $ \temp -> do
+    setEnv "XDG_CONFIG_HOME" temp
+    action (temp </> "nix")
+
+useLocal :: IO ()
+useLocal = addBinaryCache unusedConfig publicCache defautUseOptions (Install NixConf.Local)
+
+removeLocal :: IO ()
+removeLocal = removeBinaryCache "https://cachix.org" "name" (Install NixConf.Local)
+
+makeReadOnly :: FilePath -> IO ()
+makeReadOnly path = do
+  permissions <- getPermissions path
+  setPermissions path (setOwnerWritable False permissions)
+
 spec :: Spec
-spec = describe "getInstallationMode" $ do
-  it "NixOS with root prints configuration" $
-    let nixenv =
-          NixEnv
-            { isTrusted = True, -- any
-              isRoot = True,
-              isNixOS = True
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` WriteNixOS
-  it "NixOS without trust prints steps to follow" $
-    let nixenv =
-          NixEnv
-            { isTrusted = False,
-              isRoot = False,
-              isNixOS = True
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` UntrustedNixOS
-  it "NixOS without trust prints steps to follow" $
-    let nixenv =
-          NixEnv
-            { isTrusted = False,
-              isRoot = False,
-              isNixOS = True
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` UntrustedNixOS
-  it "NixOS non-root trusted results into local install" $
-    let nixenv =
-          NixEnv
-            { isTrusted = True,
-              isRoot = False,
-              isNixOS = True
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Local
-  it "non-NixOS root results into global install" $
-    let nixenv =
-          NixEnv
-            { isTrusted = True,
-              isRoot = True,
-              isNixOS = False
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Global
-  it "non-NixOS with Nix 1.X root results into global install" $
-    let nixenv =
-          NixEnv
-            { isTrusted = True,
-              isRoot = True,
-              isNixOS = False -- any
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Global
-  it "non-NixOS non-root trusted results into local install" $
-    let nixenv =
-          NixEnv
-            { isTrusted = True,
-              isRoot = False,
-              isNixOS = False
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Local
-  it "non-NixOS non-root non-trusted results into required sudo" $
-    let nixenv =
-          NixEnv
-            { isTrusted = False,
-              isRoot = False,
-              isNixOS = False
-            }
-     in getInstallationMode nixenv defautUseOptions `shouldBe` UntrustedRequiresSudo
+spec = do
+  describe "addBinaryCache and removeBinaryCache" $ do
+    it "writes the fragment and includes it from nix.conf" $
+      withLocalNixConf $ \dir -> do
+        useLocal
+        readFile (dir </> "nix.conf") `shouldReturn` "!include cachix.conf\n"
+        readFile (dir </> "cachix.conf")
+          `shouldReturn` "extra-substituters = https://name.cachix.org\nextra-trusted-public-keys = name.cachix.org-1:pub\n"
+
+    it "is idempotent across runs" $
+      withLocalNixConf $ \dir -> do
+        useLocal
+        nixConf <- readFile (dir </> "nix.conf")
+        fragment <- readFile (dir </> "cachix.conf")
+        useLocal
+        readFile (dir </> "nix.conf") `shouldReturn` nixConf
+        readFile (dir </> "cachix.conf") `shouldReturn` fragment
+
+    it "migrates legacy inline settings into the fragment" $
+      withLocalNixConf $ \dir -> do
+        createDirectoryIfMissing True dir
+        writeFile (dir </> "nix.conf") $
+          unlines
+            [ "trusted-users = root",
+              "substituters = " <> NixConf.defaultPublicURI <> " https://old.cachix.org",
+              "trusted-public-keys = " <> NixConf.defaultSigningKey <> " old-key"
+            ]
+        useLocal
+        readFile (dir </> "nix.conf") `shouldReturn` "trusted-users = root\n!include cachix.conf\n"
+        fragment <- readFile (dir </> "cachix.conf")
+        fragment
+          `shouldBe` unlines
+            [ "extra-substituters = " <> NixConf.defaultPublicURI <> " https://old.cachix.org https://name.cachix.org",
+              "extra-trusted-public-keys = " <> NixConf.defaultSigningKey <> " old-key name.cachix.org-1:pub"
+            ]
+
+    it "succeeds against a read-only nix.conf that already has the include" $
+      withLocalNixConf $ \dir -> do
+        createDirectoryIfMissing True dir
+        let legacyContents =
+              unlines
+                [ "substituters = " <> NixConf.defaultPublicURI <> " https://old.cachix.org",
+                  "trusted-public-keys = " <> NixConf.defaultSigningKey <> " old-key",
+                  "!include cachix.conf"
+                ]
+        writeFile (dir </> "nix.conf") legacyContents
+        makeReadOnly (dir </> "nix.conf")
+        useLocal
+        readFile (dir </> "nix.conf") `shouldReturn` legacyContents
+
+    it "removes the cache from the fragment and keeps the include" $
+      withLocalNixConf $ \dir -> do
+        useLocal
+        removeLocal
+        readFile (dir </> "nix.conf") `shouldReturn` "!include cachix.conf\n"
+        readFile (dir </> "cachix.conf") `shouldReturn` ""
+
+    it "does not add an include to nix.conf as part of a removal" $
+      withLocalNixConf $ \dir -> do
+        createDirectoryIfMissing True dir
+        writeFile (dir </> "cachix.conf") $
+          unlines
+            [ "extra-substituters = https://other.cachix.org https://name.cachix.org",
+              "extra-trusted-public-keys = other-key name.cachix.org-1:key"
+            ]
+        removeLocal
+        doesFileExist (dir </> "nix.conf") `shouldReturn` False
+        readFile (dir </> "cachix.conf")
+          `shouldReturn` "extra-substituters = https://other.cachix.org\nextra-trusted-public-keys = other-key\n"
+
+    it "writes and removes a self-contained nix.conf for an output directory" $
+      withTempDirectory "/tmp" "cachix-standalone" $ \temp -> do
+        addBinaryCache unusedConfig publicCache defautUseOptions (Install (NixConf.Custom temp))
+        readFile (temp </> "nix.conf")
+          `shouldReturn` "extra-substituters = https://name.cachix.org\nextra-trusted-public-keys = name.cachix.org-1:pub\n"
+        removeBinaryCache "https://cachix.org" "name" (Install (NixConf.Custom temp))
+        readFile (temp </> "nix.conf") `shouldReturn` ""
+
+  describe "getInstallationMode" $ do
+    it "NixOS with root prints configuration" $
+      let nixenv =
+            NixEnv
+              { isTrusted = True, -- any
+                isRoot = True,
+                isNixOS = True
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` WriteNixOS
+    it "NixOS without trust prints steps to follow" $
+      let nixenv =
+            NixEnv
+              { isTrusted = False,
+                isRoot = False,
+                isNixOS = True
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` UntrustedNixOS
+    it "NixOS without trust prints steps to follow" $
+      let nixenv =
+            NixEnv
+              { isTrusted = False,
+                isRoot = False,
+                isNixOS = True
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` UntrustedNixOS
+    it "NixOS non-root trusted results into local install" $
+      let nixenv =
+            NixEnv
+              { isTrusted = True,
+                isRoot = False,
+                isNixOS = True
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Local
+    it "non-NixOS root results into global install" $
+      let nixenv =
+            NixEnv
+              { isTrusted = True,
+                isRoot = True,
+                isNixOS = False
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Global
+    it "non-NixOS with Nix 1.X root results into global install" $
+      let nixenv =
+            NixEnv
+              { isTrusted = True,
+                isRoot = True,
+                isNixOS = False -- any
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Global
+    it "non-NixOS non-root trusted results into local install" $
+      let nixenv =
+            NixEnv
+              { isTrusted = True,
+                isRoot = False,
+                isNixOS = False
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` Install NixConf.Local
+    it "non-NixOS non-root non-trusted results into required sudo" $
+      let nixenv =
+            NixEnv
+              { isTrusted = False,
+                isRoot = False,
+                isNixOS = False
+              }
+       in getInstallationMode nixenv defautUseOptions `shouldBe` UntrustedRequiresSudo

--- a/cachix/test/NetRcSpec.hs
+++ b/cachix/test/NetRcSpec.hs
@@ -39,7 +39,7 @@ test caches goldenName = withSystemTempFile "hspec-netrc" $ \filepath _ -> do
   let input = "test/data/" <> toS goldenName <> ".input"
       output = "test/data/" <> toS goldenName <> ".output"
   copyFile input filepath
-  NetRc.add (Token "token123") caches filepath
+  _ <- NetRc.add (Token "token123") caches filepath
   real <- readFile filepath
   expected <- readFile output
   real `shouldBe` expected
@@ -52,3 +52,15 @@ spec =
     it "populates empty netrc file" $ test [bc1, bc2] "empty"
     it "populates netrc file with one additional entry" $ test [bc2] "add"
     it "populates netrc file with one overriden entry" $ test [bc2] "override"
+
+    it "skips the write when nothing changed" $
+      withSystemTempFile "hspec-netrc" $ \filepath _ -> do
+        copyFile "test/data/empty.input" filepath
+        NetRc.add (Token "token123") [bc1, bc2] filepath `shouldReturn` True
+        NetRc.add (Token "token123") [bc1, bc2] filepath `shouldReturn` False
+
+    it "rewrites when the auth token changed" $
+      withSystemTempFile "hspec-netrc" $ \filepath _ -> do
+        copyFile "test/data/empty.input" filepath
+        _ <- NetRc.add (Token "token123") [bc1, bc2] filepath
+        NetRc.add (Token "rotated456") [bc1, bc2] filepath `shouldReturn` True

--- a/cachix/test/NixConfSpec.hs
+++ b/cachix/test/NixConfSpec.hs
@@ -27,6 +27,10 @@ bc =
       preferredCompressionMethod = ZSTD
     }
 
+-- | The !include directive cachix adds to the nix.conf to pull in its fragment.
+cachixInclude :: NixConfLine
+cachixInclude = Include (OptionalInclude "cachix.conf")
+
 spec :: Spec
 spec = do
   describe "render . parse" $ do
@@ -34,128 +38,289 @@ spec = do
       property "substituters = a\n"
     it "handles multi value substituters" $
       property "substituters = a b c\n"
+    it "handles extra substituters" $
+      property "extra-substituters = a b c\n"
     it "handles all known keys" $
-      property "substituters = a b c\ntrusted-users = him me\ntrusted-public-keys = a\n"
+      property "substituters = a b c\nextra-substituters = d\ntrusted-users = him me\ntrusted-public-keys = a\nextra-trusted-public-keys = b\n"
     it "handles includes" $
       property "include /etc/nix/nix.conf\n!include /etc/nix/nix.conf\n"
     it "random content" $
       property "blabla = foobar\nfoo = bar\n"
 
-  describe "add" $ do
-    it "merges binary caches from both files" $
-      let globalConf =
-            NixConf
-              [ Substituters ["bc1"],
-                TrustedPublicKeys ["pub1"]
-              ]
-          localConf =
-            NixConf
-              [ Substituters ["bc2"],
-                TrustedPublicKeys ["pub2"]
-              ]
-          result =
-            NixConf
-              [ Substituters [defaultPublicURI, "bc1", "bc2", "https://name.cachix.org"],
-                TrustedPublicKeys [defaultSigningKey, "pub1", "pub2", "pub"]
-              ]
-       in add bc [globalConf, localConf] localConf `shouldBe` result
+  describe "addCache" $ do
+    it "writes the cache to the fragment and includes it from an empty nix.conf" $
+      let result =
+            ( NixConf [cachixInclude],
+              NixConf
+                [ ExtraSubstituters ["https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub"]
+                ]
+            )
+       in addCache bc (NixConf []) (NixConf []) `shouldBe` result
 
-    it "is noop if binary cache exists in one file" $
-      let globalConf =
+    it "accumulates caches in the fragment across runs" $
+      let nixConf = NixConf [cachixInclude]
+          fragment =
             NixConf
-              [ Substituters [defaultPublicURI, "https://name.cachix.org"],
-                TrustedPublicKeys [defaultSigningKey, "pub"]
+              [ ExtraSubstituters ["https://other.cachix.org"],
+                ExtraTrustedPublicKeys ["other-key"]
               ]
-          localConf = NixConf []
           result =
-            NixConf
-              [ Substituters [defaultPublicURI, "https://name.cachix.org"],
-                TrustedPublicKeys [defaultSigningKey, "pub"]
-              ]
-       in add bc [globalConf, localConf] localConf `shouldBe` result
+            ( NixConf [cachixInclude],
+              NixConf
+                [ ExtraSubstituters ["https://other.cachix.org", "https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["other-key", "pub"]
+                ]
+            )
+       in addCache bc nixConf fragment `shouldBe` result
 
-    it "preserves other nixconf entries" $
-      let globalConf =
+    it "migrates inline settings written by older versions into the fragment" $
+      -- The Nix default the legacy line carried is restated in the fragment:
+      -- the old line overrode substituters set at other config levels, so
+      -- dropping the default could remove cache.nixos.org from the effective
+      -- config on such setups.
+      let nixConf =
             NixConf
-              [ Substituters ["http"],
-                TrustedPublicKeys ["pub1"],
-                TrustedUsers ["user"],
-                Other "foo"
-              ]
-          localConf =
-            NixConf
-              [ TrustedUsers ["user2"],
-                Other "bar"
+              [ Substituters [defaultPublicURI, "https://other.cachix.org"],
+                TrustedPublicKeys [defaultSigningKey, "other-key"]
               ]
           result =
+            ( NixConf [cachixInclude],
+              NixConf
+                [ ExtraSubstituters [defaultPublicURI, "https://other.cachix.org", "https://name.cachix.org"],
+                  ExtraTrustedPublicKeys [defaultSigningKey, "other-key", "pub"]
+                ]
+            )
+       in addCache bc nixConf (NixConf []) `shouldBe` result
+
+    it "leaves unrelated nix.conf settings in place" $
+      -- Substituters/TrustedPublicKeys lines that don't carry the Nix default
+      -- (defaultPublicURI/defaultSigningKey) an older cachix always force-wrote
+      -- alongside its own entries aren't recognized as cachix's, so they must
+      -- stay in nix.conf untouched; only the new cache goes into the fragment.
+      let nixConf =
             NixConf
               [ TrustedUsers ["user2"],
                 Other "bar",
-                Substituters [defaultPublicURI, "http", "https://name.cachix.org"],
-                TrustedPublicKeys [defaultSigningKey, "pub1", "pub"]
-              ]
-       in add bc [globalConf, localConf] localConf `shouldBe` result
-
-    it "removed duplicates" $
-      let globalConf =
-            NixConf
-              [ Substituters ["bc1", "bc1"],
-                TrustedPublicKeys ["pub1", "pub1"]
-              ]
-          localConf =
-            NixConf
-              [ Substituters ["bc2", "bc2"],
-                TrustedPublicKeys ["pub2", "pub2"]
+                Substituters ["http"],
+                TrustedPublicKeys ["pub1"]
               ]
           result =
-            NixConf
-              [ Substituters [defaultPublicURI, "bc1", "bc2", "https://name.cachix.org"],
-                TrustedPublicKeys [defaultSigningKey, "pub1", "pub2", "pub"]
-              ]
-       in add bc [globalConf, localConf] localConf `shouldBe` result
+            ( NixConf
+                [ TrustedUsers ["user2"],
+                  Other "bar",
+                  Substituters ["http"],
+                  TrustedPublicKeys ["pub1"],
+                  cachixInclude
+                ],
+              NixConf
+                [ ExtraSubstituters ["https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub"]
+                ]
+            )
+       in addCache bc nixConf (NixConf []) `shouldBe` result
 
-    it "adds binary cache and defaults if no existing entries exist" $
-      let globalConf = NixConf []
-          localConf = NixConf []
+    it "does not migrate a substituters line missing the default cachix always wrote alongside its own" $
+      -- A line starting with defaultPublicURI is recognized as cachix's
+      -- legacy write; one without it (even one that happens to mention a
+      -- cachix cache URL, e.g. hand-copied by a user) is left alone.
+      let nixConf = NixConf [Substituters ["https://other.cachix.org"]]
           result =
-            NixConf
-              [ Substituters [defaultPublicURI, "https://name.cachix.org"],
-                TrustedPublicKeys [defaultSigningKey, "pub"]
-              ]
-       in add bc [globalConf, localConf] localConf `shouldBe` result
+            ( NixConf [Substituters ["https://other.cachix.org"], cachixInclude],
+              NixConf
+                [ ExtraSubstituters ["https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub"]
+                ]
+            )
+       in addCache bc nixConf (NixConf []) `shouldBe` result
 
-  describe "remove" $ do
-    it "removes a binary cache" $
-      let localConf =
+    it "does not migrate a substituters line where the default is not the first value" $
+      -- Old cachix always wrote defaultPublicURI as the FIRST value, so a
+      -- line merely containing it elsewhere is user-authored and stays put.
+      let nixConf = NixConf [Substituters ["https://other.example", defaultPublicURI]]
+          result =
+            ( NixConf [Substituters ["https://other.example", defaultPublicURI], cachixInclude],
+              NixConf
+                [ ExtraSubstituters ["https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub"]
+                ]
+            )
+       in addCache bc nixConf (NixConf []) `shouldBe` result
+
+    it "migrates a legacy line without sweeping in a separate user-authored line" $
+      -- Only the marked legacy line's values move to the fragment; the user's
+      -- own extra-substituters line stays in nix.conf and its values must not
+      -- be duplicated into the fragment, even though the marker appears
+      -- elsewhere in the same file.
+      let nixConf =
+            NixConf
+              [ Substituters [defaultPublicURI, "https://old.cachix.org"],
+                ExtraSubstituters ["https://corp.example"],
+                TrustedPublicKeys [defaultSigningKey, "old-key"]
+              ]
+          result =
+            ( NixConf [ExtraSubstituters ["https://corp.example"], cachixInclude],
+              NixConf
+                [ ExtraSubstituters [defaultPublicURI, "https://old.cachix.org", "https://name.cachix.org"],
+                  ExtraTrustedPublicKeys [defaultSigningKey, "old-key", "pub"]
+                ]
+            )
+       in addCache bc nixConf (NixConf []) `shouldBe` result
+
+    it "does not add a second include directive" $
+      let nixConf = NixConf [cachixInclude]
+       in fst (addCache bc nixConf (NixConf [])) `shouldBe` NixConf [cachixInclude]
+
+    it "removes duplicates" $
+      let fragment =
+            NixConf
+              [ ExtraSubstituters ["bc1", "bc1"],
+                ExtraTrustedPublicKeys ["pub1", "pub1"]
+              ]
+          result =
+            ( NixConf [cachixInclude],
+              NixConf
+                [ ExtraSubstituters ["bc1", "https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub1", "pub"]
+                ]
+            )
+       in addCache bc (NixConf [cachixInclude]) fragment `shouldBe` result
+
+  describe "removeCache" $ do
+    it "removes a binary cache from the fragment" $
+      let nixConf = NixConf [cachixInclude]
+          fragment =
+            NixConf
+              [ ExtraSubstituters ["https://other.example", "https://name.cachix.org"],
+                ExtraTrustedPublicKeys ["other.example-1:key", "name.cachix.org-1:key"]
+              ]
+          result =
+            ( ( NixConf [cachixInclude],
+                NixConf
+                  [ ExtraSubstituters ["https://other.example"],
+                    ExtraTrustedPublicKeys ["other.example-1:key"]
+                  ]
+              ),
+              True
+            )
+       in removeCache "https://cachix.org" "name" nixConf fragment `shouldBe` result
+
+    it "migrates and removes inline settings written by older versions" $
+      -- The restated Nix default stays behind in the fragment, preserving
+      -- the reachability the old override line guaranteed.
+      let nixConf =
             NixConf
               [ Substituters [defaultPublicURI, "https://name.cachix.org"],
                 TrustedPublicKeys [defaultSigningKey, "name.cachix.org-1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa="]
               ]
-          result =
+          fragment =
             NixConf
-              [ Substituters [defaultPublicURI],
-                TrustedPublicKeys [defaultSigningKey]
+              [ ExtraSubstituters [defaultPublicURI],
+                ExtraTrustedPublicKeys [defaultSigningKey]
               ]
-       in remove "https://cachix.org" "name" [localConf] localConf `shouldBe` (result, True)
+       in removeCache "https://cachix.org" "name" nixConf (NixConf [])
+            `shouldBe` ((NixConf [cachixInclude], fragment), True)
 
-    it "removes nothing if the binary cache is missing" $
-      let globalConf =
+    it "removes a leftover trusted public key even when the substituter is already gone" $
+      let nixConf = NixConf [cachixInclude]
+          fragment = NixConf [ExtraTrustedPublicKeys ["name.cachix.org-1:key"]]
+       in removeCache "https://cachix.org" "name" nixConf fragment
+            `shouldBe` ((NixConf [cachixInclude], NixConf []), True)
+
+    it "does not add an include when the fragment ends up empty" $
+      removeCache "https://cachix.org" "name" (NixConf []) (NixConf [ExtraTrustedPublicKeys ["name.cachix.org-1:key"]])
+        `shouldBe` ((NixConf [], NixConf []), True)
+
+    it "omits empty extra settings after removal" $
+      let nixConf = NixConf [cachixInclude]
+          fragment =
+            NixConf
+              [ ExtraSubstituters ["https://name.cachix.org"],
+                ExtraTrustedPublicKeys ["name.cachix.org-1:key"]
+              ]
+       in removeCache "https://cachix.org" "name" nixConf fragment
+            `shouldBe` ((NixConf [cachixInclude], NixConf []), True)
+
+    it "leaves both configs untouched if the binary cache is missing" $
+      let nixConf =
             NixConf
               [ Substituters [defaultPublicURI],
                 TrustedPublicKeys [defaultSigningKey]
               ]
-          localConf = globalConf
-          result = localConf
-       in remove "https://cachix.org" "name" [globalConf, localConf] localConf `shouldBe` (result, False)
+       in removeCache "https://cachix.org" "name" nixConf (NixConf [])
+            `shouldBe` ((nixConf, NixConf []), False)
+
+    it "leaves an unrelated substituters line in nix.conf untouched" $
+      let nixConf = NixConf [Substituters ["http"], TrustedPublicKeys ["pub1"]]
+       in removeCache "https://cachix.org" "name" nixConf (NixConf [])
+            `shouldBe` ((nixConf, NixConf []), False)
+
+  describe "addCacheStandalone" $ do
+    it "writes a self-contained nix.conf" $
+      addCacheStandalone bc (NixConf [])
+        `shouldBe` NixConf
+          [ ExtraSubstituters ["https://name.cachix.org"],
+            ExtraTrustedPublicKeys ["pub"]
+          ]
+
+    it "converts cache lines written by older versions in place" $
+      addCacheStandalone
+        bc
+        ( NixConf
+            [ Substituters [defaultPublicURI, "https://other.cachix.org"],
+              TrustedPublicKeys [defaultSigningKey, "other-key"]
+            ]
+        )
+        `shouldBe` NixConf
+          [ ExtraSubstituters [defaultPublicURI, "https://other.cachix.org", "https://name.cachix.org"],
+            ExtraTrustedPublicKeys [defaultSigningKey, "other-key", "pub"]
+          ]
+
+  describe "removeCacheStandalone" $ do
+    it "removes the cache and its key" $
+      removeCacheStandalone
+        "https://cachix.org"
+        "name"
+        ( NixConf
+            [ ExtraSubstituters ["https://name.cachix.org", "https://other.example"],
+              ExtraTrustedPublicKeys ["name.cachix.org-1:key", "other-1:key"]
+            ]
+        )
+        `shouldBe` ( NixConf
+                       [ ExtraSubstituters ["https://other.example"],
+                         ExtraTrustedPublicKeys ["other-1:key"]
+                       ],
+                     True
+                   )
+
+    it "reports nothing to remove" $
+      removeCacheStandalone "https://cachix.org" "name" (NixConf [ExtraSubstituters ["https://other.example"]])
+        `shouldBe` (NixConf [ExtraSubstituters ["https://other.example"]], False)
 
   describe "parse" $ do
     it "parses substituters" $
       parse "substituters = a\n"
         `shouldBe` Right (NixConf [Substituters ["a"]])
 
+    it "parses extra substituters" $
+      parse "extra-substituters = a\n"
+        `shouldBe` Right (NixConf [ExtraSubstituters ["a"]])
+
+    it "parses extra trusted public keys" $
+      parse "extra-trusted-public-keys = a\n"
+        `shouldBe` Right (NixConf [ExtraTrustedPublicKeys ["a"]])
+
     it "parses long key" $
       parse "binary-caches-parallel-connections = 40\n"
         `shouldBe` Right (NixConf [Other "binary-caches-parallel-connections = 40"])
+
+    it "leaves a line with an inline comment untouched" $
+      parse "substituters = a b # mine\n"
+        `shouldBe` Right (NixConf [Other "substituters = a b # mine"])
+
+    it "leaves Nix 1.0 alias keys untouched" $
+      parse "binary-caches = a\nbinary-cache-public-keys = b\n"
+        `shouldBe` Right (NixConf [Other "binary-caches = a", Other "binary-cache-public-keys = b"])
 
     it "parses substituters with multiple values" $
       parse "substituters = a b c\n"

--- a/cachix/test/NixConfSpec.hs
+++ b/cachix/test/NixConfSpec.hs
@@ -31,6 +31,16 @@ bc =
 cachixInclude :: NixConfLine
 cachixInclude = Include (OptionalInclude "cachix.conf")
 
+-- | The nix.conf path the pure addCache/removeCache tests pretend to operate on.
+nixConfPath' :: FilePath
+nixConfPath' = "/etc/nix/nix.conf"
+
+addCache' :: NixConf -> NixConf -> (NixConf, NixConf)
+addCache' = addCache bc MigrateLegacy nixConfPath'
+
+removeCache' :: NixConf -> NixConf -> ((NixConf, NixConf), Bool)
+removeCache' = removeCache "https://cachix.org" "name" MigrateLegacy nixConfPath'
+
 spec :: Spec
 spec = do
   describe "render . parse" $ do
@@ -46,6 +56,16 @@ spec = do
       property "include /etc/nix/nix.conf\n!include /etc/nix/nix.conf\n"
     it "random content" $
       property "blabla = foobar\nfoo = bar\n"
+    it "handles extra trusted users" $
+      property "extra-trusted-users = alice\n"
+    it "keeps a line with an inline comment byte for byte" $
+      property "substituters = a b # mine\n"
+    it "keeps Nix 1.0 alias keys byte for byte" $
+      property "binary-caches = a\nbinary-cache-public-keys = b\n"
+    it "keeps blank lines after assignments" $
+      property "trusted-users = root\n\n# note\n"
+    it "keeps a netrc-file path with spaces" $
+      property "netrc-file = /My Name/netrc\n"
 
   describe "addCache" $ do
     it "writes the cache to the fragment and includes it from an empty nix.conf" $
@@ -56,7 +76,7 @@ spec = do
                   ExtraTrustedPublicKeys ["pub"]
                 ]
             )
-       in addCache bc (NixConf []) (NixConf []) `shouldBe` result
+       in addCache' (NixConf []) (NixConf []) `shouldBe` result
 
     it "accumulates caches in the fragment across runs" $
       let nixConf = NixConf [cachixInclude]
@@ -72,7 +92,7 @@ spec = do
                   ExtraTrustedPublicKeys ["other-key", "pub"]
                 ]
             )
-       in addCache bc nixConf fragment `shouldBe` result
+       in addCache' nixConf fragment `shouldBe` result
 
     it "migrates inline settings written by older versions into the fragment" $
       -- The Nix default the legacy line carried is restated in the fragment:
@@ -91,7 +111,7 @@ spec = do
                   ExtraTrustedPublicKeys [defaultSigningKey, "other-key", "pub"]
                 ]
             )
-       in addCache bc nixConf (NixConf []) `shouldBe` result
+       in addCache' nixConf (NixConf []) `shouldBe` result
 
     it "leaves unrelated nix.conf settings in place" $
       -- Substituters/TrustedPublicKeys lines that don't carry the Nix default
@@ -118,7 +138,7 @@ spec = do
                   ExtraTrustedPublicKeys ["pub"]
                 ]
             )
-       in addCache bc nixConf (NixConf []) `shouldBe` result
+       in addCache' nixConf (NixConf []) `shouldBe` result
 
     it "does not migrate a substituters line missing the default cachix always wrote alongside its own" $
       -- A line starting with defaultPublicURI is recognized as cachix's
@@ -132,7 +152,7 @@ spec = do
                   ExtraTrustedPublicKeys ["pub"]
                 ]
             )
-       in addCache bc nixConf (NixConf []) `shouldBe` result
+       in addCache' nixConf (NixConf []) `shouldBe` result
 
     it "does not migrate a substituters line where the default is not the first value" $
       -- Old cachix always wrote defaultPublicURI as the FIRST value, so a
@@ -145,7 +165,7 @@ spec = do
                   ExtraTrustedPublicKeys ["pub"]
                 ]
             )
-       in addCache bc nixConf (NixConf []) `shouldBe` result
+       in addCache' nixConf (NixConf []) `shouldBe` result
 
     it "migrates a legacy line without sweeping in a separate user-authored line" $
       -- Only the marked legacy line's values move to the fragment; the user's
@@ -165,11 +185,62 @@ spec = do
                   ExtraTrustedPublicKeys [defaultSigningKey, "old-key", "pub"]
                 ]
             )
-       in addCache bc nixConf (NixConf []) `shouldBe` result
+       in addCache' nixConf (NixConf []) `shouldBe` result
 
     it "does not add a second include directive" $
       let nixConf = NixConf [cachixInclude]
-       in fst (addCache bc nixConf (NixConf [])) `shouldBe` NixConf [cachixInclude]
+       in fst (addCache' nixConf (NixConf [])) `shouldBe` NixConf [cachixInclude]
+
+    it "recognizes an absolute include of the fragment" $
+      -- An include spelled with the absolute path resolves to the same file,
+      -- so no second include is appended.
+      let nixConf = NixConf [Include (OptionalInclude "/etc/nix/cachix.conf")]
+       in fst (addCache' nixConf (NixConf [])) `shouldBe` nixConf
+
+    it "does not claim a lone marker-led substituters line" $
+      -- Old cachix always wrote BOTH the substituters and the
+      -- trusted-public-keys marker lines; a substituters line alone (a shape
+      -- users write by hand to override defaults) stays in nix.conf.
+      let nixConf = NixConf [Substituters [defaultPublicURI, "https://mirror.example"]]
+          result =
+            ( NixConf [Substituters [defaultPublicURI, "https://mirror.example"], cachixInclude],
+              NixConf
+                [ ExtraSubstituters ["https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub"]
+                ]
+            )
+       in addCache' nixConf (NixConf []) `shouldBe` result
+
+    it "does not sweep a commented substituters line into the fragment" $
+      let commented = Verbatim (Substituters [defaultPublicURI, "https://mine.example"]) "substituters = https://cache.nixos.org https://mine.example # mine"
+          nixConf = NixConf [commented]
+          result =
+            ( NixConf [commented, cachixInclude],
+              NixConf
+                [ ExtraSubstituters ["https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub"]
+                ]
+            )
+       in addCache' nixConf (NixConf []) `shouldBe` result
+
+    it "leaves legacy lines in place when migration is off" $
+      let nixConf =
+            NixConf
+              [ Substituters [defaultPublicURI, "https://old.cachix.org"],
+                TrustedPublicKeys [defaultSigningKey, "old-key"]
+              ]
+          result =
+            ( NixConf
+                [ Substituters [defaultPublicURI, "https://old.cachix.org"],
+                  TrustedPublicKeys [defaultSigningKey, "old-key"],
+                  cachixInclude
+                ],
+              NixConf
+                [ ExtraSubstituters ["https://name.cachix.org"],
+                  ExtraTrustedPublicKeys ["pub"]
+                ]
+            )
+       in addCache bc LeaveLegacy nixConfPath' nixConf (NixConf []) `shouldBe` result
 
     it "removes duplicates" $
       let fragment =
@@ -184,7 +255,7 @@ spec = do
                   ExtraTrustedPublicKeys ["pub1", "pub"]
                 ]
             )
-       in addCache bc (NixConf [cachixInclude]) fragment `shouldBe` result
+       in addCache' (NixConf [cachixInclude]) fragment `shouldBe` result
 
   describe "removeCache" $ do
     it "removes a binary cache from the fragment" $
@@ -203,7 +274,7 @@ spec = do
               ),
               True
             )
-       in removeCache "https://cachix.org" "name" nixConf fragment `shouldBe` result
+       in removeCache' nixConf fragment `shouldBe` result
 
     it "migrates and removes inline settings written by older versions" $
       -- The restated Nix default stays behind in the fragment, preserving
@@ -218,17 +289,17 @@ spec = do
               [ ExtraSubstituters [defaultPublicURI],
                 ExtraTrustedPublicKeys [defaultSigningKey]
               ]
-       in removeCache "https://cachix.org" "name" nixConf (NixConf [])
+       in removeCache' nixConf (NixConf [])
             `shouldBe` ((NixConf [cachixInclude], fragment), True)
 
     it "removes a leftover trusted public key even when the substituter is already gone" $
       let nixConf = NixConf [cachixInclude]
           fragment = NixConf [ExtraTrustedPublicKeys ["name.cachix.org-1:key"]]
-       in removeCache "https://cachix.org" "name" nixConf fragment
+       in removeCache' nixConf fragment
             `shouldBe` ((NixConf [cachixInclude], NixConf []), True)
 
     it "does not add an include when the fragment ends up empty" $
-      removeCache "https://cachix.org" "name" (NixConf []) (NixConf [ExtraTrustedPublicKeys ["name.cachix.org-1:key"]])
+      removeCache' (NixConf []) (NixConf [ExtraTrustedPublicKeys ["name.cachix.org-1:key"]])
         `shouldBe` ((NixConf [], NixConf []), True)
 
     it "omits empty extra settings after removal" $
@@ -238,7 +309,7 @@ spec = do
               [ ExtraSubstituters ["https://name.cachix.org"],
                 ExtraTrustedPublicKeys ["name.cachix.org-1:key"]
               ]
-       in removeCache "https://cachix.org" "name" nixConf fragment
+       in removeCache' nixConf fragment
             `shouldBe` ((NixConf [cachixInclude], NixConf []), True)
 
     it "leaves both configs untouched if the binary cache is missing" $
@@ -247,13 +318,29 @@ spec = do
               [ Substituters [defaultPublicURI],
                 TrustedPublicKeys [defaultSigningKey]
               ]
-       in removeCache "https://cachix.org" "name" nixConf (NixConf [])
+       in removeCache' nixConf (NixConf [])
             `shouldBe` ((nixConf, NixConf []), False)
 
     it "leaves an unrelated substituters line in nix.conf untouched" $
       let nixConf = NixConf [Substituters ["http"], TrustedPublicKeys ["pub1"]]
-       in removeCache "https://cachix.org" "name" nixConf (NixConf [])
+       in removeCache' nixConf (NixConf [])
             `shouldBe` ((nixConf, NixConf []), False)
+
+    it "does not add an include when nothing is migrated" $
+      -- A removal must not re-activate the remaining fragment caches on a
+      -- system where the include was deliberately absent.
+      let nixConf = NixConf [Other "# no include here"]
+          fragment =
+            NixConf
+              [ ExtraSubstituters ["https://other.example", "https://name.cachix.org"],
+                ExtraTrustedPublicKeys ["name.cachix.org-1:key"]
+              ]
+       in removeCache' nixConf fragment
+            `shouldBe` ( ( nixConf,
+                           NixConf [ExtraSubstituters ["https://other.example"]]
+                         ),
+                         True
+                       )
 
   describe "addCacheStandalone" $ do
     it "writes a self-contained nix.conf" $
@@ -314,13 +401,52 @@ spec = do
       parse "binary-caches-parallel-connections = 40\n"
         `shouldBe` Right (NixConf [Other "binary-caches-parallel-connections = 40"])
 
-    it "leaves a line with an inline comment untouched" $
+    it "preserves a line with an inline comment while reading its values" $
       parse "substituters = a b # mine\n"
-        `shouldBe` Right (NixConf [Other "substituters = a b # mine"])
+        `shouldBe` Right (NixConf [Verbatim (Substituters ["a", "b"]) "substituters = a b # mine"])
 
-    it "leaves Nix 1.0 alias keys untouched" $
+    it "reads trusted users from a line with an inline comment" $
+      -- Nix strips '#' to the end of the line, so alice IS trusted; the
+      -- line still renders back byte for byte.
+      let parsed = parse "trusted-users = root alice # admins\n"
+       in (NixConf.readLines NixConf.isTrustedUsers <$> parsed) `shouldBe` Right ["root", "alice"]
+
+    it "reads a value glued to the comment marker up to the '#'" $
+      parse "substituters = a b#comment\n"
+        `shouldBe` Right (NixConf [Verbatim (Substituters ["a", "b"]) "substituters = a b#comment"])
+
+    it "preserves Nix 1.0 alias keys while reading their values" $
       parse "binary-caches = a\nbinary-cache-public-keys = b\n"
-        `shouldBe` Right (NixConf [Other "binary-caches = a", Other "binary-cache-public-keys = b"])
+        `shouldBe` Right
+          ( NixConf
+              [ Verbatim (Substituters ["a"]) "binary-caches = a",
+                Verbatim (TrustedPublicKeys ["b"]) "binary-cache-public-keys = b"
+              ]
+          )
+
+    it "parses extra-trusted-users" $
+      parse "extra-trusted-users = alice\n"
+        `shouldBe` Right (NixConf [ExtraTrustedUsers ["alice"]])
+
+    it "drops phantom empty values from trailing whitespace" $
+      parse "substituters = a b \n"
+        `shouldBe` Right (NixConf [Substituters ["a", "b"]])
+
+    it "parses an empty assignment as no values" $
+      parse "substituters =\n"
+        `shouldBe` Right (NixConf [Substituters []])
+
+    it "preserves spaces in a netrc-file path" $
+      parse "netrc-file = /My Name/netrc\n"
+        `shouldBe` Right (NixConf [NetRcFile "/My Name/netrc"])
+
+    it "preserves blank lines after an assignment" $
+      parse "trusted-users = root\n\n# note\n"
+        `shouldBe` Right (NixConf [TrustedUsers ["root"], Other "", Other "# note"])
+
+    it "preserves an include with an inline comment" $
+      parse "!include corp.conf # managed by IT\n"
+        `shouldBe` Right (NixConf [Verbatim (Include (OptionalInclude "corp.conf")) "!include corp.conf # managed by IT"])
 
     it "parses substituters with multiple values" $
       parse "substituters = a b c\n"
@@ -375,8 +501,8 @@ spec = do
                 ]
         writeFile confPath $
           unlines
-            [ "include " <> toS requiredConfPath <> "\n",
-              "!include " <> toS optionalConfPath <> "\n"
+            [ "include " <> toS requiredConfPath,
+              "!include " <> toS optionalConfPath
             ]
         writeFile requiredConfPath realExample
 

--- a/cachix/test/NixVersionSpec.hs
+++ b/cachix/test/NixVersionSpec.hs
@@ -7,6 +7,19 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+  describe "isSupportedNixVersion" $ do
+    it "rejects versions before Nix 2.4" $
+      isSupported "nix-env (Nix) 2.3.16" `shouldBe` Right False
+
+    it "accepts Nix 2.4 without a patch version" $
+      isSupported "nix-env (Nix) 2.4" `shouldBe` Right True
+
+    it "accepts Nix 2.4.0" $
+      isSupported "nix-env (Nix) 2.4.0" `shouldBe` Right True
+
+    it "accepts versions after Nix 2.4" $
+      isSupported "nix-env (Nix) 2.24.10" `shouldBe` Right True
+
   describe "parseNixVersion" $ do
     it "fails with unknown string 'foobar'" $
       parseNixVersion "foobar" `shouldSatisfy` isLeft
@@ -27,6 +40,9 @@ spec = do
         [ ("nix-env (Lix, like Nix) 2.90-beta.0", toVersioning "2.90-beta.0"),
           ("nix-env (Lix, like Nix) 2.90-beta.1-lixpre20240506-b6799ab", toVersioning "2.90-beta.1-lixpre20240506-b6799ab")
         ]
+
+isSupported :: Text -> Either Text Bool
+isSupported = fmap isSupportedNixVersion . parseNixVersion
 
 runParserTests :: [(Text, Versioning)] -> Spec
 runParserTests tests = do


### PR DESCRIPTION
## What

`cachix use` no longer edits the contents of your `nix.conf`. It writes the caches it manages to a dedicated `cachix.conf` fragment next to the `nix.conf` it configures, and pulls that fragment in with a single `!include cachix.conf` line. From then on cachix only rewrites its own fragment and leaves the rest of your Nix settings untouched (fixes #413).

Concretely:

- **Caches live in a fragment cachix owns.** Substituters and public keys are written to `cachix.conf` as `extra-substituters` / `extra-trusted-public-keys`, which append to whatever Nix and other tools already configure rather than overriding it.
- **The user's `nix.conf` gets one stable line.** `!include cachix.conf` is added once if missing; it is the optional form, so deleting the fragment does not break Nix.
- **Upgrades migrate cleanly.** Any cache settings older versions wrote inline in the `nix.conf` (the old `substituters =` / `trusted-public-keys =` override lines, including the `cache.nixos.org` default they injected as a workaround) are lifted into the fragment and removed from `nix.conf`.

The upshot: cachix only manages the caches it was asked to add, in a file it fully owns. Removing a cache from another config (for example `substituters =` in the global `nix.conf`) now takes effect instead of being masked by a stale copy cachix pasted in.

Because `extra-*` and `!include` rely on newer Nix, the client now requires **Nix 2.4 or newer**; `cachix use` and `cachix remove` assert the version before touching config.

## Details

- `NixConf`: new `ExtraSubstituters` / `ExtraTrustedPublicKeys` constructors (parsed and rendered); `addCache` / `removeCache` operate on the `(nix.conf, fragment)` pair, building the fragment's `extra-*` settings and, on the `nix.conf` side, stripping cachix-managed cache lines and ensuring the `!include`. Empty assignments are omitted rather than written blank. Added `readPathWithDefault` and the `cachixConf` fragment name.
- `InstallationMode`: `addBinaryCache` / `removeBinaryCache` read the `nix.conf` and the fragment, write the fragment, and rewrite `nix.conf` only when it actually changes (so a settled config sees no churn). Private-cache `netrc-file` goes in the fragment too.
- `NixVersion`: `isSupportedNixVersion` gates on 2.4, handling both `Ideal` (3 component) and `General` (2 component, e.g. `2.4`) version strings.
- `remove` command asserts the Nix version, matching `use`.

## Testing

`stack test`: 115 examples, 0 failures. `addCache` / `removeCache` specs cover writing to the fragment and adding the include, accumulating across runs, migrating inline settings from older versions (and dropping the injected Nix defaults), leaving unrelated `nix.conf` settings in place, not adding a duplicate include, removing from the fragment, omitting empty assignments, and no-op removal leaving both configs untouched. Plus the 2.4 version boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
